### PR TITLE
Fixed interDimensionMultiplier for SG...

### DIFF
--- a/config/SGCraft.cfg
+++ b/config/SGCraft.cfg
@@ -52,7 +52,7 @@ stargate {
     I:explosionRadius=10
     B:explosionSmoke=true
     I:gateOpeningsPerFuelItem=24
-    D:interDimensionMultiplier=10.0
+    D:interDimensionMultiplier=4.0
     D:maxEnergyBuffer=1000.0
     I:minutesOpenPerFuelItem=80
     B:oneWayTravel=true


### PR DESCRIPTION
4x is default 10x you can't go across dims pretty much our one gate from overworld to the end cost 214,000 Power and you can only fit 4x50k under...

Not only that but this is so beyond end game 1 or 1000 power units under it make 0 difference....

So this at least lets you use it correctly...