### PR TITLE
Don't register Natura fruit to the ore dictionary, Natura now does that itself

### DIFF
--- a/scripts/Natura.zs
+++ b/scripts/Natura.zs
@@ -233,28 +233,6 @@ furnace.remove(<minecraft:coal:1>, <*>);
 recipes.removeShapeless(<Natura:barleyFood:8>, [<Natura:Bluebells>]);
 
 
-// --- Adding Natura fruits to oredict
-
-<ore:listAllfruit>.add(<Natura:berry:0>);
-<ore:listAllberry>.add(<Natura:berry:0>);
-<ore:listAllfruit>.add(<Natura:berry:1>);
-<ore:listAllberry>.add(<Natura:berry:1>);
-<ore:listAllfruit>.add(<Natura:berry:2>);
-<ore:listAllberry>.add(<Natura:berry:2>);
-<ore:listAllfruit>.add(<Natura:berry:3>);
-<ore:listAllberry>.add(<Natura:berry:3>);
-<ore:listAllfruit>.add(<Natura:berry.nether:0>);
-<ore:listAllberry>.add(<Natura:berry.nether:0>);
-<ore:listAllfruit>.add(<Natura:berry.nether:1>);
-<ore:listAllberry>.add(<Natura:berry.nether:1>);
-<ore:listAllfruit>.add(<Natura:berry.nether:2>);
-<ore:listAllberry>.add(<Natura:berry.nether:2>);
-<ore:listAllfruit>.add(<Natura:berry.nether:3>);
-<ore:listAllberry>.add(<Natura:berry.nether:3>);
-<ore:listAllfruit>.add(<Natura:saguaro.fruit>);
-<ore:cropCactusfruit>.add(<Natura:saguaro.fruit>);
-
-
 // --- Adding Recipes ---
 
 


### PR DESCRIPTION
As of https://github.com/GTNewHorizons/Natura/commit/34cfe9c82acae7995de2a70aae308f2310610a2c  Natura registers its fruits with the same tags that the Natura.zs script does.