### PR TITLE
Add AE2MatrixFrame to teleposer blacklist

### DIFF
--- a/config/AWWayofTime.cfg
+++ b/config/AWWayofTime.cfg
@@ -1080,6 +1080,7 @@ sacrifice {
         Thaumcraft:blockPortalEldritch
         Thaumcraft:blockEldritchNothing
         ThaumicHorizons:vortexTH
+        appliedenergistics2:tile.BlockMatrixFrame
      >
 }
 


### PR DESCRIPTION
AE2MatrixFrame is a non-destructible transparent block of storage cell Dim.