### PR TITLE
oredict the assembler crafting table recipe

### DIFF
--- a/scripts/Minecraft.zs
+++ b/scripts/Minecraft.zs
@@ -2881,7 +2881,7 @@ Assembler.addRecipe(<minecraft:piston>, <dreamcraft:tile.PistonBlock>, <dreamcra
 Assembler.addRecipe(<minecraft:bookshelf>, <minecraft:planks:*> * 6, <minecraft:book> * 3, 300, 16);
 
 // --- Workbench
-Assembler.addRecipe(<minecraft:crafting_table>, <minecraft:log:*>, <minecraft:flint> * 2, 200, 4);
+Assembler.addRecipe(<minecraft:crafting_table>, Log, <minecraft:flint> * 2, 200, 4);
 
 // --- Fence Gate Oak
 Assembler.addRecipe(FenceGate, <minecraft:stick> * 2, <minecraft:planks> * 2, 300, 8);


### PR DESCRIPTION
Oredict the crafting table recipe to support modded logs in the assembler. Something to be aware of: this replacement adds several (62) more recipe pages in NEI.