### PR TITLE
Update Biome-o-Plenty.zs

### DIFF
--- a/scripts/Biome-o-Plenty.zs
+++ b/scripts/Biome-o-Plenty.zs
@@ -79,9 +79,9 @@ recipes.addShapeless(<BiomesOPlenty:jarEmpty>, [<ore:bottleEmpty>]);
 recipes.addShapeless(<minecraft:glass_bottle>, [<BiomesOPlenty:jarEmpty>]);
 
 // --- Mud Ball
-recipes.addShapeless(<BiomesOPlenty:mudball> * 2, [<minecraft:dirt>, <minecraft:water_bucket>.giveBack(<minecraft:bucket>)]);
+recipes.addShapeless(<BiomesOPlenty:mudball> * 2, [<minecraft:dirt>, <minecraft:water_bucket>]);
 // -
-recipes.addShapeless(<BiomesOPlenty:mudball> * 2, [<minecraft:dirt>, <IguanaTweaksTConstruct:clayBucketWater>.giveBack(<IguanaTweaksTConstruct:clayBucketFired>)]);
+recipes.addShapeless(<BiomesOPlenty:mudball> * 2, [<minecraft:dirt>, <IguanaTweaksTConstruct:clayBucketWater>]);
 
 // --- Dart Blower
 recipes.addShaped(<BiomesOPlenty:dartBlower>, [


### PR DESCRIPTION
If you include a Bucket of Water and it also looks like Clay Bucket of Water you automatically get the bucket back without needing to script it in. This why it was duplicating. 
This not the case with all mods but it's the case here. You can also add a .noReturn() for those times you want it to be consumed.

This fixes:
#6424
#6354
#6256
#6230
#5727
#5591
#6089
#6514