### PR TITLE
Changed Unfired Coke Oven Brick to use Ore Dictionary. Issue #6623

### DIFF
--- a/scripts/CoreMod.zs
+++ b/scripts/CoreMod.zs
@@ -920,6 +920,19 @@ recipes.addShaped(<dreamcraft:item.WoodenBrickForm>, [
 // --- Coke Oven Bricks
 furnace.addRecipe(<dreamcraft:item.CokeOvenBrick>, <dreamcraft:item.UnfiredCokeOvenBrick>);
 
+// --- Remove Shaped Recipe for Unfired Coke Oven Brick
+recipes.removeShaped(<dreamcraft:item.UnfiredCokeOvenBrick> * 3, [
+[<minecraft:clay_ball>, <minecraft:clay_ball>, <minecraft:clay_ball>],
+[<minecraft:sand>, WoodenBrickForm, <minecraft:sand>],
+[<minecraft:sand>, <minecraft:sand>, <minecraft:sand>]]);
+
+// -- Add recipe for Unfired Coke Oven Brick to use Ore Dictionary
+recipes.addShaped(<dreamcraft:item.UnfiredCokeOvenBrick> * 3, [
+[<minecraft:clay_ball>, <minecraft:clay_ball>, <minecraft:clay_ball>],
+[<ore:sand>, WoodenBrickForm, <ore:sand>],
+[<ore:sand>, <ore:sand>, <ore:sand>]]);
+
+
 // --- Diamond Frame Box
 recipes.addShaped(<dreamcraft:tile.DiamondFrameBox>, [
 [<ore:stickDiamond>, <ore:stickDiamond>, <ore:stickDiamond>],


### PR DESCRIPTION
Issue #6623 

Removed the old recipe and added in a new recipe to utilize ore dictionary for the Unfired Coke Oven Brick.

![image](https://user-images.githubusercontent.com/33701188/93165204-09c1ed00-f6e1-11ea-8ead-67c1b9b31f65.png)
