### PR TITLE
Fix issue 2439, no recipe for brown smart cable in AE2.

### DIFF
--- a/scripts/AE2.zs
+++ b/scripts/AE2.zs
@@ -448,6 +448,12 @@ recipes.remove(<appliedenergistics2:item.ItemMultiPart:76>);
 // --- ME Smart Cable
 recipes.remove(<appliedenergistics2:item.ItemMultiPart:56>);
 
+// --- Add Brown Smart Cable Recipe
+recipes.addShaped(<appliedenergistics2:item.ItemMultiPart:52> * 8, [
+[<appliedenergistics2:item.ItemMultiPart:56>, <appliedenergistics2:item.ItemMultiPart:56>, <appliedenergistics2:item.ItemMultiPart:56>],
+[<appliedenergistics2:item.ItemMultiPart:56>, <ore:dyeBrown>, <appliedenergistics2:item.ItemMultiPart:56>],
+[<appliedenergistics2:item.ItemMultiPart:56>, <appliedenergistics2:item.ItemMultiPart:56>, <appliedenergistics2:item.ItemMultiPart:56>]]);
+
 
 // --- Cells ---
 


### PR DESCRIPTION
Fix missing brown smart cable recipe in AE2. Issue #2439 

Using dyeBrown ore dictionary.

![image](https://user-images.githubusercontent.com/33701188/93403391-fdf33980-f84c-11ea-93f2-fd0cad7e5c79.png)
