### PR TITLE
Removed mortar + Pam's Beet to Sugar recipe. Issue 3556.

### DIFF
--- a/scripts/Minecraft.zs
+++ b/scripts/Minecraft.zs
@@ -2188,10 +2188,6 @@ recipes.addShapeless(BlackHardClay,
 // --- Sugar
 recipes.addShapeless(Sugar,
 [Mortar, SugarCane]);
-// -
-recipes.addShapeless(Sugar,
-[Mortar, <harvestcraft:beetItem>]);
-
 
 // --- Diamond Sword
 recipes.addShaped(<minecraft:diamond_sword>, [


### PR DESCRIPTION
Partial fix to issue #3556. Next need to add recipe suggested to mortar sugar beets to 4 sugar. This simply removes the sugar from a plain beet.