### PR TITLE
Issue3556 Sugar from Beet removed.

### DIFF
--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -456,6 +456,9 @@ recipes.addShapeless(<gregtech:gt.metaitem.01:1890>, [<ore:craftingToolMortar>, 
 recipes.addShapeless(<gregtech:gt.metaitem.01:2892>, [<ore:craftingToolMortar>, <ore:listAllmeatraw>]);
 recipes.addShapeless(<gregtech:gt.metaitem.01:2892>, [<ore:craftingToolMortar>, <ore:listAllfishraw>]);
 
+// --- Sugar from Sugar Beet
+recipes.addShapeless(<minecraft:sugar> * 4, [<ore:craftingToolMortar>, <berriespp:foodBerries:1>]);
+
 // --- Cooked Mince Meat
 recipes.addShapeless(<gregtech:gt.metaitem.01:2893>, [<ore:craftingToolMortar>, <ore:listAllmeatcooked>]);
 recipes.addShapeless(<gregtech:gt.metaitem.01:2893>, [<ore:craftingToolMortar>, <ore:listAllfishcooked>]);

--- a/scripts/Minecraft.zs
+++ b/scripts/Minecraft.zs
@@ -2188,10 +2188,6 @@ recipes.addShapeless(BlackHardClay,
 // --- Sugar
 recipes.addShapeless(Sugar,
 [Mortar, SugarCane]);
-// -
-recipes.addShapeless(Sugar,
-[Mortar, <harvestcraft:beetItem>]);
-
 
 // --- Diamond Sword
 recipes.addShaped(<minecraft:diamond_sword>, [


### PR DESCRIPTION
Fix issue #3556 remove Pam's Beet to sugar in mortar. Add Sugar Beet (Crops++) to mortar but only 4 sugar. Get 8 in extractor still. Tried to add to Crops++ source but I couldn't even get Crops++ to build from fresh clone so bart will need to add it there if you want in code.

![image](https://user-images.githubusercontent.com/33701188/93656269-b0163700-f9ee-11ea-8957-7a8319e09649.png)
