### PR TITLE
Add Mark stale issues github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: "30 */2 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 3 days'
+        days-before-stale: 90
+        days-before-close: 3
+        stale-issue-label: 'stale'
+        only-labels: 'addition,additional Mod,Add Tooltip,Delta,enhancement,Epsilon,Eta,EU Live Server,Idea,Nerf,New Quests,New recipe,New Tooltip,Open for discussion,RFC (request for comment),suggestion'
+        exempt-issue-labels: 'FixedInDev,TODO,reminder,bugMajor,bugMinor,exploit'
+        asscending: true
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 3 days'
+        days-before-stale: 180
+        days-before-close: 3
+        stale-issue-label: 'stale'
+        only-labels: "can't reproduce,can't fix,Nothing i can do here"
+        exempt-issue-labels: 'reminder'
+        asscending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues
 
 on:
   schedule:
-  - cron: "30 */2 * * *"
+  - cron: "30 */6 * * *"
 
 jobs:
   stale:
@@ -14,9 +14,9 @@ jobs:
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 3 days'
         days-before-stale: 90
         days-before-close: 3
-        stale-issue-label: 'stale'
-        only-labels: 'addition,additional Mod,Add Tooltip,Delta,enhancement,Epsilon,Eta,EU Live Server,Idea,Nerf,New Quests,New recipe,New Tooltip,Open for discussion,RFC (request for comment),suggestion'
-        exempt-issue-labels: 'FixedInDev,TODO,reminder,bugMajor,bugMinor,exploit'
+        stale-issue-label: 'Status: stale'
+        only-labels: "Server: Delta,Server: EU Live Server,Server: Epsilon,Server: Eta,Server: Prospercraft,Server: Zeta,Status: NO,Status: Need new Idea,Status: Open for discussion,Status: RFC (request for comment),Status: Waiting for Feedback,Status: mod remove,Status: need to be tested,Status: report it at original Repo,Type: Idea,Type: Info,Type: Need more Info,Type: Nerf,Type: New Quests,Type: New Tooltip,Type: New recipe,Type: Not a Bug,Type: Won't change,Type: addition,Type: additional Mod,Type: balancing,Type: config,Type: duplicate,Type: enhancement,Type: invalid,Type: not our fault,Type: question,Type: refactor,Type: script changes,Type: silly suggestion,Type: suggestion"
+        exempt-issue-labels: 'Priority: CRITICAL,Priority: HIGH,Status: CodeComplete,Status: FixedInDev,Status: accepted,Status: work in progress,Status: waiting for fix,Type: bugMajor,Type: bugMinor,Type: exploit,Type: reminder,Type: urgent'
         asscending: true
     - uses: actions/stale@v3
       with:
@@ -24,7 +24,7 @@ jobs:
         stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 3 days'
         days-before-stale: 180
         days-before-close: 3
-        stale-issue-label: 'stale'
-        only-labels: "can't reproduce,can't fix,Nothing i can do here"
-        exempt-issue-labels: 'reminder'
+        stale-issue-label: 'Status: stale'
+        only-labels: "Status: can't fix,Status: can't reproduce,Status: Nothing i can do here"
+        exempt-issue-labels: 'Type: reminder'
         asscending: true


### PR DESCRIPTION
This essentially creates a stale bot that mark stale issues and close them if no activity happens after marking.

An issue is considered stale when
1. It is a balancing related change and it has not been updated in 90 days.
2. It is related to an official server and it has not been updated in 90 days.
3. It cannot be reproduced and it has not been updated in 180 days.

The bot will run 12 times per day, as we have quite a few issues to handle.
