### PR TITLE
disable WG transmutation

### DIFF
--- a/config/WitchingGadgets.cfg
+++ b/config/WitchingGadgets.cfg
@@ -32,7 +32,7 @@ modules {
 
 "ore/crucible" {
     B:"Enable clusters"=true
-    B:"Enable transmutations"=true
+    B:"Enable transmutations"=false
     S:"Not Trippling Cluster List" <
         Infinity
         Infinity Catalyst


### PR DESCRIPTION
Should be a "fix" for OP transmutations from WG, until it's either balanced or removed differently 