### PR TITLE
Fix(remove) Mining Pipe

### DIFF
--- a/scripts/IC2.zs
+++ b/scripts/IC2.zs
@@ -759,9 +759,6 @@ recipes.remove(<IC2:itemPartCFPowder>);
 
 
 
-// --- Mining Pipe Tip -> Mining Pipe
-recipes.addShapeless(<IC2:blockMiningTip>, [<IC2:blockMiningPipe>]);
-
 // --- Electric Heat Generator
 recipes.addShaped(<IC2:blockHeatGenerator:3>, [
 [<ore:cableGt01AnyCopper>, <gregtech:gt.metaitem.01:32501>, <ore:cableGt01AnyCopper>],


### PR DESCRIPTION
@Prometheus0000, recipe is already being managed >
https://github.com/GTNewHorizons/NewHorizonsCoreMod/blame/master/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java#L74
i think need remove this recipe from MT