### PR TITLE
Update ArchitectureCraft.cfg

### DIFF
--- a/config/ArchitectureCraft.cfg
+++ b/config/ArchitectureCraft.cfg
@@ -2,5 +2,21 @@ materials {
     S:UnlocalizedNames <
         tile.chisel.stained_glass
         tile.chisel.glass
+        tile.chisel.stained_glass_black
+        tile.chisel.stained_glass_red
+        tile.chisel.stained_glass_green
+        tile.chisel.stained_glass_brown
+        tile.chisel.stained_glass_blue
+        tile.chisel.stained_glass_purple
+        tile.chisel.stained_glass_cyan
+        tile.chisel.stained_glass_lightgray
+        tile.chisel.stained_glass_gray
+        tile.chisel.stained_glass_pink
+        tile.chisel.stained_glass_lime
+        tile.chisel.stained_glass_yellow
+        tile.chisel.stained_glass_lightblue
+        tile.chisel.stained_glass_magenta
+        tile.chisel.stained_glass_orange
+        tile.chisel.stained_glass_white
     >
 }


### PR DESCRIPTION
Allow chiseled stained glass to be shaped. Fix for #6882