### PR TITLE
fix autoclave of TC dusts / allow autocrafting of Galacticraft items

### DIFF
--- a/scripts/Galacticraft.zs
+++ b/scripts/Galacticraft.zs
@@ -113,22 +113,22 @@ recipes.remove(<GalacticraftCore:tile.refinery>);
 // --- Fuel Loader
 recipes.remove(<GalacticraftCore:tile.fuelLoader>);
 
-// --- Saleable Oxygen Pipe
+// --- Sealeable Oxygen Pipe
 recipes.remove(<GalacticraftCore:tile.enclosed:1>);
 
-// --- Saleable Copper Cable
+// --- Sealeable Copper Cable
 recipes.remove(<GalacticraftCore:tile.enclosed:2>);
 
-// --- Saleable Gold Cable
+// --- Sealeable Gold Cable
 recipes.remove(<GalacticraftCore:tile.enclosed:3>);
 
-// --- Saleable HV Cable
+// --- Sealeable HV Cable
 recipes.remove(<GalacticraftCore:tile.enclosed:4>);
 
-// --- Saleable Glass Fibre Cable
+// --- Sealeable Glass Fibre Cable
 recipes.remove(<GalacticraftCore:tile.enclosed:5>);
 
-// --- Saleable Tin Cable
+// --- Sealeable Tin Cable
 recipes.remove(<GalacticraftCore:tile.enclosed:6>);
 
 // --- Fuel Loader
@@ -265,7 +265,7 @@ recipes.remove(<GalacticraftCore:item.steel_shovel>);
 // --- Heavy Duty Sword
 recipes.remove(<GalacticraftCore:item.steel_sword>);
 
-// --- Heavy Duty Helm
+// --- Heavy Duty Helmet
 recipes.remove(<GalacticraftCore:item.steel_helmet>);
 
 // --- Heavy Duty Chest Plate
@@ -319,7 +319,7 @@ recipes.remove(<GalacticraftCore:item.buggymat:1>);
 // --- Buggy Storage Box
 recipes.remove(<GalacticraftCore:item.buggymat:2>);
 
-// --- Standard Wrenche
+// --- Standard Wrench
 recipes.remove(<GalacticraftCore:item.standardWrench>);
 
 // --- Can of Food
@@ -331,7 +331,7 @@ recipes.remove(<GalacticraftCore:item.basicItem:17>);
 // -
 recipes.remove(<GalacticraftCore:item.basicItem:18>);
 
-// --- Frequencey Module
+// --- Frequency Module
 recipes.remove(<GalacticraftCore:item.basicItem:19>);
 
 // --- Battery
@@ -352,7 +352,7 @@ recipes.remove(<GalacticraftMars:item.titanium_shovel>);
 // --- Titanium Sword
 recipes.remove(<GalacticraftMars:item.titanium_sword>);
 
-// --- Titanium Helm
+// --- Titanium Helmet
 recipes.remove(<GalacticraftMars:item.titanium_helmet>);
 
 // --- Titanium Chest Plate
@@ -376,19 +376,19 @@ recipes.remove(<GalacticraftMars:item.null:1>);
 // --- Gas Liquifier
 recipes.remove(<GalacticraftMars:tile.marsMachineT2>);
 
-// --- Methan Synthezizerezizer
+// --- Methan Synthesizer
 recipes.remove(<GalacticraftMars:tile.marsMachineT2:4>);
 
 // --- Water Electrolyzer
 recipes.remove(<GalacticraftMars:tile.marsMachineT2:8>);
 
-// --- Walk Away
+// --- Walkway
 recipes.remove(<GalacticraftMars:tile.walkway>);
 
-// --- Walk Away Aluminium
+// --- Walkway Aluminium
 recipes.removeShaped(<GalacticraftMars:tile.walkwayWire>);
 
-// --- Walk Away Pipes
+// --- Walkway Pipes
 recipes.removeShaped(<GalacticraftMars:tile.walkwayOxygenPipe>);
 
 // --- Thermal Cloth
@@ -400,7 +400,7 @@ recipes.remove(<GalacticraftMars:item.atmosphericValve>);
 // --- Rocket Fins
 recipes.remove(<GalacticraftCore:item.rocketFins>);
 
-// --- Heavy Rocket Fines
+// --- Heavy Rocket Fins
 recipes.remove(<GalacticraftMars:item.itemBasicAsteroids:2>);
 
 // --- Heavy Rocket Engine
@@ -517,7 +517,7 @@ furnace.remove(<*>, <GalacticraftMars:item.itemBasicAsteroids:4>);
 // --- Ilmenite Ore
 furnace.remove(<*>, <GalacticraftMars:tile.asteroidsBlock:4>);
 
-// --- Ambiete Thermal Controller
+// --- Ambient Thermal Controller
 recipes.remove(<GalacticraftCore:item.basicItem:20>);
 
 // --- Raw meteoric Iron
@@ -711,7 +711,7 @@ recipes.addShaped(<GalacticraftCore:tile.machineTiered:8>, [
 [<ore:cableGt02Gold>, <gregtech:gt.blockmachines:13>, <ore:cableGt02Gold>],
 [AdvWafer, <IC2:itemBatChargeAdv:32767>, AdvWafer]]);
 
-// --- Spin Truster
+// --- Spin Thruster
 recipes.addShaped(<GalacticraftCore:tile.spinThruster>, [
 [CompressedTi, CompressedTi, CompressedTi],
 [<GalacticraftCore:item.fuelCanisterPartial:1>, AdvWafer, <GalacticraftCore:item.fuelCanisterPartial:1>],
@@ -732,7 +732,7 @@ recipes.addShaped(<GalacticraftCore:tile.telemetry>, [
 // --- Arc Lamp
 recipes.addShaped(<GalacticraftCore:tile.arclamp>, [
 [DeshPlate,DeshPlate,DeshPlate],
-[DeshPlate, <GalacticraftCore:item.battery:*>, <ProjRed|Illumination:projectred.illumination.lamp:16>],
+[DeshPlate, <gregtech:gt.metaitem.01:32500>, <ProjRed|Illumination:projectred.illumination.lamp:16>],
 [DeshPlate, DeshPlate, DeshPlate]]);
 
 // --- Oxygen Gear
@@ -818,7 +818,7 @@ recipes.addShaped(<GalacticraftCore:item.steel_sword>, [
 [File, CompressedSteel, HHammer],
 [null, Stick, null]]);
 
-// --- Heavy Duty Helm
+// --- Heavy Duty Helmet
 recipes.addShaped(<GalacticraftCore:item.steel_helmet>, [
 [CompressedSteel, CompressedSteel, CompressedSteel],
 [CompressedSteel, HHammer, CompressedSteel],
@@ -1022,18 +1022,18 @@ recipes.addShaped(<GalacticraftCore:item.buggymat:2>, [
 [CompressedSteel, <IronChest:BlockIronChest>, CompressedSteel],
 [CompressedSteel, CompressedSteel, CompressedSteel]]);
 
-// --- Frequencey Module
+// --- Frequency Module
 recipes.addShaped(<GalacticraftCore:item.basicItem:19>, [
 [CompressedAl, <gregtech:gt.metaitem.01:32692>, CompressedAl],
 [BWafer, <gregtech:gt.metaitem.01:32740>, BWafer],
-[CompressedTin, <GalacticraftCore:item.battery>, CompressedTin]]);
+[CompressedTin, <gregtech:gt.metaitem.01:32500>, CompressedTin]]);
 // -
 recipes.addShaped(<GalacticraftCore:item.basicItem:19>, [
 [CompressedAl, <gregtech:gt.metaitem.01:32692>, CompressedAl],
 [BWafer, <gregtech:gt.metaitem.01:32740>, BWafer],
 [CompressedTin, <GalacticraftCore:item.battery:*>, CompressedTin]]);
 
-// --- Walk away
+// --- Walkway
 recipes.addShaped(<GalacticraftMars:tile.walkway> * 2, [
 [DeshPlate, DeshPlate, DeshPlate],
 [null, <ore:blockDesh>, null],
@@ -1048,7 +1048,7 @@ recipes.addShapeless(<gregtech:gt.metaitem.01:23884>, [<GalacticraftMars:item.nu
 // --- Battery
 recipes.addShapeless(<GalacticraftCore:item.battery:*>, [<gregtech:gt.metaitem.01:32500>]);
 
-// --- Standard Wrenche
+// --- Standard Wrench
 recipes.addShaped(<GalacticraftCore:item.standardWrench>, [
 [<ore:plateSteel>, <ore:craftingToolSaw>, <ore:plateSteel>],
 [<ore:screwSteel>, <ore:stickSteel>, <ore:screwSteel>],
@@ -1132,7 +1132,7 @@ recipes.addShaped(<GalacticraftCore:item.canvas>,  [
 [<harvestcraft:wovencottonItem>, <ore:stickPlastic>, <harvestcraft:wovencottonItem>],
 [<ore:stickPlastic>, <harvestcraft:wovencottonItem>, null]]);
 
-// --- Ambiete Thermal Controller
+// --- Ambient Thermal Controller
 recipes.addShaped(<GalacticraftCore:item.basicItem:20>,  [
 [<ore:circuitAdvanced>, <GalacticraftCore:item.airVent>, <ore:circuitAdvanced>],
 [<GalacticraftCore:item.basicItem:10>, <GalacticraftCore:item.basicItem:9>, <GalacticraftCore:item.basicItem:10>],
@@ -1386,7 +1386,7 @@ Assembler.addRecipe(<GalacticraftCore:item.parachute>, <GalacticraftCore:item.ca
 
 
 
-// --- Titan Ingot
+// --- Titanium Ingot
 BlastFurnace.addRecipe([<gregtech:gt.metaitem.01:11028>], [<GalacticraftMars:item.itemBasicAsteroids:4> * 2], 1500, 120, 1500);
 
 // --- Raw meteoric Iron

--- a/scripts/Galacticraft.zs
+++ b/scripts/Galacticraft.zs
@@ -1027,11 +1027,6 @@ recipes.addShaped(<GalacticraftCore:item.basicItem:19>, [
 [CompressedAl, <gregtech:gt.metaitem.01:32692>, CompressedAl],
 [BWafer, <gregtech:gt.metaitem.01:32740>, BWafer],
 [CompressedTin, <gregtech:gt.metaitem.01:32500>, CompressedTin]]);
-// -
-recipes.addShaped(<GalacticraftCore:item.basicItem:19>, [
-[CompressedAl, <gregtech:gt.metaitem.01:32692>, CompressedAl],
-[BWafer, <gregtech:gt.metaitem.01:32740>, BWafer],
-[CompressedTin, <GalacticraftCore:item.battery:*>, CompressedTin]]);
 
 // --- Walkway
 recipes.addShaped(<GalacticraftMars:tile.walkway> * 2, [

--- a/scripts/Galacticraft.zs
+++ b/scripts/Galacticraft.zs
@@ -701,15 +701,15 @@ recipes.addShaped(<GalacticraftCore:item.basicItem:1>, [
 
 // --- Energy Storage Module
 recipes.addShaped(<GalacticraftCore:tile.machineTiered>, [
-[CompressedSteel, <IC2:itemBatChargeRE:26>, CompressedSteel],
+[CompressedSteel, <IC2:itemBatChargeRE:32767>, CompressedSteel],
 [<ore:cableGt01AnyCopper>, <gregtech:gt.blockmachines:12>, <ore:cableGt01AnyCopper>],
-[BWafer, <IC2:itemBatChargeRE:26>, BWafer]]);
+[BWafer, <IC2:itemBatChargeRE:32767>, BWafer]]);
 
 // --- Energy Storage Cluster
 recipes.addShaped(<GalacticraftCore:tile.machineTiered:8>, [
-[CompressedTi, <IC2:itemBatChargeAdv:26>, CompressedTi],
+[CompressedTi, <IC2:itemBatChargeAdv:32767>, CompressedTi],
 [<ore:cableGt02Gold>, <gregtech:gt.blockmachines:13>, <ore:cableGt02Gold>],
-[AdvWafer, <IC2:itemBatChargeAdv:26>, AdvWafer]]);
+[AdvWafer, <IC2:itemBatChargeAdv:32767>, AdvWafer]]);
 
 // --- Spin Truster
 recipes.addShaped(<GalacticraftCore:tile.spinThruster>, [
@@ -1336,8 +1336,8 @@ ArcFurnace.addRecipe([<gregtech:gt.metaitem.01:32462> * 11, <gregtech:gt.metaite
 // --- Thermal Cloth
 Assembler.addRecipe(<GalacticraftMars:item.itemBasicAsteroids:7>, [<harvestcraft:wovencottonItem> * 8, <gregtech:gt.metaitem.01:29019> * 8, <dreamcraft:item.MeteoricIronString> * 8, <gregtech:gt.integrated_circuit:1> * 0], <liquid:molten.silicone> * 144, 300, 480);
 
-// --- Glowstone Torch
-Assembler.addRecipe(<GalacticraftCore:tile.glowstoneTorch>, <gregtech:gt.metaitem.01:23010>, <minecraft:glowstone_dust>, 100, 16);
+// --- Glowstone Torch (there's a 32x recipe somewhere else)
+Assembler.addRecipe(<GalacticraftCore:tile.glowstoneTorch>, [<gregtech:gt.metaitem.01:23010>, <minecraft:glowstone_dust>, <gregtech:gt.integrated_circuit:2> * 0], null, 100, 16);
 
 // --- Canister
 Assembler.addRecipe(<GalacticraftCore:item.oilCanisterPartial:1001>, <GalacticraftCore:item.basicItem:9> * 4, <gregtech:gt.metaitem.01:28305> * 4, 200, 64);

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -859,31 +859,31 @@ Autoclave.addRecipe(<Thaumcraft:ItemShard:1>, <gregtech:gt.metaitem.01:2541>, <l
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:1>, <gregtech:gt.metaitem.01:2541>, <liquid:ic2distilledwater> * 100, 9000, 1500, 30);
 // -
-Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2541>, <liquid:molten.void> * 36, 10000, 1000, 30);
+Autoclave.addRecipe(<Thaumcraft:ItemShard:1>, <gregtech:gt.metaitem.01:2541>, <liquid:molten.void> * 36, 10000, 1000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:2>, <gregtech:gt.metaitem.01:2543>, <liquid:water> * 200, 8000, 2000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:2>, <gregtech:gt.metaitem.01:2543>, <liquid:ic2distilledwater> * 100, 9000, 1500, 30);
 // -
-Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2543>, <liquid:molten.void> * 36, 10000, 1000, 30);
+Autoclave.addRecipe(<Thaumcraft:ItemShard:2>, <gregtech:gt.metaitem.01:2543>, <liquid:molten.void> * 36, 10000, 1000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:3>, <gregtech:gt.metaitem.01:2542>, <liquid:water> * 200, 8000, 2000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:3>, <gregtech:gt.metaitem.01:2542>, <liquid:ic2distilledwater> * 100, 9000, 1500, 30);
 // -
-Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2542>, <liquid:molten.void> * 36, 10000, 1000, 30);
+Autoclave.addRecipe(<Thaumcraft:ItemShard:3>, <gregtech:gt.metaitem.01:2542>, <liquid:molten.void> * 36, 10000, 1000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:4>, <gregtech:gt.metaitem.01:2545>, <liquid:water> * 200, 8000, 2000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:4>, <gregtech:gt.metaitem.01:2545>, <liquid:ic2distilledwater> * 100, 9000, 1500, 30);
 // -
-Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2545>, <liquid:molten.void> * 36, 10000, 1000, 30);
+Autoclave.addRecipe(<Thaumcraft:ItemShard:4>, <gregtech:gt.metaitem.01:2545>, <liquid:molten.void> * 36, 10000, 1000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:5>, <gregtech:gt.metaitem.01:2544>, <liquid:water> * 200, 8000, 2000, 30);
 // -
 Autoclave.addRecipe(<Thaumcraft:ItemShard:5>, <gregtech:gt.metaitem.01:2544>, <liquid:ic2distilledwater> * 100, 9000, 1500, 30);
 // -
-Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2544>, <liquid:molten.void> * 36, 10000, 1000, 30);
+Autoclave.addRecipe(<Thaumcraft:ItemShard:5>, <gregtech:gt.metaitem.01:2544>, <liquid:molten.void> * 36, 10000, 1000, 30);
 
 
 

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -93,20 +93,8 @@ recipes.removeShapeless(<gregtech:gt.metaitem.01:2881>);
 // --- Netherstar Dust
 recipes.removeShapeless(<gregtech:gt.metaitem.01:2506>);
 
-// --- GT Shovels
-recipes.removeShapeless(<gregtech:gt.metatool.01:4>);
-
 // --- Eridium Neutron Reflector
 recipes.remove(<gregtech:gt.neutronreflector>);
-
-// --- Thorium Fuel Rod
-recipes.remove(<gregtech:gt.Thoriumcell>);
-
-// --- Double Thorium Fuel Rod
-recipes.remove(<gregtech:gt.Double_Thoriumcell>);
-
-// --- Quad Thorium Fuel Rod
-recipes.remove(<gregtech:gt.Quad_Thoriumcell>);
 
 // --- 60k Helium Cooling Cell
 recipes.remove(<gregtech:gt.60k_Helium_Coolantcell>);
@@ -455,6 +443,9 @@ recipes.addShapeless(<gregtech:gt.metaitem.01:1890>, [<ore:craftingToolMortar>, 
 // --- Mince Meat
 recipes.addShapeless(<gregtech:gt.metaitem.01:2892>, [<ore:craftingToolMortar>, <ore:listAllmeatraw>]);
 recipes.addShapeless(<gregtech:gt.metaitem.01:2892>, [<ore:craftingToolMortar>, <ore:listAllfishraw>]);
+
+// --- Sugar from Sugar Beet
+recipes.addShapeless(<minecraft:sugar> * 4, [<ore:craftingToolMortar>, <berriespp:foodBerries:1>]);
 
 // --- Cooked Mince Meat
 recipes.addShapeless(<gregtech:gt.metaitem.01:2893>, [<ore:craftingToolMortar>, <ore:listAllmeatcooked>]);
@@ -813,14 +804,6 @@ Assembler.addRecipe(<gregtech:gt.blockmachines:24>, <IC2:blockElectric:6>, <greg
 // --- Iridium Neutron Reflector
 Assembler.addRecipe(<gregtech:gt.neutronreflector>, <dreamcraft:item.NeutronReflectorParts>, <IC2:itemPartIridium>, 1200, 256);
 
-// --- Double Thorium Fuel Rod
-Assembler.addRecipe(<gregtech:gt.Double_Thoriumcell>, <gregtech:gt.Thoriumcell> * 2, <gregtech:gt.metaitem.01:23305> * 4, 200, 30);
-
-// --- Quad Thorium Fuel Rod
-Assembler.addRecipe(<gregtech:gt.Quad_Thoriumcell>, <gregtech:gt.Double_Thoriumcell> * 2, <gregtech:gt.metaitem.01:23305> * 4, 200, 30);
-// -
-Assembler.addRecipe(<gregtech:gt.Quad_Thoriumcell>, <gregtech:gt.Thoriumcell> * 4, <gregtech:gt.metaitem.02:22305> * 6, 300, 30);
-
 // --- RTG Pellets
 Assembler.addRecipe(<IC2:itemRTGPellet>, <gregtech:gt.metaitem.01:22032> * 6, <IC2:itemPlutonium> * 3, <liquid:ic2coolant> * 1000, 1200, 120);
 
@@ -907,7 +890,6 @@ Autoclave.addRecipe(<Thaumcraft:ItemShard>, <gregtech:gt.metaitem.01:2544>, <liq
 // --- Blast Furnace Recipes ---
 
 
-
 // --- Graphene
 BlastFurnace.addRecipe([<gregtech:gt.metaitem.01:2819>], [<gregtech:gt.metaitem.01:2020>, <gregtech:gt.metaitem.01:2865>], 500, 480, 2000);
 // -
@@ -915,21 +897,12 @@ BlastFurnace.addRecipe([<gregtech:gt.metaitem.01:2819>], [<gregtech:gt.metaitem.
 
 
 
-
-
-
 // --- Canner Recipes ---
 
 
 
-
-// --- Thorium Fuel Rod
-Canner.addBottleRecipe(<gregtech:gt.Thoriumcell>, <IC2:itemFuelRod>, <gregtech:gt.metaitem.01:2096> * 3);
-
-
-
-
 // --- Centrifuge Recipes ---
+
 
 
 // --- Flint Dust
@@ -1786,6 +1759,10 @@ comb.add(<gregtech:gt.comb:118>);
 oreDict.combUhv.add(<gregtech:gt.comb:118>);
 comb.add(<gregtech:gt.comb:119>);
 oreDict.combUev.add(<gregtech:gt.comb:119>);
+
+// --- Add Tooltips
+
+<gregtech:gt.blockmachines:1157>.addTooltip(format.aqua("May you have all the black gold you want, RIP Cerulean"));
 
 // --- Dyes conversion
 


### PR DESCRIPTION
fix molten void autoclave recipe of TC crystal powders only giving air shards instead of their respective shards
Change Arc Lamp and Frequency Module recipes to use GT battery instead of GalactiCraft battery to allow proper autocrafting