### PR TITLE
Actaully prevent getting IV loot on ross

### DIFF
--- a/config/bartworks.cfg
+++ b/config/bartworks.cfg
@@ -383,7 +383,7 @@ multiblocks {
         664
         674
      >
-    I:"A_Ruin Machine Tiers"=6
+    I:"A_Ruin Machine Tiers"=5
 }
 
 


### PR DESCRIPTION
I missed this number before, so it regenerates the list.