### PR TITLE
Add TC oreberries to Pulverizer recipes

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -165,8 +165,8 @@ modules {
     # Set to true to show login message with modpack version [default: true]
     B:LoginMessage=true
 
-    # Version of the Modpack [default: 2.1.0.4]
-    S:ModPackVersion=2.1.0.4
+    # Version of the Modpack [default: 2.1.0.5]
+    S:ModPackVersion=2.1.0.5
 
     # Set to false to prevent the OreDict register for SpaceStones and SpaceDusts [default: true]
     B:OreDictItems=true

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -2,7 +2,7 @@
 
 
 
-// --- Imports --- 
+// --- Imports ---
 
 import minetweaker.item.IIngredient;
 import minetweaker.item.IItemStack;
@@ -100,7 +100,7 @@ recipes.remove(<gregtech:gt.neutronreflector>);
 recipes.remove(<gregtech:gt.60k_Helium_Coolantcell>);
 
 // --- 180k Helium Cooling Cell
-recipes.remove(<gregtech:gt.180k_Helium_Coolantcell>); 
+recipes.remove(<gregtech:gt.180k_Helium_Coolantcell>);
 
 // --- 360k Helium Cooling Cell
 recipes.remove(<gregtech:gt.360k_Helium_Coolantcell>);
@@ -109,7 +109,7 @@ recipes.remove(<gregtech:gt.360k_Helium_Coolantcell>);
 recipes.remove(<gregtech:gt.60k_NaK_Coolantcell>);
 
 // --- 180k NaK Cooling Cell
-recipes.remove(<gregtech:gt.180k_NaK_Coolantcell>); 
+recipes.remove(<gregtech:gt.180k_NaK_Coolantcell>);
 
 // --- 360k NaK Cooling Cell
 recipes.remove(<gregtech:gt.360k_NaK_Coolantcell>);
@@ -156,7 +156,7 @@ recipes.removeShaped(<ore:ingotDraconiumAwakened>, [
 [<ore:nuggetDraconiumAwakened>, <ore:nuggetDraconiumAwakened>, <ore:nuggetDraconiumAwakened>],
 [<ore:nuggetDraconiumAwakened>, <ore:nuggetDraconiumAwakened>, <ore:nuggetDraconiumAwakened>]]);
 
-// --- Vibrant Alloy Ingot 
+// --- Vibrant Alloy Ingot
 recipes.removeShaped(<ore:ingotVibrantAlloy>, [
 [<ore:nuggetVibrantAlloy>, <ore:nuggetVibrantAlloy>, <ore:nuggetVibrantAlloy>],
 [<ore:nuggetVibrantAlloy>, <ore:nuggetVibrantAlloy>, <ore:nuggetVibrantAlloy>],
@@ -910,7 +910,7 @@ Centrifuge.addRecipe([<gregtech:gt.metaitem.01:2802> * 8],  null, <minecraft:gra
 
 // --- Re-add Cadmium Centrifuge recipe
 Centrifuge.addRecipe([<gregtech:gt.metaitem.01:1067>, <gregtech:gt.metaitem.01:1045>, <gregtech:gt.metaitem.01:1064>, <gregtech:gt.metaitem.01:1065>, <gregtech:gt.metaitem.01:1055>, <gregtech:gt.metaitem.01:1062>], null, <gregtech:gt.metaitem.01:2891>, null, null, [2500, 2500, 2500, 2500, 2500, 2500], 64, 20);
-        
+
 
 
 
@@ -1115,8 +1115,18 @@ FormingPress.addRecipe(<dreamcraft:item.CoinBlank>, <gregtech:gt.metaitem.01:170
 
 
 
-// --- Pulverizer Recipes --- 
+// --- Pulverizer Recipes ---
 
+// Gold Nugget
+Pulverizer.addRecipe([<gregtech:gt.metaitem.01:86>], <TConstruct:oreBerries:1>, [10000], 300, 2);
+// Iron Nugget
+Pulverizer.addRecipe([<gregtech:gt.metaitem.01:32>], <TConstruct:oreBerries:0>, [10000], 300, 2);
+// Copper Nugget
+Pulverizer.addRecipe([<gregtech:gt.metaitem.01:35>], <TConstruct:oreBerries:2>, [10000], 300, 2);
+// Tin Nugget
+Pulverizer.addRecipe([<gregtech:gt.metaitem.01:57>], <TConstruct:oreBerries:3>, [10000], 300, 2);
+// Aluminum Nugget to Tiny Aluminium
+Pulverizer.addRecipe([<gregtech:gt.metaitem.01:19>], <TConstruct:oreBerries:4>, [10000], 300, 2);
 
 // --- Flour
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:2881>], <Natura:barleyFood>, [10000], 300, 2);

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -1117,15 +1117,15 @@ FormingPress.addRecipe(<dreamcraft:item.CoinBlank>, <gregtech:gt.metaitem.01:170
 
 // --- Pulverizer Recipes ---
 
-// Gold Nugget
+// Gold Oreberry
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:86>], <TConstruct:oreBerries:1>, [10000], 300, 2);
-// Iron Nugget
+// Iron Oreberry
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:32>], <TConstruct:oreBerries:0>, [10000], 300, 2);
-// Copper Nugget
+// Copper Oreberry
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:35>], <TConstruct:oreBerries:2>, [10000], 300, 2);
-// Tin Nugget
+// Tin Oreberry
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:57>], <TConstruct:oreBerries:3>, [10000], 300, 2);
-// Aluminum Nugget to Tiny Aluminium
+// Aluminum Oreberry to Tiny Aluminium
 Pulverizer.addRecipe([<gregtech:gt.metaitem.01:19>], <TConstruct:oreBerries:4>, [10000], 300, 2);
 
 // --- Flour


### PR DESCRIPTION
@Dream-Master I added the recipes locally because I had a backlog of oreberries I wanted to macerate, so I figured I might as well put up a PR. I wasn't sure what the old duration/voltage was but as I write this sentence I realize that I was just lazy and can fire up an older version to check them out, so I'll circle back after doing that.

* All recipes are 15s @ 600EU
* Aluminum oreberries crush to tiny aluminium piles.
* Used refs from [tconstruct in scripts/Tinkers-Construct.zs](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/ba4f01a32df60ec05d5c11168f4174aee231da09/scripts/Tinkers-Construct.zs#L14) and [Gregtech.zs](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/4c9222ffa366fb3dd78995af11c97fd12479a9b2/scripts/Gregtech.zs#L504)
* Some formatting fixes thanks to the ZenScript IDE Extension I grabbed.
* First time touching ZenScript so don't go easy on me.
  
    
 _Edit: Double checked in 2.0.0.0, recipes were indeed 15s @ 600EU._