### PR TITLE
Fix magnet derp

### DIFF
--- a/scripts/Draconic-Evolution.zs
+++ b/scripts/Draconic-Evolution.zs
@@ -611,16 +611,10 @@ mods.avaritia.ExtremeCrafting.addShaped(<DraconicEvolution:particleGenerator>, [
 [null, null, null, null, null, null, null, null, null]]);
 
 // --- Item Dislocator
-mods.avaritia.ExtremeCrafting.addShaped(<DraconicEvolution:magnet>, [
-[null, null, null, null, null, null, null, null, null],
-[null, null, null, null, null, null, null, null, null],
-[null, <ore:blockSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, null, null],
-[null, null, null, null, null, null, <ore:ingotSteelMagnetic>, null, null],
-[null, null, null, null, null, null, <gregtech:gt.metaitem.01:32518>, null, null],
-[null, null, null, null, null, null, <ore:ingotSteelMagnetic>, null, null],
-[null, <ore:blockSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>, null, null],
-[null, null, null, null, null, null, null, null, null],
-[null, null, null, null, null, null, null, null, null]]);
+recipes.addShaped(<DraconicEvolution:magnet>, [
+[<ore:blockSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>],
+[null, null, <gregtech:gt.metaitem.01:32518>],
+[<ore:blockSteelMagnetic>, <ore:ingotSteelMagnetic>, <ore:ingotSteelMagnetic>]]);
 
 // --- Advanced Item Dislocator
 mods.avaritia.ExtremeCrafting.addShaped(<DraconicEvolution:magnet:1>, [


### PR DESCRIPTION
 Make the first magnet actually craftable at a point earlier than the HV EIO one.

DCT->normal crafting table, otherwise it's HV locked, and you can make them all 3 involved at about the same time.

