### PR TITLE
Add GT blocks to the blacklist of the drawbridge

### DIFF
--- a/config/TMechworks.cfg
+++ b/config/TMechworks.cfg
@@ -3,6 +3,7 @@
 drawbridge {
     # Add block names that should not be placed from the drawbridge [default: ]
     S:blacklist <
+        gregtech:gt.blockmachines
      >
 }
 


### PR DESCRIPTION
To prevent cheesing solar boilers. Probably prevents crashes with other blocks too, given how buggy I hear DBs are. Why are TEs even allowed to begin with?