### PR TITLE
disabled lootgames donator list to speed up loading time

### DIFF
--- a/config/LootGames/lootgames.cfg
+++ b/config/LootGames/lootgames.cfg
@@ -148,6 +148,9 @@ games {
 main {
     # Switch to enable or disable the Master-Blocks. If disabled, no minigames will spawn. You can change this ingame [default: false]
     B:MinigamesEnabled=true
+    
+    # Disables downloading of donors list. It will speed-up mod loading, when you don't have an access to the Pastebin or play offline. [default: false]
+    B:disableDonorListDownloading=true
 }
 
 


### PR DESCRIPTION
according to @TimeConqueror, it's better if it's disabled.