### PR TITLE
Remove/hide EC2 items, and other useless AE2 related items. Also change TE recipes

### DIFF
--- a/scripts/AE2.zs
+++ b/scripts/AE2.zs
@@ -678,12 +678,6 @@ recipes.addShaped(<appliedenergistics2:tile.BlockEnergyAcceptor>, [
 [FluixCrystal, GlowstonePlate, FluixCrystal],
 [TitaniumPlate, FluixCrystal, TitaniumPlate]]);
 
-// --- Vibration Chamber
-recipes.addShaped(<appliedenergistics2:tile.BlockVibrationChamber>, [
-[TitaniumPlate, <ore:screwTitanium>, TitaniumPlate],
-[<ore:craftingToolScrewdriver>, <gregtech:gt.blockmachines:264>, <ore:craftingToolWrench>],
-[TitaniumPlate, <appliedenergistics2:tile.BlockEnergyAcceptor>, TitaniumPlate]]);
-
 // --- ME Security Terminal
 recipes.addShaped(<appliedenergistics2:tile.BlockSecurity>, [
 [TitaniumPlate, <appliedenergistics2:tile.BlockChest>, TitaniumPlate],
@@ -1448,6 +1442,11 @@ Wiremill.addRecipe(<appliedenergistics2:item.ItemMultiPart:140>, <gregtech:gt.me
 
 
 // --- Hiding Stuff ---
+
+
+// --- Vibration Chamber
+NEI.hide(<appliedenergistics2:tile.BlockVibrationChamber>);
+
 
 
 // --- Renaming Stuff ---

--- a/scripts/Extra-Cells.zs
+++ b/scripts/Extra-Cells.zs
@@ -6,7 +6,7 @@
 
 
 import mods.gregtech.Assembler;
-
+import mods.nei.NEI;
 
 
 // --- Variables ---
@@ -84,7 +84,6 @@ val HHammer = <ore:craftingToolHardHammer>;
 
 
 // --- Removing Recipes ---
-
 
 
 // --- Storage Cell - 256K
@@ -300,6 +299,8 @@ recipes.remove(<extracells:craftingstorage:2>);
 // --- Crafing Storage 16384K
 recipes.remove(<extracells:craftingstorage:3>);
 
+// --- Walrus
+recipes.remove(<extracells:walrus>);
 
 
 
@@ -307,11 +308,6 @@ recipes.remove(<extracells:craftingstorage:3>);
 
 
 // --- Storage Cell - 256K
-recipes.addShaped(Storage256K, [
-[HHammer, CertusPlate, CertusScrew],
-[ChromePlate, StorageComponent256K, ChromePlate],
-[CertusScrew, ChromePlate, Screwdriver]]);
-// -
 recipes.addShaped(Storage256K, [
 [HHammer, CertusPlate, CertusScrew],
 [ChromePlate, StorageComponent256K, ChromePlate],
@@ -324,11 +320,6 @@ recipes.addShaped(Storage1024K, [
 [HHammer, CertusPlate, CertusScrew],
 [ChromePlate, StorageComponent1024K, ChromePlate],
 [CertusScrew, ChromePlate, Screwdriver]]);
-// -
-recipes.addShaped(Storage1024K, [
-[HHammer, CertusPlate, CertusScrew],
-[ChromePlate, StorageComponent1024K, ChromePlate],
-[CertusScrew, ChromePlate, Screwdriver]]);
 
 recipes.addShapeless(<extracells:storage.physical:1>, [<extracells:storage.component:1>, <extracells:storage.casing:0>]);
 
@@ -337,20 +328,10 @@ recipes.addShaped(Storage4096K, [
 [HHammer, CertusPlate, CertusScrew],
 [ChromePlate, StorageComponent4096K, ChromePlate],
 [CertusScrew, ChromePlate, Screwdriver]]);
-// -
-recipes.addShaped(Storage4096K, [
-[HHammer, CertusPlate, CertusScrew],
-[ChromePlate, StorageComponent4096K, ChromePlate],
-[CertusScrew, ChromePlate, Screwdriver]]);
 
 recipes.addShapeless(<extracells:storage.physical:2>, [<extracells:storage.component:2>, <extracells:storage.casing:0>]);
 
 // --- Storage Cell - 16384K
-recipes.addShaped(Storage16384K, [
-[HHammer, CertusPlate, CertusScrew],
-[ChromePlate, StorageComponent16384K, ChromePlate],
-[CertusScrew, ChromePlate, Screwdriver]]);
-// -
 recipes.addShaped(Storage16384K, [
 [HHammer, CertusPlate, CertusScrew],
 [ChromePlate, StorageComponent16384K, ChromePlate],
@@ -387,193 +368,6 @@ recipes.addShaped(UAdvStorageHousing, [
 [HHammer, CertusPlate, CertusScrew],
 [ChromePlate, ClearPane, ChromePlate],
 [CertusScrew, ChromePlate, Screwdriver]]);
-// -
-recipes.addShaped(UAdvStorageHousing, [
-[Screwdriver, CertusPlate, CertusScrew],
-[ChromePlate, ClearPane, ChromePlate],
-[CertusScrew, ChromePlate, HHammer]]);
-
-// --- Fluid Storage Cell - 1K
-recipes.addShaped(FluidStorage1K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent1K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage1K, [
-[Screwdriver, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent1K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, HHammer]]);
-
-recipes.addShapeless(<extracells:storage.fluid:0>, [<extracells:storage.component:4>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 4K
-recipes.addShaped(FluidStorage4K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent4K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage4K, [
-[Screwdriver, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent4K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, HHammer]]);
-
-recipes.addShapeless(<extracells:storage.fluid:1>, [<extracells:storage.component:5>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 16K
-recipes.addShaped(FluidStorage16K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent16K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage16K, [
-[Screwdriver, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent16K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, HHammer]]);
-
-recipes.addShapeless(<extracells:storage.fluid:2>, [<extracells:storage.component:6>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 64K
-recipes.addShaped(FluidStorage64K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent64K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage64K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent64K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-
-recipes.addShapeless(<extracells:storage.fluid:3>, [<extracells:storage.component:7>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 256K
-recipes.addShaped(FluidStorage256K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent256K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage256K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent256K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-
-recipes.addShapeless(<extracells:storage.fluid:4>, [<extracells:storage.component:8>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 1024K
-recipes.addShaped(FluidStorage1024K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent1024K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage1024K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent1024K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-
-recipes.addShapeless(<extracells:storage.fluid:5>, [<extracells:storage.component:9>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell - 4096K
-recipes.addShaped(FluidStorage4096K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent4096K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(FluidStorage4096K, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, FluidSComponent4096K, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-
-recipes.addShapeless(<extracells:storage.fluid:6>, [<extracells:storage.component:10>, <extracells:storage.casing:1>]);
-
-// --- Fluid Storage Cell Component - 1K
-recipes.addShaped(FluidSComponent1K, [
-[PrimitiveCircuit, <appliedenergistics2:item.ItemMultiMaterial:8>, PrimitiveCircuit],
-[<appliedenergistics2:item.ItemMultiMaterial:8>, <dreamcraft:item.EngineeringProcessorFluidDiamondCore>, <appliedenergistics2:item.ItemMultiMaterial:8>],
-[PrimitiveCircuit, <appliedenergistics2:item.ItemMultiMaterial:8>, PrimitiveCircuit]]);
-
-// --- Fluid Storage Cell Component - 4K
-recipes.addShaped(FluidSComponent4K, [
-[BasicCircuit, FluidSComponent1K, BasicCircuit],
-[FluidSComponent1K, <dreamcraft:item.EngineeringProcessorFluidDiamondCore>, FluidSComponent1K],
-[BasicCircuit, FluidSComponent1K, BasicCircuit]]);
-
-// --- Fluid Storage Cell Component - 16K
-recipes.addShaped(FluidSComponent16K, [
-[GoodCircuit, FluidSComponent4K, GoodCircuit],
-[FluidSComponent4K, <dreamcraft:item.EngineeringProcessorFluidDiamondCore>, FluidSComponent4K],
-[GoodCircuit, FluidSComponent4K, GoodCircuit]]);
-
-// --- Fluid Storage Cell Component - 64K
-recipes.addShaped(FluidSComponent64K, [
-[AdvCircuit, FluidSComponent16K, AdvCircuit],
-[FluidSComponent16K, <dreamcraft:item.EngineeringProcessorFluidDiamondCore>, FluidSComponent16K],
-[AdvCircuit, FluidSComponent16K, AdvCircuit]]);
-
-// --- Fluid Storage Cell Component - 256K
-recipes.addShaped(FluidSComponent256K, [
-[DataCircuit, FluidSComponent64K, DataCircuit],
-[FluidSComponent64K, <dreamcraft:item.EngineeringProcessorFluidEmeraldCore>, FluidSComponent64K],
-[DataCircuit, FluidSComponent64K, DataCircuit]]);
-
-// --- Fluid Storage Cell Component - 1024K
-recipes.addShaped(FluidSComponent1024K, [
-[EliteCircuit, FluidSComponent256K, EliteCircuit],
-[FluidSComponent256K, <dreamcraft:item.EngineeringProcessorFluidEmeraldCore>, FluidSComponent256K],
-[EliteCircuit, FluidSComponent256K, EliteCircuit]]);
-
-// --- Fluid Storage Cell Component - 4096K
-recipes.addShaped(FluidSComponent4096K, [
-[MasterCircuit, FluidSComponent1024K, MasterCircuit],
-[FluidSComponent1024K, <dreamcraft:item.EngineeringProcessorFluidEmeraldCore>, FluidSComponent1024K],
-[MasterCircuit, FluidSComponent1024K, MasterCircuit]]);
-
-// --- Universal Fluid Storage Housing
-recipes.addShaped(UFluidStorageHousing, [
-[HHammer, CertusPlate, CertusScrew],
-[TitaniumPlate, ClearPane, TitaniumPlate],
-[CertusScrew, TitaniumPlate, Screwdriver]]);
-// -
-recipes.addShaped(UFluidStorageHousing, [
-[Screwdriver, CertusPlate, CertusScrew],
-[TitaniumPlate, ClearPane, TitaniumPlate],
-[CertusScrew, TitaniumPlate, HHammer]]);
-
-// --- ME Fluid Terminal
-recipes.addShaped(<extracells:part.base:3>, [
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>],
-[<appliedenergistics2:item.ItemMultiMaterial:43>, <appliedenergistics2:item.ItemMultiPart:380>, <appliedenergistics2:item.ItemMultiMaterial:44>],
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>]]);
-
-// --- ME Fluid Assembler
-recipes.addShaped(<extracells:fluidcrafter>, [
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>],
-[<extracells:storage.component:4>, <appliedenergistics2:tile.BlockMolecularAssembler>, <extracells:storage.component:4>],
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>]]);
-
-// --- ME Fluid Interface
-recipes.addShaped(<extracells:ecbaseblock>, [
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>],
-[<extracells:storage.component:4>, <appliedenergistics2:tile.BlockInterface>, <extracells:storage.component:4>],
-[<ore:plateLapis>, <appliedenergistics2:item.ItemMultiPart:16>, <ore:plateLapis>]]);
-// -
-recipes.addShapeless(<extracells:ecbaseblock>, [<extracells:part.base:9>]);
-
-// --- ME Fluid Auto Filler
-recipes.addShaped(<extracells:ecbaseblock:1>, [
-[<ore:plateLapis>, <extracells:part.base:3>, <ore:plateLapis>],
-[<appliedenergistics2:item.ItemMultiPart:16>, <extracells:fluidcrafter>, <appliedenergistics2:item.ItemMultiPart:16>],
-[<ore:plateLapis>, <extracells:part.base:4>, <ore:plateLapis>]]);
-
-// --- Blast Resistance ME Drive
-recipes.addShaped(<extracells:hardmedrive>, [
-[<ore:plateDenseObsidian>, <appliedenergistics2:item.ItemMultiPart:76>, <ore:plateDenseObsidian>],
-[<ore:plateDenseObsidian>, <appliedenergistics2:tile.BlockDrive>, <ore:plateDenseObsidian>],
-[<ore:plateDenseLead>, <ore:plateDenseLead>, <ore:plateDenseLead>]]);
-
-// --- Fluid Vibration Chamber
-recipes.addShaped(<extracells:vibrantchamberfluid>, [
-[<ore:plateLapis>, <extracells:part.base:3>, <ore:plateLapis>],
-[<appliedenergistics2:item.ItemMultiPart:16>, <appliedenergistics2:tile.BlockVibrationChamber>, <appliedenergistics2:item.ItemMultiPart:16>],
-[<ore:plateLapis>, <extracells:certustank>, <ore:plateLapis>]]);
 
 // --- ME Block Container
 recipes.addShaped(<extracells:storage.physical:4>, [
@@ -581,56 +375,13 @@ recipes.addShaped(<extracells:storage.physical:4>, [
 [<ore:screwTitanium>, <appliedenergistics2:tile.BlockChest>, <ore:screwTitanium>],
 [<ore:craftingToolScrewdriver>, <appliedenergistics2:item.ItemMultiMaterial:39>, <ore:craftingToolWrench>]]);
 
-// --- ME Portable Fluid Storage
-recipes.addShaped(<extracells:storage.fluid.portable>, [
-[null, <extracells:storage.component:4>, null],
-[<ore:screwTitanium>, <appliedenergistics2:tile.BlockChest>, <ore:screwTitanium>],
-[<ore:craftingToolScrewdriver>, <appliedenergistics2:tile.BlockEnergyCell>, <ore:craftingToolWrench>]]);
-
 
 
 // --- Assembler Recipes ---
 
 
-
 // --- Quartz Tank
 Assembler.addRecipe(<extracells:certustank>, <appliedenergistics2:tile.BlockQuartzGlass> * 8, <gregtech:gt.integrated_circuit:8> * 0, 800, 30);
-
-// --- ME Fluid Export Bus
-Assembler.addRecipe(<extracells:part.base>, <appliedenergistics2:item.ItemMultiPart:260>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Import Bus
-Assembler.addRecipe(<extracells:part.base:1>, <appliedenergistics2:item.ItemMultiPart:240>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Storage Bus
-Assembler.addRecipe(<extracells:part.base:2>, <appliedenergistics2:item.ItemMultiPart:220>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Level Emitter
-Assembler.addRecipe(<extracells:part.base:4>, <appliedenergistics2:item.ItemMultiPart:280>, <gregtech:gt.metaitem.01:17526>, 100, 120);
-
-// --- ME Fluid Annihilation Plane
-Assembler.addRecipe(<extracells:part.base:5>, <appliedenergistics2:item.ItemMultiPart:300>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Formating Plane
-Assembler.addRecipe(<extracells:part.base:6>, <appliedenergistics2:item.ItemMultiPart:320>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Drive Fixture
-Assembler.addRecipe(<extracells:part.base:7>, <appliedenergistics2:tile.BlockDrive>, <gregtech:gt.metaitem.01:17306> * 3, 300, 120);
-
-// --- ME Energy Cell Fixture
-Assembler.addRecipe(<extracells:part.base:8>, <appliedenergistics2:tile.BlockEnergyCell>, <gregtech:gt.metaitem.01:17306> * 3, 300, 120);
-
-// --- Fluid Storage Monitor
-Assembler.addRecipe(<extracells:part.base:10>, <appliedenergistics2:item.ItemMultiPart:400>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Conversion Monitor
-Assembler.addRecipe(<extracells:part.base:11>, <appliedenergistics2:item.ItemMultiPart:420>, <gregtech:gt.metaitem.01:17526> * 3, 300, 120);
-
-// --- ME Fluid Pattern
-Assembler.addRecipe(<extracells:pattern.fluid>, <extracells:storage.casing:1>, <minecraft:bucket>, 100, 120);
-
-// --- Wireless Fluid ME Terminal
-Assembler.addRecipe(<extracells:terminal.fluid.wireless>, <appliedenergistics2:item.ToolWirelessTerminal:*>, <extracells:part.base:3>, 600, 120);
 
 // --- Crafing Storage 256K
 Assembler.addRecipe(<extracells:craftingstorage>, <appliedenergistics2:tile.BlockCraftingUnit>, <extracells:storage.component>, 400, 1920);
@@ -649,5 +400,116 @@ Assembler.addRecipe(<appliedenergistics2:tile.BlockCraftingStorage:3>, <appliede
 
 
 
-
 // --- Hiding Stuff ---
+
+
+// --- ME Fluid Assembler
+NEI.hide(<extracells:fluidcrafter>);
+
+// --- ME Fluid Pattern
+NEI.hide(<extracells:pattern.fluid>);
+
+// --- ME Fluid Export Bus
+NEI.hide(<extracells:part.base>);
+
+// --- ME Fluid Import Bus
+NEI.hide(<extracells:part.base:1>);
+
+// --- ME Fluid Storage Bus
+NEI.hide(<extracells:part.base:2>);
+
+// -- ME Ore Dictionary Bus
+NEI.hide(<extracells:part.base:12>);
+
+// --- ME Fluid Terminal
+NEI.hide(<extracells:part.base:3>);
+
+// --- ME Fluid Level Emitter
+NEI.hide(<extracells:part.base:4>);
+
+// --- ME Fluid Annihilation Plane
+NEI.hide(<extracells:part.base:5>);
+
+// --- ME Fluid Formating Plane
+NEI.hide(<extracells:part.base:6>);
+
+// --- ME Drive Fixture
+NEI.hide(<extracells:part.base:7>);
+
+// --- ME Energy Cell Fixture
+NEI.hide(<extracells:part.base:8>);
+
+// --- ME Fluid Storage Monitor
+NEI.hide(<extracells:part.base:10>);
+
+// --- ME Fluid Conversion Monitor
+NEI.hide(<extracells:part.base:11>);
+
+// --- Fluid Storage Cell - 1K
+NEI.hide(FluidStorage1K);
+
+// --- Fluid Storage Cell - 4K
+NEI.hide(FluidStorage4K);
+
+// --- Fluid Storage Cell - 16K
+NEI.hide(FluidStorage16K);
+
+// --- Fluid Storage Cell - 64K
+NEI.hide(FluidStorage64K);
+
+// --- Fluid Storage Cell - 256K
+NEI.hide(FluidStorage256K);
+
+// --- Fluid Storage Cell - 1024K
+NEI.hide(FluidStorage1024K);
+
+// --- Fluid Storage Cell - 4096K
+NEI.hide(FluidStorage4096K);
+
+// --- Fluid Storage Cell Component - 1K
+NEI.hide(FluidSComponent1K);
+
+// --- Fluid Storage Cell Component - 4K
+NEI.hide(FluidSComponent4K);
+
+// --- Fluid Storage Cell Component - 16K
+NEI.hide(FluidSComponent16K);
+
+// --- Fluid Storage Cell Component - 64K
+NEI.hide(FluidSComponent64K);
+
+// --- Fluid Storage Cell Component - 256K
+NEI.hide(FluidSComponent256K);
+
+// --- Fluid Storage Cell Component - 1024K
+NEI.hide(FluidSComponent1024K);
+
+// --- Fluid Storage Cell Component - 4096K
+NEI.hide(FluidSComponent4096K);
+
+// --- Fluid Storage Housing
+NEI.hide(<extracells:storage.casing:1>);
+
+// --- ME Fluid Interface
+NEI.hide(<extracells:ecbaseblock>);
+
+// --- ME Fluid Interface as part
+NEI.hide(<extracells:part.base:9>);
+
+// --- ME Fluid Auto Filler
+NEI.hide(<extracells:ecbaseblock:1>);
+
+// --- Blast Resistance ME Drive
+NEI.hide(<extracells:hardmedrive>);
+
+// --- Fluid Vibration Chamber
+NEI.hide(<extracells:vibrantchamberfluid>);
+
+// --- ME Portable Fluid Storage
+NEI.hide(<extracells:storage.fluid.portable:*>);
+
+// --- Wireless Fluid ME Terminal
+NEI.hide(<extracells:terminal.fluid.wireless:*>);
+
+// --- Walrus
+NEI.hide(<extracells:walrus>);

--- a/scripts/Thaumic-Energistics.zs
+++ b/scripts/Thaumic-Energistics.zs
@@ -402,7 +402,8 @@ mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEINFPROV", 3);
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEESSPROV");
 
 // --- Iron Gear Box
-mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEIRONGEARBOX");
+mods.thaumcraft.Research.orphanResearch("thaumicenergistics.TEIRONGEARBOX");
+mods.thaumcraft.Research.removeResearch("thaumicenergistics.TEIRONGEARBOX");
 
 // --- Arcane Crafting Terminal
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEARCANETERM");
@@ -417,7 +418,8 @@ mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TECORES");
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEESSTERM");
 
 // --- Vibration Chamber
-mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEESSVIBCMBR");
+mods.thaumcraft.Research.orphanResearch("thaumicenergistics.TEESSVIBCMBR");
+mods.thaumcraft.Research.removeResearch("thaumicenergistics.TEESSVIBCMBR");
 
 // --- Digi Sentia Transportation
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEIO");
@@ -434,11 +436,12 @@ mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEGOLEMWIFIBA
 // --- Essentia Storage
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TESTORAGE");
 
-// --- Vis rellay Interface
+// --- Vis relay Interface
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEVISINT");
 
 // --- Thaumic Gear Box
-mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TETHAUMGBOX");
+mods.thaumcraft.Research.orphanResearch("thaumicenergistics.TETHAUMGBOX");
+mods.thaumcraft.Research.removeResearch("thaumicenergistics.TETHAUMGBOX");
 
 // --- Arcane Assembler
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEARCANEASSEMBLER");

--- a/scripts/Thaumic-Energistics.zs
+++ b/scripts/Thaumic-Energistics.zs
@@ -5,20 +5,15 @@
 // --- Importing Stuff ---
 
 
-
-
 import mods.gregtech.Assembler;
-
+import mods.nei.NEI;
 
 
 // --- Variables ---
 
 
 
-
-
 // --- Removing Recipes ---
-
 
 
 // --- Wireless Essentia ME Terminal
@@ -125,15 +120,11 @@ mods.thaumcraft.Infusion.removeRecipe(<thaumicenergistics:thaumicenergistics.blo
 
 
 
-
 // --- Adding Recipes ----
 
 
 
-
-
 // --- Assembler Recipes ---
-
 
 
 // --- Wireless Essentia ME Terminal
@@ -141,9 +132,7 @@ Assembler.addRecipe(<thaumicenergistics:wireless.essentia.terminal>, <appliedene
 
 
 
-
 // --- Thaumcraft Stuff
-
 
 
 // --- Essentia Provider
@@ -153,21 +142,6 @@ mods.thaumcraft.Infusion.addRecipe("thaumicenergistics.TEESSPROV", <appliedenerg
 // -
 mods.thaumcraft.Research.setAspects("thaumicenergistics.TEESSPROV", "sensus 21, praecantatio 18, lucrum 15, metallum 12, ordo 9, potentia 6, machina 3");
 mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEESSPROV", 3);
-
-// --- Iron Gear
-mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEIRONGEARBOX", <thaumicenergistics:material:2>, "terra 10, ignis 5, ordo 5", [
-[<ore:stickIron>, <ore:plateIron>, <ore:stickIron>],
-[<ore:plateIron>, <ore:gearWood>, <ore:plateIron>],
-[<ore:stickIron>, <ore:plateIron>, <ore:stickIron>]]);
-
-// --- Iron Gear Box
-mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEIRONGEARBOX", <thaumicenergistics:thaumicenergistics.block.gear.box>, "aer 15, ignis 15, ordo 15", [
-[<Thaumcraft:blockCosmeticSolid:6>, <ore:gearIron>, <Thaumcraft:blockCosmeticSolid:6>],
-[<ore:gearIron>, <gregtech:gt.metaitem.01:32601>, <ore:gearIron>],
-[<Thaumcraft:blockCosmeticSolid:6>, <ore:gearIron>, <Thaumcraft:blockCosmeticSolid:6>]]);
-// -
-mods.thaumcraft.Research.setAspects("thaumicenergistics.TEIRONGEARBOX", "terra 15, metallum 12, machina 9, permutatio 6, metallum 3");
-mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEIRONGEARBOX", 3);
 
 // --- Arcane Crafting Terminal
 mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEARCANETERM", <thaumicenergistics:part.base:5>, "aqua 25, ignis 25, aer 25, terra 25, ordo 25, perditio 25", [
@@ -238,31 +212,22 @@ mods.thaumcraft.Research.addArcanePage("thaumicenergistics.TEESSTERM", <thaumice
 mods.thaumcraft.Research.setAspects("thaumicenergistics.TEESSTERM", "praecantatio 15, permutatio 12, sensus 9, potentia 6, aqua 3");
 mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEESSTERM", 3);
 
-// --- Vibration Chamber
-mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEESSVIBCMBR", <thaumicenergistics:thaumicenergistics.block.essentia.vibration.chamber>, "ignis 35, ordo 35, perditio 35, aqua 35", [
-[<ore:plateInfusedOrder>, <thaumicenergistics:part.base:4>, <ore:plateInfusedOrder>],
-[<thaumicenergistics:material>, <extracells:vibrantchamberfluid>, <thaumicenergistics:material>],
-[<ore:plateInfusedEntropy>, <Thaumcraft:blockJar>, <ore:plateInfusedEntropy>]]);
-// -
-mods.thaumcraft.Research.setAspects("thaumicenergistics.TEESSVIBCMBR", "vitreus 18, machina 15, potentia 12, praecantatio 9, motus 6, aqua 3");
-mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEESSVIBCMBR", 3);
-
 // --- Essentia Import Bus
 mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEIO", <thaumicenergistics:part.base>, "ordo 15, aqua 15, ignis 15, terra 15", [
 [<Thaumcraft:blockCosmeticOpaque:2>, <thaumicenergistics:material>, <Thaumcraft:blockCosmeticOpaque:2>],
-[<ore:plateInfusedOrder>, <extracells:part.base:1>, <ore:plateInfusedOrder>],
+[<ore:plateInfusedOrder>, <appliedenergistics2:item.ItemMultiPart:240>, <ore:plateInfusedOrder>],
 [<Thaumcraft:blockJar>, <Thaumcraft:blockTube:3>, <Thaumcraft:blockJar>]]);
 
 // --- Essentia Export Bus
 mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEIO", <thaumicenergistics:part.base:3>, "ordo 15, aqua 15, ignis 15, terra 15", [
 [<Thaumcraft:blockJar>, <Thaumcraft:blockTube:3>, <Thaumcraft:blockJar>],
-[<ore:plateInfusedOrder>, <extracells:part.base>, <ore:plateInfusedOrder>],
+[<ore:plateInfusedOrder>, <appliedenergistics2:item.ItemMultiPart:260>, <ore:plateInfusedOrder>],
 [<Thaumcraft:blockCosmeticOpaque:2>, <thaumicenergistics:material:1>, <Thaumcraft:blockCosmeticOpaque:2>]]);
 
 // --- Essentia Storage Bus
 mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEIO", <thaumicenergistics:part.base:2>, "ordo 20, aqua 20, ignis 20, terra 20", [
 [<Thaumcraft:blockJar>, <ore:plateInfusedWater>, <Thaumcraft:blockJar>],
-[<thaumicenergistics:material>, <extracells:part.base:2>, <thaumicenergistics:material:1>],
+[<thaumicenergistics:material>, <appliedenergistics2:item.ItemMultiPart:220>, <thaumicenergistics:material:1>],
 [<Thaumcraft:blockTube:3>, <ore:plateInfusedWater>, <Thaumcraft:blockTube:3>]]);
 // -
 mods.thaumcraft.Research.setAspects("thaumicenergistics.TEIO", "motus 18, machina 15, metallum 12, vitreus 9, aer 6, aqua 3");
@@ -391,18 +356,12 @@ mods.thaumcraft.Research.setComplexity("thaumicenergistics.TESTORAGE", 3);
 
 // --- Vis Relay Interface
 mods.thaumcraft.Arcane.addShaped("thaumicenergistics.TEVISINT", <thaumicenergistics:part.base:6>, "ordo 20, terra 20, ignis 20, aqua 20, perditio 20, aer 20", [
-[<Thaumcraft:blockCrystal:6>, <extracells:part.base:9>, <Thaumcraft:blockCrystal:6>],
+[<Thaumcraft:blockCrystal:6>, <appliedenergistics2:item.ItemMultiPart:440>, <Thaumcraft:blockCrystal:6>],
 [<ore:screwInfusedEarth>, <appliedenergistics2:item.ItemMultiPart:460>, <ore:screwInfusedEarth>],
 [<ore:plateInfusedOrder>, <ore:plateInfusedOrder>, <ore:plateInfusedOrder>]]);
 // -
 mods.thaumcraft.Research.setAspects("thaumicenergistics.TEVISINT", "vacuos 21, potentia 18, auram 15, metallum 12, cognitio 9, machina 6, aqua 3");
 mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEVISINT", 3);
-
-// --- Thaumic Gear Box
-mods.thaumcraft.Crucible.addRecipe("thaumicenergistics.TETHAUMGBOX", <thaumicenergistics:thaumicenergistics.block.golem.gear.box>, <thaumicenergistics:thaumicenergistics.block.gear.box>, "metallum 32, praecantatio 32");
-// -
-mods.thaumcraft.Research.setAspects("thaumicenergistics.TETHAUMGBOX", "terra 15, machina 12, metallum 9, praecantatio 6, permutatio 3");
-mods.thaumcraft.Research.setComplexity("thaumicenergistics.TETHAUMGBOX", 3);
 
 // --- Arcane Assembler
 mods.thaumcraft.Infusion.addRecipe("thaumicenergistics.TEARCANEASSEMBLER", <extracells:fluidcrafter>, 
@@ -434,7 +393,6 @@ mods.thaumcraft.Infusion.addRecipe("thaumicenergistics.TEINFPROV", <thaumicenerg
 // -
 mods.thaumcraft.Research.setAspects("thaumicenergistics.TEINFPROV", "permutatio 21, motus 18, sensus 15, machina 12, praecantatio 9, alienis 6, spiritus 3");
 mods.thaumcraft.Research.setComplexity("thaumicenergistics.TEINFPROV", 3);
-
 
 
 // --- Research Refresh
@@ -490,3 +448,20 @@ mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEKNOWLEDGEIN
 
 // --- Infusion Provider
 mods.thaumcraft.Research.refreshResearchRecipe("thaumicenergistics.TEINFPROV");
+
+
+
+// --- Hiding Stuff ---
+
+
+// --- Essentia vibration chamber
+NEI.hide(<thaumicenergistics:thaumicenergistics.block.essentia.vibration.chamber>);
+
+// --- Iron gear
+NEI.hide(<thaumicenergistics:material:2>);
+
+// --- Iron gearbox
+NEI.hide(<thaumicenergistics:thaumicenergistics.block.gear.box>);
+
+// --- Thaumium gearbox
+NEI.hide(<thaumicenergistics:thaumicenergistics.block.golem.gear.box>);


### PR DESCRIPTION
Vibration chambers are useless, so removed. Grinder was removed already, so removed the related gear items.

Otherwise, see #7927.

Quests need to be adjusted after.