### PR TITLE
Disable shared itemstack tooltip

### DIFF
--- a/config/bartworks.cfg
+++ b/config/bartworks.cfg
@@ -405,6 +405,9 @@ singleblocks {
 ##########################################################################################################
 
 system {
+    # If you wish to enable "Shared Item Stack" tooltips
+    B:BartWorksSharedItemStackToolTips=false
+    
     # If you wish to enable extra tooltips
     B:BartWorksToolTips=true
 


### PR DESCRIPTION
Updated bartworks config with lost from dev version option and disabled shared itemstack tooltip