### PR TITLE
Removed Tooltips on Adv Backpacks

### DIFF
--- a/scripts/Advanced-Backpacks.zs
+++ b/scripts/Advanced-Backpacks.zs
@@ -288,9 +288,4 @@ mods.gregtech.Brewery.addRecipe(<liquid:melonjuice> * 750, <minecraft:melon>, <l
 
 
 
-// --- Tooltips ---
-
-
-
-
-<Backpack:backpack:*>.addTooltip(format.red("Idiots! Do not upgrade your backpack with important stuff inside - Dream 2017!"));
+// --- Tooltips --- 


### PR DESCRIPTION
Since this is supposedly fixed by #7137 and #7299.

Should fix #8189.