### PR TITLE
Update stale bot configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         operations-per-run: 50
         stale-issue-label: 'Status: stale'
         any-of-labels: "Server: Delta,Server: EU Live Server,Server: Epsilon,Server: Eta,Server: Prospercraft,Server: Zeta,Status: NO,Status: Need new Idea,Status: Open for discussion,Status: RFC (request for comment),Status: Waiting for Feedback,Status: mod remove,Status: need to be tested,Status: report it at original Repo,Type: Idea,Type: Info,Type: Need more Info,Type: Nerf,Type: New Quests,Type: New Tooltip,Type: New recipe,Type: Not a Bug,Type: Won't change,Type: addition,Type: additional Mod,Type: balancing,Type: config,Type: duplicate,Type: enhancement,Type: invalid,Type: not our fault,Type: question,Type: refactor,Type: script changes,Type: silly suggestion,Type: suggestion"
-        exempt-issue-labels: 'Priority: CRITICAL,Priority: HIGH,Status: CodeComplete,Status: FixedInDev,Status: accepted,Status: work in progress,Status: waiting for fix,Type: bugMajor,Type: bugMinor,Type: exploit,Type: reminder,Type: urgent'
+        exempt-issue-labels: 'Priority: CRITICAL,Priority: HIGH,Status: CodeComplete,Status: FixedInDev,Status: accepted,Status: work in progress,Status: waiting for fix,Type: bugMajor,Type: bugMinor,Type: exploit,Type: reminder,Type: urgent,Type: Crash'
         ascending: true
     - uses: actions/stale@v3
       with:
@@ -28,5 +28,14 @@ jobs:
         operations-per-run: 50
         stale-issue-label: 'Status: stale'
         any-of-labels: "Status: can't fix,Status: can't reproduce,Status: Nothing i can do here"
-        exempt-issue-labels: 'Type: reminder'
+        exempt-issue-labels: 'Type: reminder,Type: Crash'
+        ascending: true
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been FixedInDev for quite a while and nobody commented in 7 days. Remove FixedInDev label or comment or this will be closed in 1 days'
+        days-before-stale: 7
+        days-before-close: 1
+        operations-per-run: 50
+        stale-issue-label: 'Status: FixedInDev'
         ascending: true


### PR DESCRIPTION
* Prevent crash reports from being closed
* Automatically close FixedInDev in case someone forgot