### PR TITLE
Disables Witch of the Wind / Set Spawn Chance to 0

### DIFF
--- a/config/SpecialMobs.cfg
+++ b/config/SpecialMobs.cfg
@@ -458,7 +458,7 @@ witch_rates {
     I:shadows=1
     I:undead=1
     I:wilds=1
-    I:wind=1
+    I:wind=0
 }
 
 


### PR DESCRIPTION
Disables them until they can be reworked. Otherwise, they are complete bullshit that has no legitimate counter-play.