### PR TITLE
Fix adding label

### DIFF
--- a/.github/ISSUE_TEMPLATE/004-suggest-a-new-mod.yml
+++ b/.github/ISSUE_TEMPLATE/004-suggest-a-new-mod.yml
@@ -2,7 +2,7 @@ name: Suggest a New Mod
 description: Suggest the addition of a new mod.
 labels:
 - "Status: Triage"
-- "Type: additional mods"
+- "Type: Mod Addition"
 body:
 - type: input
   id: discord


### PR DESCRIPTION
PS: I renamed the label itself to be more grammatically correct first too.

Also, there was no triage label, so those weren't being added, so I created that one too.