### PR TITLE
Update Thaumcraft-02-Thaumaturgy-1.zs

### DIFF
--- a/scripts/Thaumcraft-02-Thaumaturgy-1.zs
+++ b/scripts/Thaumcraft-02-Thaumaturgy-1.zs
@@ -217,9 +217,9 @@ mods.thaumcraft.Research.addArcanePage("CAP_silver", <Thaumcraft:WandCasting:4>.
 mods.thaumcraft.Research.clearPages("CAP_thaumium");
 mods.thaumcraft.Research.addPage("CAP_thaumium", "tc.research_page.CAP_thaumium.1");
 mods.thaumcraft.Arcane.addShaped("CAP_thaumium", <Thaumcraft:WandCap:6>, "ordo 30, ignis 30, aer 30", [
-[<ore:screwTitanium>, <ore:foilThaumium>, <ore:screwTitanium>],
+[<ore:screwKnightmetal>, <ore:foilThaumium>, <ore:screwKnightmetal>],
 [<ore:foilThaumium>, <ore:ringThaumium>, <ore:foilThaumium>],
-[<ore:screwTitanium>, <ore:foilThaumium>, <ore:screwTitanium>]]);
+[<ore:screwKnightmetal>, <ore:foilThaumium>, <ore:screwKnightmetal>]]);
 // -
 mods.thaumcraft.Research.addArcanePage("CAP_thaumium", <Thaumcraft:WandCap:6>);
 


### PR DESCRIPTION
Retiers Thaumium Wand Caps from Titanium (EV) to Knight Metal, a magical metal/steel that requires the player to travel far deeper within the Twilight Forest to obtain.