### PR TITLE
Fix recipes consuming circuits, and use oredict properly

### DIFF
--- a/scripts/Project_Red.zs
+++ b/scripts/Project_Red.zs
@@ -1621,175 +1621,52 @@ Mixer.addRecipe(<ProjRed|Core:projectred.core.part:58>, [<gregtech:gt.metaitem.0
 Mixer.addRecipe(<ProjRed|Core:projectred.core.part:57>, [<minecraft:iron_ingot>, <ProjRed|Core:projectred.core.part:56> * 8], 400, 30);
 
 // --- White Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:15> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <BiomesOPlenty:misc:8> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:23> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:77> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32429> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:19> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeWhite> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Orange Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:20> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:14> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:20> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32428> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:20> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:1> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:20> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:51> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:20> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeOrange> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Magenta Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:21> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:13> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:21> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:40> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:21> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:2> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:21> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32427> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:21> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeMagenta> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Light Blue Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:22> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:12> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:22> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:22> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:22> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:3> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:22> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32426> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:22> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeLightBlue> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Yellow Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:11> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:20> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:78> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:4> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32425> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:23> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeYellow> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Lime Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:24> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:10> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:24> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:38> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:24> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:5> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:24> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32424> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:24> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeLime> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Pink Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:25> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:9> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:25> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:29> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:25> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:6> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:25> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32423> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:25> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyePink> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Grey Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:26> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:8> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:26> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:10> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:26> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32422> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:26> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:7> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:26> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeGray> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Light Grey Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:27> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:7> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:27> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:8> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:27> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32421> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:27> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:35> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:27> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeLightGray> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Cyan Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:28> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:6> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:28> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:8> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:28> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32420> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:28> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:9> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:28> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeCyan> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Purple Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:29> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:5> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:29> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:20> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:29> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:10> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:29> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32419> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:29> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyePurple> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Blue Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:4> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <BiomesOPlenty:misc:5> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:21> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:24> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:11> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32418> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32410> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:30> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeBlue> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Brown Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <BiomesOPlenty:misc:6> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:25> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:3> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:65> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32417> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:12> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:31> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeBrown> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Green Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:2> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <BiomesOPlenty:misc:7> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:22> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:28> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:13> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32416> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:32> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeGreen> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Red Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye:1> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:19> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:59> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:14> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32415> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:33> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeRed> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 // --- Black Iluminator
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <minecraft:dye> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <BiomesOPlenty:misc:9> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <ExtraBees:misc:24> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <Botany:pigment:1> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <ProjRed|Exploration:projectred.exploration.lilyseed:15> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
-// -
-Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <gregtech:gt.metaitem.02:32414> * 2, <gregtech:gt.integrated_circuit:8>], 50, 8);
+Mixer.addRecipe(<ProjRed|Core:projectred.core.part:34> * 8, [<minecraft:glowstone_dust> * 2, <ore:dyeBlack> * 2, <gregtech:gt.integrated_circuit:8> * 0], 50, 8);
 
 
 


### PR DESCRIPTION
Should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8568 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8559

Dream, you forgot to add the * 0 part. Also, why didn't you use oredict on the dyes, it's way less work?