### PR TITLE
Adding EV Conveyor Rubber plate recipe

### DIFF
--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -803,7 +803,7 @@ Assembler.addRecipe(<gregtech:gt.neutronreflector>, <dreamcraft:item.NeutronRefl
 Assembler.addRecipe(<IC2:itemRTGPellet>, <gregtech:gt.metaitem.01:22032> * 6, <IC2:itemPlutonium> * 3, <liquid:ic2coolant> * 1000, 1200, 120);
 
 // --- EV Conveyor
-Assembler.addRecipe(<gregtech:gt.metaitem.01:32633>, [<gregtech:gt.metaitem.01:32603> * 2, <gregtech:gt.metaitem.01:17880> * 6, <gregtech:gt.blockmachines:1586>], null, 1000, 240);
+Assembler.addRecipe(<gregtech:gt.metaitem.01:32633>, [<gregtech:gt.metaitem.01:32603> * 2, <gregtech:gt.metaitem.01:17880> * 6, <gregtech:gt.blockmachines:1586>], null, 200, 240);
 
 
 

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -802,6 +802,10 @@ Assembler.addRecipe(<gregtech:gt.neutronreflector>, <dreamcraft:item.NeutronRefl
 // --- RTG Pellets
 Assembler.addRecipe(<IC2:itemRTGPellet>, <gregtech:gt.metaitem.01:22032> * 6, <IC2:itemPlutonium> * 3, <liquid:ic2coolant> * 1000, 1200, 120);
 
+// --- EV Conveyor
+Assembler.addRecipe(<gregtech:gt.metaitem.01:32633>, [<gregtech:gt.metaitem.01:32603> * 2, <gregtech:gt.metaitem.01:17880> * 6, <gregtech:gt.blockmachines:1586>], null, 1000, 240);
+
+
 
 
 // --- Alloy Smelter Recipes ---


### PR DESCRIPTION
Added EV Conveyor Rubber recipe to Assembler which is craftable in the HV Version, since can be handcrafted as described in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8803

Big thank you to @D-Cysteine for helping me.

Co-Authored-By: D-Cysteine <54219287+D-Cysteine@users.noreply.github.com>