### PR TITLE
Fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/002-suggest-a-change.yml
+++ b/.github/ISSUE_TEMPLATE/002-suggest-a-change.yml
@@ -2,7 +2,7 @@ name: Suggest a Change
 description: Suggest a change to an existing feature.
 labels:
 - "Status: Triage"
-- "Type: suggestion"
+- "Type: Suggestion"
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/003-request-new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/003-request-new-feature.yml
@@ -1,8 +1,8 @@
 name: 'Request New Feature'
 description: Request a new feature.
 labels: 
-- "Type: suggestion"
 - "Status: Triage"
+- "Type: Suggestion"
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
Someone renamed `Type: suggestion` to `Type: Suggestion` and accidentally broke the issue templates. It does look better though, so let's keep it. This PR will fix the issue template.