### PR TITLE
Update RIO.cfg

### DIFF
--- a/config/RIO.cfg
+++ b/config/RIO.cfg
@@ -2,7 +2,7 @@
 
 optout {
     # Opt-out of localization updates, and only use lang files packaged with the JAR
-    B:localization_update=false
+    B:localization_update=true
 }
 
 


### PR DESCRIPTION
Stop pointless check which throws an error anyway.

```
706]  [19:19:08] [Client thread/INFO]: Resource manager reload, new language: en_US
[B#706]  [19:19:08] [Client thread/ERROR]: Unable to access any field [languageList, field_74816_c, d] on type net.minecraft.util.StringTranslate
[B#706]  cpw.mods.fml.relauncher.ReflectionHelper$UnableToAccessFieldException: java.lang.NullPointerException
[B#706]  	at cpw.mods.fml.relauncher.ReflectionHelper.getPrivateValue(ReflectionHelper.java:121) ~[modpack.jar:?]
[B#706]  	at cpw.mods.fml.common.ObfuscationReflectionHelper.getPrivateValue(ObfuscationReflectionHelper.java:60) [ObfuscationReflectionHelper.class:?]
[B#706]  	at remoteio.common.core.handler.LocalizationUpdater$StringTranslateDelegate.inject(LocalizationUpdater.java:136) [LocalizationUpdater$StringTranslateDelegate.class:?]
[B#706]  	at remoteio.common.core.handler.LocalizationUpdater.loadLangFiles(LocalizationUpdater.java:109) [LocalizationUpdater.class:?]
[B#706]  	at remoteio.common.core.handler.LocalizationUpdater.access$500(LocalizationUpdater.java:28) [LocalizationUpdater.class:?]
[B#706]  	at remoteio.common.core.handler.LocalizationUpdater$2.func_110549_a(LocalizationUpdater.java:99) [LocalizationUpdater$2.class:?]
[B#706]  	at net.minecraft.client.resources.SimpleReloadableResourceManager.func_110544_b(SimpleReloadableResourceManager.java:143) [brg.class:?]
[B#706]  	at net.minecraft.client.resources.SimpleReloadableResourceManager.func_110541_a(SimpleReloadableResourceManager.java:121) [brg.class:?]
[B#706]  	at net.minecraft.client.Minecraft.func_110436_a(Minecraft.java:609) [bao.class:?]
[B#706]  	at cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:327) [FMLClientHandler.class:?]
[B#706]  	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552) [bao.class:?]
[B#706]  	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878) [bao.class:?]
[B#706]  	at net.minecraft.client.main.Main.main(SourceFile:148) [Main.class:?]
[B#706]  	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_242]
[B#706]  	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_242]
[B#706]  	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_242]
[B#706]  	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_242]
[B#706]  	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
[B#706]  	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
[B#706]  Caused by: java.lang.NullPointerException
[B#706]  	at sun.reflect.UnsafeFieldAccessorImpl.ensureObj(UnsafeFieldAccessorImpl.java:57) ~[?:1.8.0_242]
[B#706]  	at sun.reflect.UnsafeQualifiedObjectFieldAccessorImpl.get(UnsafeQualifiedObjectFieldAccessorImpl.java:38) ~[?:1.8.0_242]
[B#706]  	at java.lang.reflect.Field.get(Field.java:393) ~[?:1.8.0_242]
[B#706]  	at cpw.mods.fml.relauncher.ReflectionHelper.getPrivateValue(ReflectionHelper.java:117) ~[modpack.jar:?]
[B#706]  	... 18 more
```