### PR TITLE
already removed in code

### DIFF
--- a/scripts/Railcraft.zs
+++ b/scripts/Railcraft.zs
@@ -557,9 +557,6 @@ mods.railcraft.BlastFurnace.removeRecipe(<Railcraft:ingot>);
 // --- Steel Block
 mods.railcraft.BlastFurnace.removeRecipe(<Railcraft:cube:2>);
 
-// --- Steel Nuggets
-mods.railcraft.BlastFurnace.removeRecipe(<Railcraft:nugget:1>);
-
 // --- Meteoric Iron
 mods.railcraft.BlastFurnace.removeRecipe(<gregtech:gt.metaitem.01:11340>);
 


### PR DESCRIPTION
<img width="630" alt="image" src="https://user-images.githubusercontent.com/533931/145735981-f09c8591-3707-4afc-8ecc-7aad3da61b4c.png">

It was removed from Railcraft and so not needed to be removed here (currently throws that message on 2.1.2.0)