### PR TITLE
Enabled adventure backpack tank tooltip

### DIFF
--- a/config/adventurebackpack.cfg
+++ b/config/adventurebackpack.cfg
@@ -46,8 +46,8 @@ graphics {
     # Enable rendering for tools in the backpack tool slots [default: true]
     B:"Enable Tools Render"=true
 
-    # Show hovering text on fluid tanks? [default: false]
-    B:"Hovering Text"=false
+    # Show hovering text on fluid tanks? [default: true]
+    B:"Hovering Text"=true
 
     # 1,2 or 3 for different rendering of fluids in the Backpack GUI [range: 1 ~ 3, default: 3]
     I:"Tank Render Type"=3


### PR DESCRIPTION
As required to enable the tooltip fixed in https://github.com/GTNewHorizons/AdventureBackpack2/pull/4.