### PR TITLE
flat bedrock on new chunks

### DIFF
--- a/config/cofh/core/common.cfg
+++ b/config/cofh/core/common.cfg
@@ -43,7 +43,7 @@ Version {
 
 World {
     # This will flatten the bedrock layer.
-    B:FlatBedrock=false
+    B:FlatBedrock=true
 
     # The number of layers of bedrock to flatten to. (Max: 8)
     I:FlatBedrockLayers=1
@@ -63,5 +63,4 @@ World {
     }
 
 }
-
 


### PR DESCRIPTION
We can have flat bedrock and it would be a nice QoL.

Retroactive flattening bedrock is not on because of the performance hit; that would better be done on a "once scan" perhaps.