### PR TITLE
(Self-)Sacrificing is less tedious overall

### DIFF
--- a/config/AWWayofTime.cfg
+++ b/config/AWWayofTime.cfg
@@ -441,12 +441,12 @@ orecrushing {
 
 
 sacrifice {
-    D:"LP per (self-)sacrifice with incense"=50.0
-    I:"LP per sacrifice"=400
-    I:"LP per sacrifice with Well of Suffering ritual"=10
-    I:"LP per self-sacrifice"=100
+    D:"LP per (self-)sacrifice with incense"=150.0
+    I:"LP per sacrifice"=600
+    I:"LP per sacrifice with Well of Suffering ritual"=25
+    I:"LP per self-sacrifice"=125
     I:"LP per self-sacrifice (when Soul Fray potion is active)"=1
-    I:"LP per self-sacrifice with Ritual of Feathered Knife"=100
+    I:"LP per self-sacrifice with Ritual of Feathered Knife"=125
 
     "custom values" {
         I:AWWayofTime.AirElemental=250


### PR DESCRIPTION
Incense sacrificing increased from 50 to 150 (this is a very oddball way of getting LP and is a "charged" means instead of spamming).
LP per sacrifice increased from 400 to 600.
WoS amount on "hit" per mob increased from 10 to 25. This apparently matches the later Minecraft versions of BM.
Self-sacrifice increased from 100 to 125.
Ritual of Feathered Knife increased from 100 to 125; it's basically automated & safe self-sacrificing for LP gain.

I also forgot to name the patch before accidentally hitting enter, whoops!