### PR TITLE
Botania + Forbidden Magic exploit fixes

### DIFF
--- a/scripts/Forbidden-Magic-01-Wands.zs
+++ b/scripts/Forbidden-Magic-01-Wands.zs
@@ -6,22 +6,20 @@ import mods.thaumcraft.Research;
 
 // --- Vars ---
 val capThauminite = <thaumicbases:resource:2>;
-val capMana = <ForbiddenMagic:WandCaps:3>; 
+val capMana = <ForbiddenMagic:WandCaps:3>;
+val capManaInert = <ForbiddenMagic:WandCaps:4>;
 val capTerra = <ForbiddenMagic:WandCaps:2>; // awesome vis discount!
 val capVinteum = <ForbiddenMagic:WandCaps:1>;
-val capElementium = <ForbiddenMagic:WandCaps:5>; 
+val capElementium = <ForbiddenMagic:WandCaps:5>;
+val capElementiumInert = <ForbiddenMagic:WandCaps:6>;
 val primalCharm = <Thaumcraft:ItemResource:15>;
 
-// --- Adding Research ---
-
-
+// --- Remove Research to avoid slot conflicts ---
+mods.thaumcraft.Research.clearPages("CAP_manasteel");
+mods.thaumcraft.Research.clearPages("CAP_terrasteel");
+mods.thaumcraft.Research.clearPages("CAP_elementium");
 
 // --- Arcane Recipes ---
-Arcane.addShaped("CAP_elementium", <ForbiddenMagic:WandCaps:6>, "aer 60, terra 60, ignis 60, aqua 60, ordo 60, perditio 60", [
-[<ore:screwTungstenSteel>,<ore:plateInfusedAir>, <ore:screwTungstenSteel>],
-[<ore:plateInfusedWater>, capMana, <ore:plateInfusedFire>],
-[<ore:screwTungstenSteel>, <ore:plateInfusedEarth>,<ore:screwTungstenSteel>]]);
-
 Arcane.addShaped("CAP_vinteum", capVinteum, "aer 40, terra 40, ignis 40, aqua 40, ordo 40, perditio 40", [
 [<ore:screwTitanium>,<ore:foilVinteum>, <ore:screwTitanium>],
 [<ore:foilVinteum>, <ore:ringVinteum>, <ore:foilVinteum>],
@@ -31,11 +29,6 @@ Arcane.addShaped("ROD_witchwood_staff", <ForbiddenMagic:WandCores:10>, "aer 125,
 [<Thaumcraft:blockCrystal:0>,<Thaumcraft:blockCrystal:1>, primalCharm],
 [<Thaumcraft:blockCrystal:2>, <ForbiddenMagic:WandCores:4>, <Thaumcraft:blockCrystal:3>],
 [<ForbiddenMagic:WandCores:4>, <Thaumcraft:blockCrystal:4>,<Thaumcraft:blockCrystal:5>]]);
-
-Arcane.addShaped("ROD_dreamwood_staff", <ForbiddenMagic:WandCores:13>, "aer 125, terra 125, ignis 125, aqua 125, ordo 125, perditio 125", [
-[<Thaumcraft:blockCrystal:0>,<Thaumcraft:blockCrystal:1>, primalCharm],
-[<Thaumcraft:blockCrystal:2>, <ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:3>],
-[<ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:4>,<Thaumcraft:blockCrystal:5>]]);
 
 Arcane.addShaped("ROD_witchwood_staff", <ForbiddenMagic:WandCaps:10>, "aer 40, terra 40, ignis 40, aqua 40, ordo 40, perditio 40", [
 [<ore:screwTitanium>,<ore:foilVinteum>, <ore:screwTitanium>],
@@ -47,31 +40,10 @@ mods.thaumcraft.Crucible.addRecipe("VINTEUM", <gregtech:gt.metaitem.01:9529>, <g
 
 // --- Infusion Recipes ---
 
-//Livingwood Wand Core
-mods.thaumcraft.Infusion.addRecipe("ROD_livingwood", <Thaumcraft:WandRod:0>,
-[<AWWayofTime:bucketLife>,<TConstruct:materials:6>,<Thaumcraft:blockMagicalLog:0>,<AWWayofTime:bucketLife>,<TConstruct:materials:6>,<Thaumcraft:blockMagicalLog:0>,<AWWayofTime:bucketLife>,<TConstruct:materials:6>,<Thaumcraft:blockMagicalLog:0>],
- "victus 64, herba 32, arbor 32, praecantatio 24, instrumentum 24", <ForbiddenMagic:WandCores:7>, 6);
- 
-//Dreamwood Wand Core 
-mods.thaumcraft.Infusion.addRecipe("ROD_dreamwood", <ForbiddenMagic:WandCores:7>,
- [<Thaumcraft:blockMagicalLog:1>,<EnderIO:itemMaterial:5>,<EnderIO:itemMaterial:6>,<Thaumcraft:blockMagicalLog:1>,<EnderIO:itemMaterial:5>,<EnderIO:itemMaterial:6>],
- "auram 64, praecantatio 48, tempestas 32, instrumentum 24, lux 24", <ForbiddenMagic:WandCores:11>, 7);
- 
 // Witchwood Wand Core 
 mods.thaumcraft.Infusion.addRecipe("ROD_witchwood", <witchery:ingredient:82>,
  [<gregtech:gt.metaitem.01:8529>,<witchery:witchsapling:0>,<witchery:ingredient:34>,<witchery:witchsapling:1>,<witchery:ingredient:36>,<witchery:witchsapling:2>,<gregtech:gt.metaitem.01:8529>,<witchery:witchsapling:0>,<witchery:ingredient:34>,<witchery:witchsapling:1>,<witchery:ingredient:36>,<witchery:witchsapling:2>],
  "arbor 64, praecantatio 48, herba 32, instrumentum 24,vacuos 24", <ForbiddenMagic:WandCores:4>, 6);
-//Manasteel Wand Cap
-mods.thaumcraft.Infusion.addRecipe("CAP_manasteel", <Thaumcraft:WandCap:4>, [<gregtech:gt.metaitem.01:2333>,<ProjRed|Core:projectred.core.part:56>,<gregtech:gt.metaitem.01:2333>,<ProjRed|Core:projectred.core.part:56>,<gregtech:gt.metaitem.01:2333>,<ProjRed|Core:projectred.core.part:56>,<gregtech:gt.metaitem.01:2333>,<ProjRed|Core:projectred.core.part:56>,<gregtech:gt.metaitem.01:2333>,<ProjRed|Core:projectred.core.part:56>],
- "potentia 64, praecantatio 48, electrum 32, instrumentum 24, machina 24", capMana, 6);
-//Terrasteel Wand Cap
-mods.thaumcraft.Infusion.addRecipe("CAP_terrasteel", capMana, [<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.01:17339>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.01:17339>,<Thaumcraft:blockCrystal:3>],
- "praecantatio 256, ordo 64, metallum 64, superbia 20, strontio 10", capTerra, 6);
-//Elementium Wand Cap
-mods.thaumcraft.Infusion.addRecipe("CAP_elementium", <ForbiddenMagic:WandCaps:6>,
-[<Thaumcraft:blockCrystal:6>,<Thaumcraft:ItemResource:14>,<Thaumcraft:blockCrystal:0>,<Thaumcraft:ItemResource:14>,<Thaumcraft:blockCrystal:1>,<Thaumcraft:ItemResource:14>,<Thaumcraft:blockCrystal:6>,<Thaumcraft:ItemResource:14>,<Thaumcraft:blockCrystal:2>,<Thaumcraft:ItemResource:14>,<Thaumcraft:blockCrystal:3>,<Thaumcraft:ItemResource:14>],
- "ignis 32, aqua 32 , aer 32, terra 32, ordo 32 , perditio 32, praecantatio 32, potentia 24", capElementium, 7);
-
 
 // Journey
 mods.thaumcraft.Research.addResearch("JOURNEY", "FORBIDDEN", "iter 5, praecantatio 10, instrumentum 3", -3 as int, 1, 8, <BiomesOPlenty:food:7>);
@@ -99,37 +71,53 @@ mods.thaumcraft.Research.addPrereq("ROD_livingwood", "ROD_greatwood", false);
 mods.thaumcraft.Warp.addToResearch("ROD_livingwood",2);
 
 // Dreamwood Wand Rod
-mods.thaumcraft.Research.addResearch("ROD_dreamwood", "FORBIDDEN", "auram 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", 1, 4, 8, <ForbiddenMagic:WandCores:11>);
-game.setLocalization("en_US", "tc.research_name.ROD_dreamwood", "Dreamwood Rod");
-game.setLocalization("en_US", "tc.research_text.ROD_dreamwood", "[FM] Sweet dreams are made of these");
-mods.thaumcraft.Research.addPage("ROD_dreamwood", "derp.research_page.ROD_dreamwood");
-game.setLocalization("en_US", "derp.research_page.ROD_dreamwood", "Livingwood is quite useful, but it can't be turned into a staff, it's just to unstable. You heard about dreamwood, which is quite stable, but requires elven magic and you have no idea where you can get an elve from. Maybe it is possible to just stabalize your livingwood rod with some magical crystals and a bit of Silverwood. The thaumonomicon told you that this has to be done in the elven world, but you simply tried to use more auram, which seemed to work aswell. <BR> You new rod now holds exact the same amount of vis than the old one, but it can be turnd into a staff and looks much more stylish.");
-mods.thaumcraft.Research.addInfusionPage("ROD_dreamwood",<ForbiddenMagic:WandCores:11>);
-mods.thaumcraft.Research.setConcealed("ROD_dreamwood", true);
-mods.thaumcraft.Research.addPrereq("ROD_dreamwood", "ROD_livingwood", false);
-mods.thaumcraft.Research.addPrereq("ROD_dreamwood", "ROD_silverwood", false);
+mods.thaumcraft.Research.orphanResearch("ROD_dreamwood");
+mods.thaumcraft.Research.removeResearch("ROD_dreamwood");
+mods.thaumcraft.Research.addResearch("ROD_dreamwood_v2", "FORBIDDEN", "auram 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", 1, 4, 8, <ForbiddenMagic:WandCores:11>);
+
+game.setLocalization("en_US", "tc.research_name.ROD_dreamwood_v2", "Dreamwood Rod");
+game.setLocalization("en_US", "tc.research_text.ROD_dreamwood_v2", "[FM] Sweet dreams are made of these");
+mods.thaumcraft.Research.addPage("ROD_dreamwood_v2", "derp.research_page.ROD_dreamwood_v2");
+game.setLocalization("en_US", "derp.research_page.ROD_dreamwood_v2", "Livingwood is quite useful, but it can't be turned into a staff, it's just to unstable. You heard about dreamwood, which is quite stable, but requires elven magic and you have no idea where you can get an elve from. Maybe it is possible to just stabalize your livingwood rod with some magical crystals and a bit of Silverwood. The thaumonomicon told you that this has to be done in the elven world, but you simply tried to use more auram, which seemed to work aswell. <BR> You new rod now holds exact the same amount of vis than the old one, but it can be turnd into a staff and looks much more stylish.");
+mods.thaumcraft.Research.addInfusionPage("ROD_dreamwood_v2",<ForbiddenMagic:WandCores:12>);
+mods.thaumcraft.Research.setConcealed("ROD_dreamwood_v2", true);
+mods.thaumcraft.Research.addPrereq("ROD_dreamwood_v2", "ROD_livingwood", false);
+mods.thaumcraft.Research.addPrereq("ROD_dreamwood_v2", "ROD_silverwood", false);
 
 
 // Dreamwood Staff Rod
-mods.thaumcraft.Research.addResearch("ROD_dreamwood_staff", "FORBIDDEN", "auram 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", 3, 4, 8, <ForbiddenMagic:WandCores:13>);
-game.setLocalization("en_US", "tc.research_name.ROD_dreamwood_staff", "Dreamwood Staff");
-game.setLocalization("en_US", "tc.research_text.ROD_dreamwood_staff", "[FM] Oh, fantasy free me!");
-mods.thaumcraft.Research.addPage("ROD_dreamwood_staff", "derp.research_page.ROD_dreamwood_staff");
-game.setLocalization("en_US", "derp.research_page.ROD_dreamwood_staff", "You finally are able to build a staff out of dreamwood, just add a primal charm, some crystal clusters and two rods together and you've got you new staff, that holds up to 250 vis of each type.");
-mods.thaumcraft.Research.addPrereq("ROD_dreamwood_staff", "ROD_dreamwood", false);
-mods.thaumcraft.Research.addArcanePage("ROD_dreamwood_staff",<ForbiddenMagic:WandCores:13>);
-mods.thaumcraft.Research.setSpikey("ROD_dreamwood_staff", true);
-mods.thaumcraft.Research.setConcealed("ROD_dreamwood_staff", true);
-mods.thaumcraft.Research.addPrereq("ROD_dreamwood_staff", "ROD_silverwood_staff", false);
-mods.thaumcraft.Warp.addToResearch("ROD_dreamwood_staff",3);
+mods.thaumcraft.Research.orphanResearch("ROD_dreamwood_staff");
+mods.thaumcraft.Research.removeResearch("ROD_dreamwood_staff");
+mods.thaumcraft.Research.addResearch("ROD_dreamwood_staff_v2", "FORBIDDEN", "auram 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", 3, 4, 8, <ForbiddenMagic:WandCores:13>);
+
+mods.thaumcraft.Arcane.removeRecipe(<ForbiddenMagic:WandCores:13>);
+mods.thaumcraft.Arcane.addShaped("ROD_dreamwood_staff_v2", <ForbiddenMagic:WandCores:13>, "aer 125, terra 125, ignis 125, aqua 125, ordo 125, perditio 125", [
+[<Thaumcraft:blockCrystal:0>,<Thaumcraft:blockCrystal:1>, primalCharm],
+[<Thaumcraft:blockCrystal:2>, <ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:3>],
+[<ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:4>,<Thaumcraft:blockCrystal:5>]]);
+
+game.setLocalization("en_US", "tc.research_name.ROD_dreamwood_staff_v2", "Dreamwood Staff");
+game.setLocalization("en_US", "tc.research_text.ROD_dreamwood_staff_v2", "[FM] Oh, fantasy free me!");
+mods.thaumcraft.Research.addPage("ROD_dreamwood_staff_v2", "derp.research_page.ROD_dreamwood_staff_v2");
+game.setLocalization("en_US", "derp.research_page.ROD_dreamwood_staff_v2", "You finally are able to build a staff out of dreamwood, just add a primal charm, some crystal clusters and two rods together and you've got you new staff, that holds up to 250 vis of each type.");
+mods.thaumcraft.Research.addPrereq("ROD_dreamwood_staff_v2", "ROD_dreamwood_v2", false);
+mods.thaumcraft.Research.addArcanePage("ROD_dreamwood_staff_v2",<ForbiddenMagic:WandCores:13>);
+mods.thaumcraft.Research.setSpikey("ROD_dreamwood_staff_v2", true);
+mods.thaumcraft.Research.setConcealed("ROD_dreamwood_staff_v2", true);
+mods.thaumcraft.Research.addPrereq("ROD_dreamwood_staff_v2", "ROD_silverwood_staff", false);
+mods.thaumcraft.Warp.addToResearch("ROD_dreamwood_staff_v2",3);
 
 // Manasteel Wand Caps
 mods.thaumcraft.Research.addResearch("CAP_manasteel", "FORBIDDEN", "metallum 5, praecantatio 10, lucrum 3,instrumentum 4, auram 5", 1, 2, 8, capMana);
+
+mods.thaumcraft.Infusion.addRecipe("CAP_manasteel", <Thaumcraft:WandCap:4>, [<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>],
+ "potentia 64, praecantatio 48, electrum 32, instrumentum 24, machina 24", capManaInert, 6);
+
 game.setLocalization("en_US", "tc.research_name.CAP_manasteel", "Manasteel Caps");
 game.setLocalization("en_US", "tc.research_text.CAP_manasteel", "[FM] The secret of Mana");
 mods.thaumcraft.Research.addPage("CAP_manasteel", "derp.research_page.CAP_manasteel");
 game.setLocalization("en_US", "derp.research_page.CAP_manasteel", "Manasteel is the Botanical equivalent to Thaumium, so it should be possible to create caps out of it, by infusing some silver caps with some electrotine and astral silver you were able to create a cap with the strength of blue alloy and a higher magical conductivity than mundane silver. The vis discount is the same as Thaumium, you think thats the reason why it is call Botanical Thaumium.");
-mods.thaumcraft.Research.addInfusionPage("CAP_manasteel",capMana);
+mods.thaumcraft.Research.addInfusionPage("CAP_manasteel",capManaInert);
 mods.thaumcraft.Research.setConcealed("CAP_manasteel", true);
 mods.thaumcraft.Research.addPrereq("CAP_manasteel", "ROD_livingwood", false);
 mods.thaumcraft.Research.addPrereq("CAP_manasteel", "CAP_silver", false);
@@ -138,6 +126,10 @@ mods.thaumcraft.Warp.addToResearch("CAP_manasteel",2);
 
 // Terrasteel Wand Caps
 mods.thaumcraft.Research.addResearch("CAP_terrasteel", "FORBIDDEN", "terra 5, praecantatio 10, superbia 3,instrumentum 4,strontio 2, vitreus 5", 3, 2, 8, capTerra);
+
+mods.thaumcraft.Infusion.addRecipe("CAP_terrasteel", capMana, [<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.01:17339>,<Botania:manaResource:4>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<Botania:manaResource:4>,<gregtech:gt.metaitem.01:17339>,<Thaumcraft:blockCrystal:3>],
+"praecantatio 256, ordo 64, metallum 64, superbia 20, strontio 10", capTerra, 6);
+
 game.setLocalization("en_US", "tc.research_name.CAP_terrasteel", "Terrasteel Wand Caps");
 game.setLocalization("en_US", "tc.research_text.CAP_terrasteel", "[FM] Completion!");
 mods.thaumcraft.Research.addPage("CAP_terrasteel", "derp.research_page.CAP_terrasteel");
@@ -149,13 +141,20 @@ mods.thaumcraft.Research.addPrereq("CAP_terrasteel", "TRANSEMERALD", true);
 mods.thaumcraft.Warp.addToResearch("CAP_terrasteel",4);
 
 // Elementium Wand Caps
-mods.thaumcraft.Research.addResearch("CAP_elementium", "FORBIDDEN", "auram 5, praecantatio 10, victus 3,instrumentum 4, humanus 5", 3, 1, 8, capElementium);
+mods.thaumcraft.Research.addResearch("CAP_elementium", "FORBIDDEN", "auram 5, praecantatio 10, victus 3,instrumentum 4, humanus 5", 3, 4, 8, capElementium);
+
+mods.thaumcraft.Arcane.removeRecipe(capElementiumInert);
+mods.thaumcraft.Arcane.addShaped("CAP_elementium", capElementiumInert, "terra 40, aqua 40, aer 40", [
+[<ore:screwTungstenSteel>, <ore:ingotElvenElementium>, <ore:screwTungstenSteel>],
+[<ore:ingotElvenElementium>, <ore:elvenPixieDust>, <ore:ingotElvenElementium>],
+[<ore:screwTungstenSteel>, <ore:ingotElvenElementium>, <ore:screwTungstenSteel>]]);
+
 game.setLocalization("en_US", "tc.research_name.CAP_elementium", "Elementium Wand Caps");
 game.setLocalization("en_US", "tc.research_text.CAP_elementium", "[FM] Eco Friendly Wand Caps");
 mods.thaumcraft.Research.addPage("CAP_elementium", "derp.research_page.CAP_elementium");
 game.setLocalization("en_US", "derp.research_page.CAP_elementium", "What would happen if you combine you Manasteel caps with power of elemental shards? Instead of thinking about what could happen, you simply tried it, since the shards seem to resist the cap you decided to use some tungstensteel screws to bind it all together. The result is a metal, that has a higher vis discount than thaumium. Sadly it has to be reinfused, due to it's new non magical components.");
 mods.thaumcraft.Research.addPrereq("CAP_elementium", "CAP_manasteel", false);
-mods.thaumcraft.Research.addArcanePage("CAP_elementium",<ForbiddenMagic:WandCaps:6>);
+mods.thaumcraft.Research.addArcanePage("CAP_elementium",capElementiumInert);
 mods.thaumcraft.Research.addInfusionPage("CAP_elementium",capElementium);
 mods.thaumcraft.Research.setConcealed("CAP_elementium", true);
 
@@ -210,3 +209,17 @@ mods.thaumcraft.Research.addPrereq("ROD_witchwood_staff", "ROD_witchwood", false
 mods.thaumcraft.Research.addPrereq("ROD_witchwood_staff", "ROD_silverwood_staff", false);
 mods.thaumcraft.Warp.addToResearch("ROD_witchwood_staff",4);
 
+// Refreshers
+mods.thaumcraft.Research.refreshResearchRecipe("CAP_manasteel");
+mods.thaumcraft.Research.refreshResearchRecipe("CAP_terrasteel");
+mods.thaumcraft.Research.refreshResearchRecipe("CAP_elementium");
+mods.thaumcraft.Research.refreshResearchRecipe("CAP_elementium_v2");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_livingwood");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_dreamwood");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_dreamwood_v2");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_dreamwood_staff");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_dreamwood_staff_v2");
+mods.thaumcraft.Research.refreshResearchRecipe("VINTEUM");
+mods.thaumcraft.Research.refreshResearchRecipe("CAP_vinteum");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_witchwood");
+mods.thaumcraft.Research.refreshResearchRecipe("ROD_witchwood_staff");


### PR DESCRIPTION
Redoes all the caps and wands derived from Botania:
- Make recipes look more like GT:NH style - to the extent those materials exist
- Put everything back in its appropriate tier
- Remove or replace the previous placeholder recipes that use exclusively non-botania ingredients.

P.S.: Don't merge this before Botania itself is actually added