### PR TITLE
fix stargate recipe

### DIFF
--- a/scripts/SGCraft.zs
+++ b/scripts/SGCraft.zs
@@ -22,10 +22,10 @@ val sgFoil = <dreamcraft:item.StargateShieldingFoil>;
 val sgChevron = <dreamcraft:item.StargateChevron>;
 val sgFrame = <dreamcraft:item.StargateFramePart>;
 val Nanocircuit = <dreamcraft:item.NanoCircuit>;
-val UEVFieldGen = <gregtech:gt.metaitem.01:32679>;
-val UEVPiston = <gregtech:gt.metaitem.01:32649>;
-val UEVSensor = <gregtech:gt.metaitem.01:32699>;
-val UEVEmitter= <gregtech:gt.metaitem.01:32689>;
+val UVFieldGen = <gregtech:gt.metaitem.01:32677>;
+val UVPiston = <gregtech:gt.metaitem.01:32647>;
+val UVSensor = <gregtech:gt.metaitem.01:32697>;
+val UVEmitter= <gregtech:gt.metaitem.01:32687>;
 val CreativeEnergyBank = <EnderIO:blockCapBank>.withTag({type: "CREATIVE", storedEnergyRF: 2500000});
 val SuperconductingCoil = <gregtech:gt.blockcasings:15>;
 
@@ -71,36 +71,36 @@ recipes.remove(sgLargeCapacitor);
 // --- sgRingBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgRingBlock, [
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil]]);
 
 // --- sgChevronUpgrade
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronUpgrade, [
 [null, null, null, null, null, null, null, null, null],
-[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
-[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
-[null, null, null, UEVFieldGen, sgChevron, UEVFieldGen, null, null, null],
-[null, null, null, sgFrame, UEVSensor, sgFrame, null, null, null],
-[null, null, null, UEVFieldGen, sgFrame, UEVFieldGen, null, null, null],
-[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
-[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
+null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
+[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
+[null, null, null, UVFieldGen, sgChevron, UVFieldGen, null, null, null],
+[null, null, null, sgFrame, UVSensor, sgFrame, null, null, null],
+[null, null, null, UVFieldGen, sgFrame, UVFieldGen, null, null, null],
+[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
+[null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
 // ---sgChevronBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>, null, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, <ore:blockNaquadahAlloy>, UEVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UEVSensor, <ore:blockNaquadahAlloy>, null],
+[null, <ore:blockNaquadahAlloy>, UVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UVSensor, <ore:blockNaquadahAlloy>, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>,null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>,null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>,null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
@@ -108,7 +108,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 mods.avaritia.ExtremeCrafting.addShaped(sgBaseBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, null, sgRingBlock, sgChevronBlock, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgCoreCrystal, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgRingBlock, sgRingBlock, null, null, null],
@@ -121,9 +121,9 @@ mods.avaritia.ExtremeCrafting.addShaped(sgLargeCapacitor, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
-[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
-[null, null, sgFoil, CreativeEnergyBank, UEVFieldGen, CreativeEnergyBank, sgFoil, null, null],
-[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, CreativeEnergyBank, UVFieldGen, CreativeEnergyBank, sgFoil, null, null],
+[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
@@ -138,7 +138,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgIrisBlade, [
 [null, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null],
-[<ore:blockTitanium>, UEVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
+[<ore:blockTitanium>, UVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
 [SuperconductingCoil, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>]]);
 
 // ---sgIrisUpgrade
@@ -169,15 +169,15 @@ mods.avaritia.ExtremeCrafting.addShaped(sgRFPowerAcceptor, [
 
 // ---sgOpenComputerInterface
 mods.avaritia.ExtremeCrafting.addShaped(sgOpenComputerInterface, [
-[Nanocircuit, UEVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVSensor, Nanocircuit],
-[UEVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVEmitter],
+[Nanocircuit, UVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVSensor, Nanocircuit],
+[UVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVEmitter],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, Nanocircuit, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
-[UEVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVSensor],
-[Nanocircuit, UEVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVEmitter, Nanocircuit]]);
+[UVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVSensor],
+[Nanocircuit, UVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVEmitter, Nanocircuit]]);
 
 // Leave this part here to copy&paste the variable names
 //sgRingBlock


### PR DESCRIPTION
Revert the change unless circuits for higher tiers are corrected.

Current circuit system goes 3 tiers above the starting circuit.
So example, with crystalprocessors, is:
IV -> LuV -> ZPM -> UV
UHV Crystalprocessors don't exist, next tier is wetware
Wetware goes LuV -> ZPM -> UV -> UHV

Then there's bioware
bioware goes:
ZPM -> UV -> UHV -> UEV -> UIV -> UMV
with UMV actually requiring 8 UIV circuits instead of 2 for some reasons... this is 256 ZPM circuits for 1 UMV

Game is clearly missing a circuit line starting from UV and another one starting from UHV
Adding those can make the UMV circuits actually possible. Stargate nerf should come after those circuits are made possible if they require those.

Other possibility is to make stargate require less power and only up to UEV circuits.