### PR TITLE
fix stargate recipe or change circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GT New Horizons Mod Pack
 
-Version 2.1.2.1 is out 21.12.2021
+Version 2.1.2.2 is out 20.01.2021
 
 [![Build Status](http://jenkins.usrv.eu:8080/buildStatus/icon?job=GTNewHorizons%20Configs)](http://jenkins.usrv.eu:8080/job/GTNewHorizons%20Configs/)
 
@@ -182,233 +182,236 @@ Downloads can be found at http://downloads.gtnewhorizons.com - do not try to dow
 | Name | Version |
 | --- | --- |
 | [Advanced Solar Panels](https://forum.industrial-craft.net/thread/3291-ic2-exp-1-7-10-advanced-solar-panels-v3-5-1-quantum-generator-solar-helmets/) | 3.5.1a |
-| [Adventure Backpack](https://github.com/GTNewHorizons/AdventureBackpack2) | 1.0.0-GTNH |
+| [Adventure Backpack](https://github.com/GTNewHorizons/AdventureBackpack2) | 1.0.2-GTNH |
 | [AE2 Stuff](https://github.com/GTNewHorizons/ae2stuff/) | 0.5.1.13-GTNH |
-| [AE2 Wireless Crafting Terminal](https://github.com/GTNewHorizons/WirelessCraftingTerminal) | 1.8.8.2-GTNH |
+| [AE2 Wireless Crafting Terminal](https://github.com/GTNewHorizons/WirelessCraftingTerminal) | 1.8.8.3-GTNH |
 | [AFSU](https://www.curseforge.com/minecraft/mc-mods/afsu-mod) | 1.2.3.a |
 | [Anger Mod](https://github.com/GTNewHorizons/AngerMod) | 0.6.2 |
-| [Applied Energistics](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial) | rv3-beta-66-GTNH |
+| [Applied Energistics](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial) | rv3-beta-72-GTNH |
 | [Architecture Craft](https://github.com/GTNewHorizons/ArchitectureCraft) | 1.7.4-GTNH |
 | [Aroma Backup](https://www.curseforge.com/minecraft/mc-mods/aromabackup) | 0.1.0.0 |
 | [Automagy](https://www.curseforge.com/minecraft/mc-mods/automagy) | 0.28.2 |
-| [Avaritia](https://github.com/GTNewHorizons/Avaritia/) | 1.20 |
+| [Avaritia](https://github.com/GTNewHorizons/Avaritia/) | 1.22 |
 | [Avaritiaddons](https://github.com/GTNewHorizons/Avaritiaddons/) | 1.5.2 |
-| [BackPack](https://github.com/runescapejon/Minecraft-Backpack-Mod) | 2.2.4 |
-| [Bartworks](https://github.com/GTNewHorizons/bartworks/) | 0.5.32 |
+| [BackPack](https://github.com/runescapejon/Minecraft-Backpack-Mod) | 2.2.5-GTNH |
+| [Bartworks](https://github.com/GTNewHorizons/bartworks/) | 0.5.34 |
 | [Bee Better At Bees](https://www.curseforge.com/minecraft/mc-mods/beebetteratbees) | 0.3 |
 | [Better Archivements](https://www.curseforge.com/minecraft/mc-mods/betterachievements) | 0.1.0 |
-| [Better Builders Wands](https://www.curseforge.com/minecraft/mc-mods/better-builders-wands) | 0.8.1r92 |
+| [Better Builders Wands](https://www.curseforge.com/minecraft/mc-mods/better-builders-wands) | 0.9.0 |
 | [Better Loading Screen](https://github.com/GTNewHorizons/BetterLoadingScreen/) | 1.3.31-GTNH |
-| [Better Questing](https://github.com/GTNewHorizons/BetterQuesting/) | 3.0.350-GTNH |
+| [Better Questing](https://github.com/GTNewHorizons/BetterQuesting/) | 3.0.351-GTNH |
 | [Bibliocraft](https://www.curseforge.com/minecraft/mc-mods/bibliocraft) | 1.11.7 |
 | [BiblioWoods Biomes O'Plenty Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-biomes-oplenty-edition) | 1.9 |
 | [BiblioWoods Forestry Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-forestry-edition) | 1.7 |
 | [BiblioWoods Natura Edition](https://www.curseforge.com/minecraft/mc-mods/bibliocraft-bibliowoods-natura-edition) | 1.5 |
-| [Binnie Mods](https://github.com/GTNewHorizons/Binnie/) | 2.0.32 |
-| [Biomes o Plenty](http://jenkins.usrv.eu:8080/job/BoP/) | 2.1.2-GTNH |
+| [Binnie Mods](https://github.com/GTNewHorizons/Binnie/) | 2.0.33 |
+| [Biomes o Plenty](http://jenkins.usrv.eu:8080/job/BoP/) | 2.1.3-GTNH |
 | [BlockLimiter](https://github.com/GTNewHorizons/BlockLimiter/) | 0.54 |
 | [Blood Arsenal](https://github.com/GTNewHorizons/BloodArsenal) | 1.2.3-11 |
-| [BloodMagic](https://github.com/GTNewHorizons/BloodMagic) | 1.3.4 |
-| [Botdustries](https://github.com/GTNewHorizons/Botdustries) | 1.2.6 |
+| [BloodMagic](https://github.com/GTNewHorizons/BloodMagic) | 1.3.5 |
+| [Botania](https://github.com/GTNewHorizons/Botania) | 1.9.1 |
+| [Botanic Horizons](https://github.com/GTNewHorizons/Botanic-horizons) | 1.9.1-GTNH |
+| [Botdustries](https://github.com/GTNewHorizons/Botdustries) | 1.0.1-GTNH |
 | [Bug Torch](https://github.com/GTNewHorizons/BugTorch) | 1.1.2-GTNH |
 | [Buildcraft](https://github.com/GTNewHorizons/BuildCraft) | 7.1.24 |
-| [Buildcraft Compat](https://github.com/GTNewHorizons/BuildCraftCompat) | 7.1.8 |
+| [Buildcraft Compat](https://github.com/GTNewHorizons/BuildCraftCompat) | 7.1.9 |
 | [Build Craft Oil Tweak](https://files.vexatos.com/?dir=BuildCraftOilTweak) | 1.0.3 |
 | [Carpenter's Blocks](https://www.curseforge.com/minecraft/mc-mods/carpenters-blocks) | 3.3.8.2 |
-| [Catwalk Mod](https://www.curseforge.com/minecraft/mc-mods/catwalks-2) | 2.0.4 |
-| [Chisel](https://github.com/GTNewHorizons/Chisel) | 2.10.4 |
+| [Catwalk Mod](https://www.curseforge.com/minecraft/mc-mods/catwalks-2) | 2.1.0-GTNH |
+| [Chisel](https://github.com/GTNewHorizons/Chisel) | 2.10.6 |
 | [Chisel Tones](https://www.curseforge.com/minecraft/mc-mods/chiseltones) | 1.0-3 |
-| [Cooking for Blockheads](https://github.com/GTNewHorizons/CookingForBlockheads) | 1.2.5-GTNH |
+| [Cooking for Blockheads](https://github.com/GTNewHorizons/CookingForBlockheads) | 1.2.6-GTNH |
 | [Command Block BQ Mod](https://www.curseforge.com/minecraft/mc-mods/command-blocks-for-better-questing) | 3 |
 | [Compact Kinetic Generators](https://github.com/GTNewHorizons/CompactKineticGenerators) | 1.0 |
 | [Computronics](https://github.com/GTNewHorizons/Computronics) | 1.6.9 |
 | [Controlling](https://www.curseforge.com/minecraft/mc-mods/controlling) | 1.0.0 |
 | [CraftPresence](https://www.curseforge.com/minecraft/mc-mods/craftpresence) | 1.8.2 |
-| [Craft Tweaker](https://github.com/GTNewHorizons/CraftTweaker) | 3.2.3-21-GTNH |
-| [Crops ++](https://github.com/GTNewHorizons/Crops-plus-plus) | 1.3.5.6 |
+| [Craft Tweaker](https://github.com/GTNewHorizons/CraftTweaker) | 3.2.5 |
+| [Crops ++](https://github.com/GTNewHorizons/Crops-plus-plus) | 1.3.5.8 |
 | [Custom Main Menu](https://www.curseforge.com/minecraft/mc-mods/custom-main-menu) | 1.9.2 |
 | [Default World Generator](https://github.com/GTNewHorizons/DefaultWorldGenerator) | 0.1-b13 |
 | [Draconic Evolution](https://github.com/GTNewHorizons/Draconic-Evolution) | 1.1.1 |
-| [Electro Magic Tools](https://github.com/GTNewHorizons/Electro-Magic-Tools) | 1.2.8.4 |
-| [Ender IO](https://github.com/GTNewHorizons/EnderIO) | 2.3.1.24 |
-| [Ender Storage](https://github.com/GTNewHorizons/EnderStorage) | 1.4.9 |
-| [Ender Zoo](https://github.com/GTNewHorizons/EnderZoo) | 1.0.21 |
+| [Electro Magic Tools](https://github.com/GTNewHorizons/Electro-Magic-Tools) | 1.2.8.5 |
+| [Ender IO](https://github.com/GTNewHorizons/EnderIO) | 2.3.1.27 |
+| [Ender Storage](https://github.com/GTNewHorizons/EnderStorage) | 1.4.11 |
+| [Ender Zoo](https://github.com/GTNewHorizons/EnderZoo) | 1.0.22 |
 | [Enhanced Loot Bags](https://github.com/GTNewHorizons/EnhancedLootBags) | 1.0.5 |
 | [Enhanced Portals 3](https://www.curseforge.com/minecraft/mc-mods/enhanced-portals-3) | 3.0.12 |
 | [Eternal Singularity](https://www.curseforge.com/minecraft/mc-mods/eternal-singularity/files/2577977) | 1.0.4b |
-| [Extra Cells](https://github.com/GTNewHorizons/ExtraCells2) | 2.5.2 |
+| [Extra Cells](https://github.com/GTNewHorizons/ExtraCells2) | 2.5.4 |
 | [Extra Utilities](https://www.curseforge.com/minecraft/mc-mods/extra-utilities/files/2264383) | 1.2.13a |
 | [FastCraft](https://www.curseforge.com/minecraft/mc-mods/fastcraft) | 1.25 |
 | [Find It](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/Find-It/) | 1.0.2 |
 | [Flood Light](https://www.curseforge.com/minecraft/mc-mods/floodlights) | 1.2.8.137 |
-| [Forbidden Magic](https://github.com/GTNewHorizons/ForbiddenMagic) | 0.6-GTNH |
-| [Forestry](https://github.com/GTNewHorizons/ForestryMC) | 4.4.3 |
+| [Forbidden Magic](https://github.com/GTNewHorizons/ForbiddenMagic) | 0.6.1-GTNH |
+| [Forestry](https://github.com/GTNewHorizons/ForestryMC) | 4.4.5 |
 | [Forgelin](https://github.com/GTNewHorizons/Forgelin) | 1.9.2-GTNH |
-| [Forge Multipart](https://github.com/GTNewHorizons/ForgeMultipart) | 1.2.0.347 |
+| [Forge Multipart](https://github.com/GTNewHorizons/ForgeMultipart) | 1.2.7 |
 | [Forge Relocation](https://www.curseforge.com/minecraft/mc-mods/forge-relocation) | 0.0.1.4 |
 | [Forge Relocation FMP](https://www.curseforge.com/minecraft/mc-mods/forge-relocation-fmp-plugin) | 0.0.1.2 |
-| [Gadomancy](https://github.com/GTNewHorizons/Gadomancy) | 1.0.8.3 |
-| [Galacticraft](https://github.com/GTNewHorizons/Galacticraft) | 3.0.34-GTNH |
-| [GalactiGreg](https://github.com/GTNewHorizons/GalacticGregGT5) | 1.0.5 |
-| [Galaxy Space](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/Galaxy-Space/) | 1.2.2-GTNH |
-| [Gendustry](https://github.com/GTNewHorizons/gendustry) | 1.6.5.2 |
-| [Good Generator](https://github.com/GTNewHorizons/GoodGenerator) | 0.3.2 |
+| [Gadomancy](https://github.com/GTNewHorizons/Gadomancy) | 1.0.8.4 |
+| [Galacticraft](https://github.com/GTNewHorizons/Galacticraft) | 3.0.37-GTNH |
+| [GalactiGreg](https://github.com/GTNewHorizons/GalacticGregGT5) | 1.0.7 |
+| [Galaxy Space](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/Galaxy-Space/) | 1.1.9-GTNH |
+| [Gendustry](https://github.com/GTNewHorizons/gendustry) | 1.6.5.3 |
+| [Good Generator](https://github.com/GTNewHorizons/GoodGenerator) | 0.3.5 |
 | [Gravitation Suite](Source hidden ask Namikon)| 2.0.68u |
-| [Gregtech](https://github.com/GTNewHorizons/GT5-Unofficial) | 5.09.40.16 |
-| [GT Scanner Mod](https://github.com/GTNewHorizons/DetravScannerMod) | 1.6.3 |
+| [Gregtech](https://github.com/GTNewHorizons/GT5-Unofficial) | 5.09.40.19 |
+| [GT Scanner Mod](https://github.com/GTNewHorizons/DetravScannerMod) | 1.6.4 |
 | [GT Ore Nei Plugin](https://github.com/GTNewHorizons/GTNEIOrePlugin) | 1.0.9 |
-| [GT New Horizons Core Mod](https://github.com/GTNewHorizons/NewHorizonsCoreMod) | 1.9.11 |
-| [GT++](https://github.com/GTNewHorizons/GTPP) | 1.7.23-GTNH |
+| [GT New Horizons Core Mod](https://github.com/GTNewHorizons/NewHorizonsCoreMod) | 1.9.13 |
+| [GT++](https://github.com/GTNewHorizons/GTPP) | 1.7.25-GTNH |
 | [GTNH TC Wands](https://github.com/GTNewHorizons/GTNH-TC-Wands) | 1.2.5 |
 | [GTTweaker](https://github.com/GTNewHorizons/Minetweaker-Gregtech-5-Addon) | 1.7.5 |
 | [Hardcore Darkness](https://www.curseforge.com/minecraft/mc-mods/hardcore-darkness) | 1.7 |
-| [Hardcore Ender Expansion](https://github.com/GTNewHorizons/Hardcore-Ender-Expansion) | 1.9.0 |
+| [Hardcore Ender Expansion](https://github.com/GTNewHorizons/Hardcore-Ender-Expansion) | 1.9.1 |
 | [Healer](https://github.com/Glease/Healer) | 1.1.0 |
 | [Help Fixer](https://www.curseforge.com/minecraft/mc-mods/helpfixer) | 1.0.7 |
-| [Hodgepodge](https://github.com/GTNewHorizons/Hodgepodge) | 1.6.20 |
+| [Hodgepodge](https://github.com/GTNewHorizons/Hodgepodge) | 1.6.23 |
 | [Holo Inventory](https://github.com/GTNewHorizons/HoloInventory) | 2.1.6-beta |
 | [Hunger Overhaul](https://github.com/GTNewHorizons/HungerOverhaul) | 1.0.2 |
-| [Hydro Energy](https://github.com/GTNewHorizons/HydroEnergy) | 1.0.9 |
-| [IC2 Nuclear Control](https://www.curseforge.com/minecraft/mc-mods/nuclear-control-2) | 2.4.7 |
+| [Hydro Energy](https://github.com/GTNewHorizons/HydroEnergy) | 1.0.10 |
+| [IC2 Nuclear Control](https://www.curseforge.com/minecraft/mc-mods/nuclear-control-2) | 2.4.8 |
 | [IFU](https://github.com/GTNewHorizons/IFU) | 1.9.1 |
 | [IguanaTinkerTweaks](https://github.com/GTNewHorizons/IguanaTweaksTConstruct) | 2.2.0 |
 | [Industrial Craft 2](http://jenkins.ic2.player.to/job/IC2_experimental/828/) | 2.2.2.828a |
 | [Industrial Craft 2 Nei Plugin](https://www.curseforge.com/minecraft/mc-mods/ic2-nei-crop-plugin/files) | 1.3.1 |
 | [Infernal Mobs](https://github.com/GTNewHorizons/Infernal-Mobs) | 1.7.5 |
-| [InGame Info XML](https://github.com/GTNewHorizons/InGame-Info-XML) | 2.8.3.8 |
-| [Inventory Tweaks](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/Inventory-Tweaks/) | 1.5.11 |
-| [Iron Chest Minecarts](https://www.curseforge.com/minecraft/mc-mods/iron-chest-minecarts) | 1.0.5 |
-| [Iron Chests](https://www.curseforge.com/minecraft/mc-mods/iron-chests) | 6.0.66 |
+| [InGame Info XML](https://github.com/GTNewHorizons/InGame-Info-XML) | 2.8.3.10 |
+| [Inventory Tweaks](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/Inventory-Tweaks/) | 1.5.13 |
+| [Iron Chest Minecarts](https://www.curseforge.com/minecraft/mc-mods/iron-chest-minecarts) | 1.0.6 |
+| [Iron Chests](https://www.curseforge.com/minecraft/mc-mods/iron-chests) | 6.0.68 |
 | [Iron Tanks](https://github.com/GTNewHorizons/Irontanks) | 1.2.4 |
 | [It's the little things](https://www.curseforge.com/minecraft/mc-mods/its-the-little-things/) | 1.0.3 |
-| [Jabba](https://github.com/GTNewHorizons/Jabba) | 1.2.11 |
+| [Jabba](https://github.com/GTNewHorizons/Jabba) | 1.2.13 |
 | [JourneyMap](https://www.curseforge.com/minecraft/mc-mods/journeymap) | 5.1.4p2 |
-| [Kekztech](https://github.com/GTNewHorizons/KekzTech) | 0.6.0 |
-| [Little Tiles](https://www.curseforge.com/minecraft/mc-mods/littletiles) | 1.2.0 |
-| [Logistic Pipes](https://github.com/GTNewHorizons/LogisticsPipes) | 0.9.4.5.2 |
-| [Lootgames](https://github.com/GTNewHorizons/LootGames) | 2.0.3 |
-| [Magic Bees](https://github.com/GTNewHorizons/MagicBees) | 2.5.7-GTNH |
+| [Kekztech](https://github.com/GTNewHorizons/KekzTech) | 0.6.1 |
+| [Little Tiles](https://www.curseforge.com/minecraft/mc-mods/littletiles) | 1.2.1-GTNH |
+| [Logistic Pipes](https://github.com/GTNewHorizons/LogisticsPipes) | 0.9.4.5.4 |
+| [Lootgames](https://github.com/GTNewHorizons/LootGames) | 2.0.4 |
+| [Magic Bees](https://github.com/GTNewHorizons/MagicBees) | 2.5.8-GTNH |
 | [Malisis Doors](https://www.curseforge.com/minecraft/mc-mods/malisisdoors) | 1.13.2 |
 | [Mine and Blade Battlegear](https://github.com/GTNewHorizons/Battlegear2) | 1.1.1.7-GTNH |
 | [Minecraft Forge](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.7.10.html) | 10.13.4.1614 |
 | [Mod Mixins](https://github.com/GTNewHorizons/ModMixins) | 0.0.5 |
 | [Mod Tweaker 2](https://www.curseforge.com/minecraft/mc-mods/modtweaker) | 0.9.7 |
 | [Mouse Tweaks](https://www.curseforge.com/minecraft/mc-mods/mouse-tweaks) | 2.4.4 |
-| [Natura](https://github.com/GTNewHorizons/Natura) | 2.4.6 |
+| [Natura](https://github.com/GTNewHorizons/Natura) | 2.4.9 |
 | [Natures Compass](https://www.curseforge.com/minecraft/mc-mods/natures-compass) | 1.3.1 |
-| [NEI](https://github.com/GTNewHorizons/NotEnoughItems) | 2.1.18-GTNH |
-| [Nei Addons](https://www.curseforge.com/minecraft/mc-mods/nei-addons) | 1.12.17 |
-| [Nei Custom Diagramm](http://jenkins.usrv.eu:8080/job/Nei-custom-diagram/) | 1.4.2 |
+| [NEI](https://github.com/GTNewHorizons/NotEnoughItems) | 2.1.22-GTNH |
+| [Nei Addons](https://www.curseforge.com/minecraft/mc-mods/nei-addons) | 1.12.18 |
+| [Nei Custom Diagramm](http://jenkins.usrv.eu:8080/job/Nei-custom-diagram/) | 1.4.4 |
 | [Nei Integration](https://github.com/GTNewHorizons/NEI-Integration) | 1.1.3 |
 | [Nether Portal Fix](https://github.com/GTNewHorizons/NetherPortalFix) | 1.1.1 |
 | [Nodal Mechanics](https://github.com/GTNewHorizons/Nodal-Mechanics) | 1.1-6-GTNH |
-| [Not Enough Energistics](http://jenkins.usrv.eu:8080/job/NotEnoughEnergistics/) | 1.3.4 |
+| [Not Enough Energistics](http://jenkins.usrv.eu:8080/job/NotEnoughEnergistics/) | 1.3.8 |
 | [Open Blocks](https://github.com/GTNewHorizons/OpenBlocks) | 1.6.7 |
-| [Open Computers](https://github.com/GTNewHorizons/OpenComputers) | 1.7.5.17-GTNH |
+| [Open Computers](https://github.com/GTNewHorizons/OpenComputers) | 1.7.5.20-GTNH |
 | [Open Modular Turrets](https://www.curseforge.com/minecraft/mc-mods/openmodularturrets) | 2.2.11.245 |
-| [Open Glasses](https://github.com/GTNewHorizons/OCGlasses/) | 1.1 |
+| [Open Glasses](https://github.com/GTNewHorizons/OCGlasses/) | 1.2.1-GTNH |
 | [Open Printers](https://www.curseforge.com/minecraft/mc-mods/openprinter) | 0.1.0.132 |
 | [Open Security](https://www.curseforge.com/minecraft/mc-mods/opensecurity) | 1.0-117 |
 | [Overloaded Armorbar](https://github.com/GTNewHorizons/OverloadedArmorBar) | 1.0.0 |
-| [Pam's Harvestcraft](http://jenkins.usrv.eu:8080/job/harvestcraft/) | 1.0.8-GTNH |
+| [Pam's Harvestcraft](http://jenkins.usrv.eu:8080/job/harvestcraft/) | 1.0.10-GTNH |
 | [Pam's Harvestcraft Nether](https://www.curseforge.com/minecraft/mc-mods/pams-harvest-the-nether) | 1.7.10a |
 | [Project Blue](https://www.cosc.canterbury.ac.nz/greg.ewing/minecraft/mods/ProjectBlue/) | 1.1.7 |
-| [Project Red](https://github.com/GTNewHorizons/ProjectRed) | 4.7.1 |
+| [Project Red](https://github.com/GTNewHorizons/ProjectRed) | 4.7.4 |
 | [Questbook](https://github.com/GTNewHorizons/QuestBook) | 2.1.1 |
-| [Railcraft](https://www.curseforge.com/minecraft/mc-mods/railcraft) | 9.13.2 |
+| [Railcraft](https://www.curseforge.com/minecraft/mc-mods/railcraft) | 9.13.5 |
 | [Random Things](https://www.curseforge.com/minecraft/mc-mods/random-things) | 2.2.4 |
 | [Realistic World Gen](https://github.com/GTNewHorizons/Realistic-World-Gen) | 1.3.2 |
-| [RemoteIO](https://github.com/GTNewHorizons/RemoteIO) | 2.4.2 |
-| [Rogue like Dungeons](https://github.com/GTNewHorizons/Roguelike-Dungeons) | 1.5.1 |
-| [Resource Loader](https://www.curseforge.com/minecraft/mc-mods/resource-loader) | 1.3.0 |
-| [Schematica](https://www.curseforge.com/minecraft/mc-mods/schematica) | 1.7.6.131 |
+| [RemoteIO](https://github.com/GTNewHorizons/RemoteIO) | 2.4.4 |
+| [Rogue like Dungeons](https://github.com/GTNewHorizons/Roguelike-Dungeons) | 1.5.2-GTNH |
+| [Resource Loader](https://www.curseforge.com/minecraft/mc-mods/resource-loader) | 1.3 |
+| [Schematica](https://www.curseforge.com/minecraft/mc-mods/schematica) | 1.8.1 |
 | [SG Craft](https://github.com/GTNewHorizons/SGCraft) | 1.13.11 |
-| [Sleeping Bag](https://www.curseforge.com/minecraft/mc-mods/bag-o-sleep) | 0.1.1 |
+| [Sleeping Bag](https://www.curseforge.com/minecraft/mc-mods/bag-o-sleep) | 0.1.2-GTNH |
 | [Special Mobs](https://github.com/GTNewHorizons/SpecialMobs) | 3.3.9 |
-| [Spice of Life](https://github.com/GTNewHorizons/SpiceOfLife) | 2.0.0-carot-beta-9 |
-| [Standard Expansion](http://jenkins.usrv.eu:8080/job/StandartExpansion/) | 3.0.186-GTNH |
-| [Steve's Carts](http://jenkins.usrv.eu:8080/job/Steve-Carts/) | 2.0.0.20b |
+| [Spice of Life](https://github.com/GTNewHorizons/SpiceOfLife) | 2.0.0-carot-beta-10 |
+| [Standard Expansion](http://jenkins.usrv.eu:8080/job/StandartExpansion/) | 3.0.188-GTNH |
+| [Steve's Carts](http://jenkins.usrv.eu:8080/job/Steve-Carts/) | 2.0.1 |
 | [Steve's Factory Manager](https://github.com/GTNewHorizons/Steve-s-Factory-Manager) | ALPHA98-GTNH |
 | [Steve's Factory Manager Addon](https://github.com/GTNewHorizons/StevesAddons) | 0.10.17 |
-| [Storage Drawers](https://github.com/GTNewHorizons/StorageDrawers) | 1.11.10-gtnh |
-| [Storage Drawers Wood Addons Forestry](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-forestry-pack) | 1.19.9 |
-| [Storage Drawers Wood Addons Biome O plenty](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-biomes-o-plenty-pack) | 1.11.9 | 
-| [Storage Drawers Wood Addons Natura](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-natura-pack) | 1.11.9 |
-| [Storage Drawers Wood Addons Misc](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-misc-pack) | 1.11.9 |
+| [Storage Drawers](https://github.com/GTNewHorizons/StorageDrawers) | 1.11.11-gtnh |
+| [Storage Drawers Wood Addons Forestry](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-forestry-pack) | 1.11.10 |
+| [Storage Drawers Wood Addons Biome O plenty](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-biomes-o-plenty-pack) | 1.11.10 | 
+| [Storage Drawers Wood Addons Natura](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-natura-pack) | 1.11.10 |
+| [Storage Drawers Wood Addons Misc](https://www.curseforge.com/minecraft/mc-mods/storage-drawers-misc-pack) | 1.11.10 |
 | [Super Solar Panel](https://github.com/GTNewHorizons/supersolarpanels) | 1.1.2 |
 | [Super Tic](https://github.com/GTNewHorizons/Super-TiC) | 1.2.1 |
 | [Tainted Magic](https://github.com/GTNewHorizons/Tainted-Magic) | r7.6 |
 | [TC Node Tracker](https://www.curseforge.com/minecraft/mc-mods/thaumcraft-node-tracker) | 1.1.4 |
 | [TC Inventoryscann](https://www.curseforge.com/minecraft/mc-mods/thaumcraft-inventory-scanning) | 1.0.11 |
-| [Tec Tech](https://github.com/GTNewHorizons/TecTech) | 4.10.12 |
+| [Tec Tech](https://github.com/GTNewHorizons/TecTech) | 4.10.16 |
 | [Thaumcraft](https://www.curseforge.com/minecraft/mc-mods/thaumcraft) | 4.2.3.5 |
 | [Thaumcraft Mob Aspects](http://jenkins.usrv.eu:8080/view/3rd%20Party%20Mods/job/ThaumcraftMobAspects/) | 1.0.0-GTNH |
-| [Thaumcraft-NEI-Additions](https://github.com/GTNewHorizons/TCNEIAdditions) | 1.1.0.3 |
+| [Thaumcraft-NEI-Additions](https://github.com/GTNewHorizons/TCNEIAdditions) | 1.1.0.4 |
 | [Thaumcraft-Research-Tweaks](https://github.com/GTNewHorizons/thaumcraft-research-tweaks) | 1.0.2 |
 | [ThaumcraftNEIPlugins](https://www.curseforge.com/minecraft/mc-mods/thaumcraft-nei-plugin) | 1.7a |
 | [Thaumic Bases](https://github.com/GTNewHorizons/ThaumicBases) | 1.4.27 |
-| [Thaumic Energistics](https://github.com/GTNewHorizons/ThaumicEnergistics) | 1.3.15 |
-| [Thaumic Exploration](https://github.com/GTNewHorizons/Thaumic_Exploration) | 1.1.81 |
-| [Thaumic Horizons](https://github.com/GTNewHorizons/ThaumicHorizons) | 1.2.0.5-GTNH |
+| [Thaumic Energistics](https://github.com/GTNewHorizons/ThaumicEnergistics) | 1.3.16-GTNH |
+| [Thaumic Exploration](https://github.com/GTNewHorizons/Thaumic_Exploration) | 1.1.81-GTNH |
+| [Thaumic Horizons](https://github.com/GTNewHorizons/ThaumicHorizons) | 1.2.1.0-GTNH |
 | [Thaumic Machina](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/wip-mods/2200956-wip-1-7-10-open-beta-thaumcraft-4-2-addon-thaumic) | 0.2.1 |
-| [Thaumic Tinkerer](https://github.com/GTNewHorizons/ThaumicTinkerer) | 2.5-4 |
-| [Thaumcraft Tweaks](https://github.com/GTNewHorizons/TC4Tweaks) | 1.4.9 |
-| [TiCTooltips](https://github.com/GTNewHorizons/TiC-Tooltips) | 1.2.7 |
-| [Tinkers' Construct](https://github.com/GTNewHorizons/TinkersConstruct) | 1.9.0.6 |
+| [Thaumic Tinkerer](https://github.com/GTNewHorizons/ThaumicTinkerer) | 2.6.0 |
+| [Thaumcraft Tweaks](https://github.com/GTNewHorizons/TC4Tweaks) | 1.4.14 |
+| [TiCTooltips](https://github.com/GTNewHorizons/TiC-Tooltips) | 1.2.8 |
+| [Tinkers' Construct](https://github.com/GTNewHorizons/TinkersConstruct) | 1.9.0.10-GTNH |
 | [Tinkers' Gregworks](https://github.com/GTNewHorizons/TinkersGregworks) | 1.0.23-GTNH |
 | [Tinkers' Defense](https://www.curseforge.com/minecraft/mc-mods/compendium/) | 1.2.1d |
 | [Tinkers' Mechworks](https://github.com/GTNewHorizons/TinkersMechworks) | 0.2.16.2 |
 | [Too Much Loot](https://github.com/GTNewHorizons/TooMuchLoot) | 4.1.0-GTNH |
 | [Toro Health](https://github.com/GTNewHorizons/ToroHealth) | 1.0.0 |
-| [Translocator](https://www.curseforge.com/minecraft/mc-mods/translocators) | 1.1.2.16 |
-| [Travellers Gear](https://github.com/GTNewHorizons/TravellersGear) | 1.16.7 |
-| [Twillight Forest](https://github.com/GTNewHorizons/twilightforest) | 2.3.8.10 |
+| [Translocator](https://www.curseforge.com/minecraft/mc-mods/translocators) | 1.1.2.19 |
+| [Travellers Gear](https://github.com/GTNewHorizons/TravellersGear) | 1.16.8 |
+| [Twillight Forest](https://github.com/GTNewHorizons/twilightforest) | 2.3.8.11 |
 | [Ulity Worlds](https://www.curseforge.com/minecraft/mc-mods/utility-worlds/) | 1.0.9e |
 | [Universal Singularities Version](https://github.com/GTNewHorizons/Universal-Singularities) | 8.6.3 |
-| [Visual Prospecting](http://jenkins.usrv.eu:8080/job/Visual-Prospecting/) | 1.0.25b |
-| [Waila](https://github.com/GTNewHorizons/waila) | 1.5.16 |
-| [Waila Harvestability](https://github.com/GTNewHorizons/WailaHarvestability) | 1.1.8 |
-| [Waila Plugins](https://github.com/GTNewHorizons/WAILAPlugins) | 0.2.3.2-24 |
-| [Wawla](https://github.com/GTNewHorizons/WAWLA) | 1.1.1-GTNH |
-| [Warp Theory](https://github.com/GTNewHorizons/WarpTheory) | 1.2.5-GTNH |
-| [Wireless Redstone CBE](https://github.com/GTNewHorizons/WirelessRedstone) | 1.4.3-GTNH |
+| [Visual Prospecting](http://jenkins.usrv.eu:8080/job/Visual-Prospecting/) | 1.0.26b |
+| [Waila](https://github.com/GTNewHorizons/waila) | 1.5.18 |
+| [Waila Harvestability](https://github.com/GTNewHorizons/WailaHarvestability) | 1.1.9-GTNH |
+| [Waila Plugins](https://github.com/GTNewHorizons/WAILAPlugins) | 0.2.4 |
+| [Wawla](https://github.com/GTNewHorizons/WAWLA) | 1.1.2-GTNH |
+| [Warp Theory](https://github.com/GTNewHorizons/WarpTheory) | 1.2.6-GTNH |
+| [Wireless Redstone CBE](https://github.com/GTNewHorizons/WirelessRedstone) | 1.4.4-GTNH |
 | [Witchery](https://github.com/GTNewHorizons/Witchery) | 0.24.1 |
 | [Witchery Extras](https://github.com/GTNewHorizons/WitcheryExtras) | 1.1.3 |
-| [Witching Gadgets](https://github.com/GTNewHorizons/WitchingGadgets) | 1.2.14-GTNH |
+| [Witching Gadgets](https://github.com/GTNewHorizons/WitchingGadgets) | 1.2.15-GTNH |
 | [Ztones](https://www.curseforge.com/minecraft/mc-mods/ztones/) | 2.2.2custom |
 
 ## Libs and Cores
 | Name | Version |
 | --- | --- |
-| [AppleCore](https://github.com/GTNewHorizons/AppleCore) | 3.1.4 |
+| [AppleCore](https://github.com/GTNewHorizons/AppleCore) | 3.1.6 |
 | [Aroma Core](https://www.curseforge.com/minecraft/mc-mods/aroma1997core) | 1.0.2.16 |
 | [AsieLib](https://github.com/Vexatos/AsieLib) | 0.5.0 |
-| [Baubles](https://github.com/GTNewHorizons/Baubles/) | 1.0.1.12 |
-| [BdLib](https://www.curseforge.com/minecraft/mc-mods/bdlib) | 1.9.4.109 |
+| [Baubles](https://github.com/GTNewHorizons/Baubles/) | 1.0.1.14 |
+| [BdLib](https://www.curseforge.com/minecraft/mc-mods/bdlib) | 1.9.6 |
 | [Brandon's Core](https://www.curseforge.com/minecraft/mc-mods/brandons-core) | 1.0.0.12 |
-| [CodeChickenCore](https://www.curseforge.com/minecraft/mc-mods/codechickencore) | 1.1.1 |
-| [CodeChickenLib](https://github.com/GTNewHorizons/CodeChickenLib/tree/1.7) | 1.1.4 |
+| [CodeChickenCore](https://www.curseforge.com/minecraft/mc-mods/codechickencore) | 1.1.3 |
+| [CodeChickenLib](https://github.com/GTNewHorizons/CodeChickenLib/tree/1.7) | 1.1.5.1 |
 | [CofhCore](https://www.curseforge.com/minecraft/mc-mods/cofh-core) | 3.1.4.329 |
 | [CofhLib](https://www.curseforge.com/minecraft/mc-mods/cofh-lib) | 1.2.1.185 |
-| [Creative Core](https://www.curseforge.com/minecraft/mc-mods/creativecore) | 1.3.24 |
+| [Creative Core](https://www.curseforge.com/minecraft/mc-mods/creativecore) | 1.3.25-GTNH |
 | [Crop Loader Core](https://github.com/GTNewHorizons/CropLoadCore) | 0.1.5 |
 | [CTMLib] (https://www.curseforge.com/minecraft/mc-mods/ctmlib) | 1.4.1.5 |
 | [Dummy Core](https://www.curseforge.com/minecraft/mc-mods/dummycore) | 1.13 |
-| [Ender Core](https://www.curseforge.com/minecraft/mc-mods/endercore) | 0.2.4 |
-| [Forge Multipart](http://jenkins.usrv.eu:8080/job/Forge-Multipart/) | 1.2.5 |
+| [Ender Core](https://www.curseforge.com/minecraft/mc-mods/endercore) | 0.2.6 |
+| [Forge Multipart](http://jenkins.usrv.eu:8080/job/Forge-Multipart/) | 1.2.7 |
 | [InpureCore](https://www.curseforge.com/minecraft/mc-mods/inpurecore) | 1.0.0B9-62 |
+| [Lunatius Core](https://github.com/GTNewHorizons/LunatriusCore) | 1.1.4 |
 | [Malisis Core](https://www.curseforge.com/minecraft/mc-mods/malisiscore) | 0.14.3 |
-| [Mantle](https://www.curseforge.com/minecraft/mc-mods/mantle) | 0.3.2b |
+| [Mantle](https://www.curseforge.com/minecraft/mc-mods/mantle) | 0.3.4 |
 | [MrTJPCore](https://www.curseforge.com/minecraft/mc-mods/mrtjpcore) | 1.1.0.33 |
 | [Netty Patcher](http://jenkins.usrv.eu:8080/job/Netty-Patcher) | 0.3 |
 | [OAuth](https://github.com/GTNewHorizons/oauth) | 1.06.1 |
-| [Open Mods Lib](https://www.curseforge.com/minecraft/mc-mods/openmodslib) | 0.10.1 |
+| [Open Mods Lib](https://www.curseforge.com/minecraft/mc-mods/openmodslib) | 0.10.3 |
 | [p455w0rdslib](https://www.curseforge.com/minecraft/mc-mods/p455w0rds-library) | 1.0.4 |
 | [Player api](https://www.curseforge.com/minecraft/mc-mods/player-api) | 1.4 |
-| [Sponge Mixins](https://github.com/GTNewHorizons/SpongeMixins) | 1.4.0 |
-| [Structure Lib](https://github.com/GTNewHorizons/StructureLib) | 1.0.10 |
-| [Wanion Lib](https://www.curseforge.com/minecraft/mc-mods/wanionlib) | 1.8.1 |
-| [YamCore](https://github.com/GTNewHorizons/Yamcl) | 0.5.81 |
+| [Sponge Mixins](https://github.com/GTNewHorizons/SpongeMixins) | 1.5.0 |
+| [Structure Lib](https://github.com/GTNewHorizons/StructureLib) | 1.0.15 |
+| [Wanion Lib](https://www.curseforge.com/minecraft/mc-mods/wanionlib) | 1.8.2 |
+| [YamCore](https://github.com/GTNewHorizons/Yamcl) | 0.5.82 |
 
 ---
 

--- a/scripts/SGCraft.zs
+++ b/scripts/SGCraft.zs
@@ -22,10 +22,10 @@ val sgFoil = <dreamcraft:item.StargateShieldingFoil>;
 val sgChevron = <dreamcraft:item.StargateChevron>;
 val sgFrame = <dreamcraft:item.StargateFramePart>;
 val Nanocircuit = <dreamcraft:item.NanoCircuit>;
-val UVFieldGen = <gregtech:gt.metaitem.01:32677>;
-val UVPiston = <gregtech:gt.metaitem.01:32647>;
-val UVSensor = <gregtech:gt.metaitem.01:32697>;
-val UVEmitter= <gregtech:gt.metaitem.01:32687>;
+val UEVFieldGen = <gregtech:gt.metaitem.01:32679>;
+val UEVPiston = <gregtech:gt.metaitem.01:32649>;
+val UEVSensor = <gregtech:gt.metaitem.01:32699>;
+val UEVEmitter= <gregtech:gt.metaitem.01:32689>;
 val CreativeEnergyBank = <EnderIO:blockCapBank>.withTag({type: "CREATIVE", storedEnergyRF: 2500000});
 val SuperconductingCoil = <gregtech:gt.blockcasings:15>;
 
@@ -71,36 +71,36 @@ recipes.remove(sgLargeCapacitor);
 // --- sgRingBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgRingBlock, [
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UEVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil]]);
 
 // --- sgChevronUpgrade
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronUpgrade, [
 [null, null, null, null, null, null, null, null, null],
-null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
-[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
-[null, null, null, UVFieldGen, sgChevron, UVFieldGen, null, null, null],
-[null, null, null, sgFrame, UVSensor, sgFrame, null, null, null],
-[null, null, null, UVFieldGen, sgFrame, UVFieldGen, null, null, null],
-[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
-[null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
+[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
+[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
+[null, null, null, UEVFieldGen, sgChevron, UEVFieldGen, null, null, null],
+[null, null, null, sgFrame, UEVSensor, sgFrame, null, null, null],
+[null, null, null, UEVFieldGen, sgFrame, UEVFieldGen, null, null, null],
+[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
+[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
 // ---sgChevronBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>, null, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, <ore:blockNaquadahAlloy>, UVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UVSensor, <ore:blockNaquadahAlloy>, null],
+[null, <ore:blockNaquadahAlloy>, UEVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UEVSensor, <ore:blockNaquadahAlloy>, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>,null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>,null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>,null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
@@ -108,7 +108,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 mods.avaritia.ExtremeCrafting.addShaped(sgBaseBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UEVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, null, sgRingBlock, sgChevronBlock, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgCoreCrystal, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgRingBlock, sgRingBlock, null, null, null],
@@ -121,9 +121,9 @@ mods.avaritia.ExtremeCrafting.addShaped(sgLargeCapacitor, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
-[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
-[null, null, sgFoil, CreativeEnergyBank, UVFieldGen, CreativeEnergyBank, sgFoil, null, null],
-[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, CreativeEnergyBank, UEVFieldGen, CreativeEnergyBank, sgFoil, null, null],
+[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
@@ -138,7 +138,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgIrisBlade, [
 [null, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null],
-[<ore:blockTitanium>, UVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
+[<ore:blockTitanium>, UEVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
 [SuperconductingCoil, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>]]);
 
 // ---sgIrisUpgrade
@@ -169,15 +169,15 @@ mods.avaritia.ExtremeCrafting.addShaped(sgRFPowerAcceptor, [
 
 // ---sgOpenComputerInterface
 mods.avaritia.ExtremeCrafting.addShaped(sgOpenComputerInterface, [
-[Nanocircuit, UVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVSensor, Nanocircuit],
-[UVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVEmitter],
+[Nanocircuit, UEVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVSensor, Nanocircuit],
+[UEVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVEmitter],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, Nanocircuit, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
-[UVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVSensor],
-[Nanocircuit, UVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVEmitter, Nanocircuit]]);
+[UEVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVSensor],
+[Nanocircuit, UEVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVEmitter, Nanocircuit]]);
 
 // Leave this part here to copy&paste the variable names
 //sgRingBlock

--- a/scripts/SGCraft.zs
+++ b/scripts/SGCraft.zs
@@ -22,10 +22,10 @@ val sgFoil = <dreamcraft:item.StargateShieldingFoil>;
 val sgChevron = <dreamcraft:item.StargateChevron>;
 val sgFrame = <dreamcraft:item.StargateFramePart>;
 val Nanocircuit = <dreamcraft:item.NanoCircuit>;
-val UEVFieldGen = <gregtech:gt.metaitem.01:32679>;
-val UEVPiston = <gregtech:gt.metaitem.01:32649>;
-val UEVSensor = <gregtech:gt.metaitem.01:32699>;
-val UEVEmitter= <gregtech:gt.metaitem.01:32689>;
+val UVFieldGen = <gregtech:gt.metaitem.01:32677>;
+val UVPiston = <gregtech:gt.metaitem.01:32647>;
+val UVSensor = <gregtech:gt.metaitem.01:32697>;
+val UVEmitter= <gregtech:gt.metaitem.01:32687>;
 val CreativeEnergyBank = <EnderIO:blockCapBank>.withTag({type: "CREATIVE", storedEnergyRF: 2500000});
 val SuperconductingCoil = <gregtech:gt.blockcasings:15>;
 
@@ -71,36 +71,36 @@ recipes.remove(sgLargeCapacitor);
 // --- sgRingBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgRingBlock, [
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UEVFieldGen, null, null],
-[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UEVFieldGen, UEVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFoil, UVFieldGen, null, null],
+[<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgFrame, sgFrame, sgFoil, UVFieldGen, UVFieldGen],
 [<ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, sgFrame, sgChevron, sgFrame, sgFrame, sgFoil, sgFoil]]);
 
 // --- sgChevronUpgrade
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronUpgrade, [
 [null, null, null, null, null, null, null, null, null],
-[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
-[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
-[null, null, null, UEVFieldGen, sgChevron, UEVFieldGen, null, null, null],
-[null, null, null, sgFrame, UEVSensor, sgFrame, null, null, null],
-[null, null, null, UEVFieldGen, sgFrame, UEVFieldGen, null, null, null],
-[null, null, null, sgFrame, UEVPiston, sgFrame, null, null, null],
-[null, null, null, UEVPiston, sgChevron, UEVPiston, null, null, null],
+null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
+[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
+[null, null, null, UVFieldGen, sgChevron, UVFieldGen, null, null, null],
+[null, null, null, sgFrame, UVSensor, sgFrame, null, null, null],
+[null, null, null, UVFieldGen, sgFrame, UVFieldGen, null, null, null],
+[null, null, null, sgFrame, UVPiston, sgFrame, null, null, null],
+[null, null, null, UVPiston, sgChevron, UVPiston, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
 // ---sgChevronBlock
 mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>, null, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, <ore:blockNaquadahAlloy>, UEVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UEVSensor, <ore:blockNaquadahAlloy>, null],
+[null, <ore:blockNaquadahAlloy>, UVSensor, sgChevronUpgrade, sgRingBlock, sgChevronUpgrade, UVSensor, <ore:blockNaquadahAlloy>, null],
 [null, null, <ore:blockNaquadahAlloy>, Nanocircuit, sgChevronUpgrade, Nanocircuit, <ore:blockNaquadahAlloy>, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVSensor, <ore:blockNaquadahAlloy>,null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVSensor, <ore:blockNaquadahAlloy>,null, null, null],
 [null, null, null, null, <ore:blockNaquadahAlloy>,null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
 
@@ -108,7 +108,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgChevronBlock, [
 mods.avaritia.ExtremeCrafting.addShaped(sgBaseBlock, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, null, null, null],
-[null, null, null, <ore:blockNaquadahAlloy>, UEVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
+[null, null, null, <ore:blockNaquadahAlloy>, UVEmitter, <ore:blockNaquadahAlloy>, null, null, null],
 [null, null, null, sgRingBlock, sgChevronBlock, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgCoreCrystal, sgRingBlock, null, null, null],
 [null, null, null, sgRingBlock, sgRingBlock, sgRingBlock, null, null, null],
@@ -121,9 +121,9 @@ mods.avaritia.ExtremeCrafting.addShaped(sgLargeCapacitor, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
-[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
-[null, null, sgFoil, CreativeEnergyBank, UEVFieldGen, CreativeEnergyBank, sgFoil, null, null],
-[null, null, sgFoil, UEVFieldGen, CreativeEnergyBank, UEVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
+[null, null, sgFoil, CreativeEnergyBank, UVFieldGen, CreativeEnergyBank, sgFoil, null, null],
+[null, null, sgFoil, UVFieldGen, CreativeEnergyBank, UVFieldGen, sgFoil, null, null],
 [null, null, null, sgFoil, sgFoil, sgFoil, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);
@@ -138,7 +138,7 @@ mods.avaritia.ExtremeCrafting.addShaped(sgIrisBlade, [
 [null, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null, null],
 [<ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null, null],
-[<ore:blockTitanium>, UEVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
+[<ore:blockTitanium>, UVPiston, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, null],
 [SuperconductingCoil, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>, <ore:blockTitanium>]]);
 
 // ---sgIrisUpgrade
@@ -169,15 +169,15 @@ mods.avaritia.ExtremeCrafting.addShaped(sgRFPowerAcceptor, [
 
 // ---sgOpenComputerInterface
 mods.avaritia.ExtremeCrafting.addShaped(sgOpenComputerInterface, [
-[Nanocircuit, UEVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVSensor, Nanocircuit],
-[UEVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVEmitter],
+[Nanocircuit, UVEmitter, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVSensor, Nanocircuit],
+[UVSensor, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVEmitter],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, Nanocircuit, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil],
 [<ore:blockNaquadahAlloy>, null, null, SuperconductingCoil, SuperconductingCoil, SuperconductingCoil, null, null, <ore:blockNaquadahAlloy>],
 [<ore:blockNaquadahAlloy>, null, SuperconductingCoil, null, SuperconductingCoil, null, SuperconductingCoil, null, <ore:blockNaquadahAlloy>],
-[UEVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UEVSensor],
-[Nanocircuit, UEVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UEVEmitter, Nanocircuit]]);
+[UVEmitter, SuperconductingCoil, null, null, SuperconductingCoil, null, null, SuperconductingCoil, UVSensor],
+[Nanocircuit, UVSensor, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, SuperconductingCoil, <ore:blockNaquadahAlloy>, <ore:blockNaquadahAlloy>, UVEmitter, Nanocircuit]]);
 
 // Leave this part here to copy&paste the variable names
 //sgRingBlock


### PR DESCRIPTION
I don't accept colen closing my PR without giving a valid reason.

Revert the change unless circuits for higher tiers are corrected.

Current circuit system goes 3 tiers above the starting circuit.
So example, with crystalprocessors, is:
IV -> LuV -> ZPM -> UV
UHV Crystalprocessors don't exist, next tier is wetware
Wetware goes LuV -> ZPM -> UV -> UHV

Then there's bioware
bioware goes:
ZPM -> UV -> UHV -> UEV -> UIV -> UMV
with UMV actually requiring 8 UIV circuits instead of 2 for some reasons... this is 256 ZPM circuits for 1 UMV
Just for reference this is 32 times more expensive than normal circuits, UV crystalprocessors only actually requiring 8 IV circuits

Game is clearly missing a circuit line starting from UV and another one starting from UHV
Adding those can make the UMV circuits actually possible. Stargate nerf should come after those circuits are made possible if they require those.

Other possibility is to make stargate require less power and only up to UEV circuits.