### PR TITLE
Remove mention of the MB sifter 13% output bonus, since it's not there anymore

### DIFF
--- a/resources/minecraft/lang/en_US.lang
+++ b/resources/minecraft/lang/en_US.lang
@@ -5682,7 +5682,7 @@ gtnh.quest1419.desc=...when it means you don't have to strip naked to recharge y
 
 # Quest.1420 - §9§lShake That Booty...
 gtnh.quest1420.name=§9§lShake That Booty...
-gtnh.quest1420.desc=...out of the purified ores. Anyways, a Large Sifter will increase your sifting rate significantly. What will you do with all these gems??%n%n§3Has a 13% bonus output, which kinda breaks the platline balance.%n%nYou need one more casing if you don't want to use 2 energy hatches.
+gtnh.quest1420.desc=...out of the purified ores. Anyways, a Large Sifter will increase your sifting rate significantly. What will you do with all these gems??%n%n§3You need one more casing if you don't want to use 2 energy hatches.
 
 # Quest.1421 - Hulk Smash!
 gtnh.quest1421.name=Hulk Smash!


### PR DESCRIPTION
I couldn't find the MR with the corresponding code change for reference, but according to my in-game measurements and a few discussions on Discord, it seems the 13% output bonus on the multiblock sifter is not there anymore.

Therefore, it makes sense to remove its mention from the questbook.