### PR TITLE
Update Gregtech.zs

### DIFF
--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -1319,7 +1319,13 @@ mods.tconstruct.Casting.addTableRecipe(<gregtech:gt.metaitem.01:32375>, <liquid:
 //--- Seismic Prospector EV
 <gregtech:gt.blockmachines:1173>.addTooltip("Work Area 128 Blocks Radius = 256 Chunks");
 
+// --- Old Tooltips for circuits (stupid IC2 ARR).
 
+// LV
+<IC2:itemPartCircuit>.addTooltip(format.gray("LV-tier"));
+
+// HV
+<IC2:itemPartCircuitAdv>.addTooltip(format.yellow("HV-tier"));
 
 
 // --- Ordict Combs ---


### PR DESCRIPTION
Re-add IC2 tooltips to HV/LV circuits because ARR (at least they're coloured right now...).