### PR TITLE
Removed obsolete sleeping bag sleep height warning

### DIFF
--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -12,7 +12,6 @@
 	<ToolTip ItemName="GregsLighting:ic2ElectricFloodlight" ToolTip="§4Maximum voltage in: 32 EU/t"/>
 	<ToolTip ItemName="IguanaTweaksTConstruct:clayBucketLava" ToolTip="§4You need Gloves for it?"/>
 	<ToolTip ItemName="minecraft:lava_bucket" ToolTip="§4You need Gloves for it?"/>
-	<ToolTip ItemName="OpenBlocks:sleepingBag" ToolTip="§4Don't use above y-level 128"/>
 	<ToolTip ItemName="RIO:item.chip.upgrade:2" ToolTip="§4Disabled Item; No recipe"/>
 	<ToolTip ItemName="Thaumcraft:ItemManaBean" ToolTip="§4left click disabled"/>
 	<ToolTip ItemName="Thaumcraft:WandCasting:36" ToolTip="§4Prolonged use is not recommended..."/>


### PR DESCRIPTION
Sleeping height bug is patched by GT ++ in java/gtPlusPlus/plugin/fixes/vanilla/VanillaBedHeightFix.java since https://github.com/GTNewHorizons/GTplusplus/commit/e199da91c8b6614caca1f056fbaab8cae01df32b