### PR TITLE
Enable MagicBees + Botania integration

### DIFF
--- a/config/MagicBees.cfg
+++ b/config/MagicBees.cfg
@@ -17,7 +17,7 @@ botaniaplugin {
     D:hiveacynthPrincessSpawnRate=0.09
 
     # Rate at which the Hiveacynth will produce a Pristine Princess, when it produces a princess. Default: 0.15. Setting to 0 will disable, setting to 1 will make every Princess produced pristine..
-    D:hiveacynthPristineRate=0.15
+    D:hiveacynthPristineRate=0
 
     # Rate at which the Hiveacynth applies rain resist to spawned bees. Default: 0.1 Setting to 0 will disable.
     D:hiveacynthRainResistRate=0.1
@@ -91,7 +91,7 @@ modules {
     B:AppliedEnergistics2=true
     B:ArsMagica=false
     B:BloodMagic=true
-    B:Botania=false
+    B:Botania=true
     B:EquivalentExchange=false
     B:ExtraBees=true
     B:RedstoneArsenal=false

--- a/scripts/Magic-Bees.zs
+++ b/scripts/Magic-Bees.zs
@@ -587,6 +587,23 @@ mods.thaumcraft.Research.refreshResearchRecipe("MB_GrafterVoid");
 
 
 
+// --- Botania integration ---
+
+// --- Beegonia (mana from bees)
+mods.botania.Apothecary.removeRecipe("beegonia");
+mods.botania.Apothecary.addRecipe("beegonia", [<ore:flowerIngredientWhite>, <ore:flowerIngredientYellow>, <ore:flowerIngredientYellow>, <ore:flowerIngredientBlack>, <ore:powderMana>, <ore:powderMana>, <ore:powderMana>, <ore:flowerAnemoneWhite>]);
+
+// --- Hiveacynth (bees from mana)
+mods.botania.Apothecary.removeRecipe("hiveacynth");
+mods.botania.Apothecary.addRecipe("hiveacynth", [<ore:flowerIngredientLightBlue>, <ore:flowerIngredientCyan>, <ore:flowerIngredientCyan>, <ore:flowerIngredientBlue>, <ore:powderMana>, <MagicBees:wax:1>, <MagicBees:miscResources:7>, <ore:powderMana>, <ore:redstoneRoot>, <ore:runeSpringB>, <ore:flowerIcyIris>]);
+
+// --- Hibeescus (ignoble to pristine bees)
+mods.botania.Apothecary.removeRecipe("hibeescus");
+mods.botania.Apothecary.addRecipe("hibeescus",  [<ore:flowerIngredientOrange>, <ore:flowerIngredientMagenta>, <ore:flowerIngredientMagenta>, <ore:flowerIngredientMagenta>, <ore:flowerIngredientRed>, <ore:powderMana>, <MagicBees:wax:1>, <MagicBees:wax:2>, <ore:runeEnvyB>, <ore:runeGreedB>, <ore:runePrideB>, <MagicBees:miscResources:10>, <ore:redstoneRoot>, <ore:eternalLifeEssence>, <ore:flowerHibiscusPink>]);
+
+
+
+
 // --- Ore dict stuff ---
 
 


### PR DESCRIPTION
Magic bees support part 2/2
- Enables magic bees' builtin botania integration
- Removes pristine bee drops from hiveacynth - its on par with the vanilla swarmer and far less expensive than gendustry and those can't do it either.
- Make hiveacynth require HV + soulful bee branch
- Make hibeescus require IV + multiple MB bee branches (this is the flower that turns ignobles into pristines).

Part 1 (required) is at https://github.com/GTNewHorizons/Botanic-horizons/pull/8