### PR TITLE
De-conflicts the potion ids for botania. Requires mod support to work.

### DIFF
--- a/config/Botania.cfg
+++ b/config/Botania.cfg
@@ -1,0 +1,11 @@
+# Configuration file
+
+potions {
+    I:allure=128
+    I:bloodthirst=129
+    I:clear=130
+    I:emptiness=131
+    I:featherFeet=132
+    I:soulCross=133
+}
+


### PR DESCRIPTION
Botania potions fix part 3/3 - see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9568

- Move the botania potion IDs to use empty slots.

Note: do not merge or test this without applying part 1 and 2 first, or things will break.
https://github.com/GTNewHorizons/Hodgepodge/pull/56
https://github.com/GTNewHorizons/Botania/pull/7