### PR TITLE
Disable useless EBF gas crap

### DIFF
--- a/config/bartworks.cfg
+++ b/config/bartworks.cfg
@@ -418,7 +418,7 @@ system {
     B:"Disable BioLab"=false
 
     # This switch disables extra gas recipes for the EBF, i.e. Xenon instead of Nitrogen
-    B:"Disable Extra Gases for EBF"=false
+    B:"Disable Extra Gases for EBF"=true
 
     # Enables or Disables GT++ Logging.
     B:"Disable GT++ Logging"=false


### PR DESCRIPTION
- Cuts down on NEI bloat (like 200+ pages of recipes...)
- These overwrite existing recipes, so you can't set a recipe with radon to a specific time...

Need to re-add some argon recipes and remove some others, but neon, krypton, Og are all utterly useless for EBFing and afaik no one uses them. Radon left as is.