### PR TITLE
Disable registry name tooltip from EnderCore

### DIFF
--- a/config/endercore/endercore.cfg
+++ b/config/endercore/endercore.cfg
@@ -76,7 +76,7 @@ general {
     # 2 - Only with shift
     # 3 - Only in debug mode
     # [range: 0 ~ 3, default: 3]
-    I:showRegistryNameTooltips=3
+    I:showRegistryNameTooltips=0
 
     # 0 - Do nothing
     # 1 - Remove stacktraces, leave 1-line missing texture errors


### PR DESCRIPTION
There are two, though I don't know which mod adds the another one.
![2022-03-09_12 32 23](https://user-images.githubusercontent.com/40035906/157367984-37dfaadc-ac6d-4987-9b9a-29d11d69bb3a.png)
