### PR TITLE
Liquid Air prospecting planet buffs

### DIFF
--- a/config/GregTech/GregTech.cfg
+++ b/config/GregTech/GregTech.cfg
@@ -633,7 +633,7 @@ undergroundfluid {
             I:DecreasePerOperationAmount=5
 
             # Max amount generation (per operation, sets the VeinData) 80000 MAX
-            I:MaxAmount=20
+            I:MaxAmount=200
 
             # Min amount generation (per operation, sets the VeinData) 0 MIN
             I:MinAmount=2
@@ -839,7 +839,7 @@ undergroundfluid {
             I:DecreasePerOperationAmount=5
 
             # Max amount generation (per operation, sets the VeinData) 80000 MAX
-            I:MaxAmount=40
+            I:MaxAmount=300
 
             # Min amount generation (per operation, sets the VeinData) 0 MIN
             I:MinAmount=4
@@ -982,7 +982,7 @@ undergroundfluid {
             I:DecreasePerOperationAmount=5
 
             # Max amount generation (per operation, sets the VeinData) 80000 MAX
-            I:MaxAmount=20
+            I:MaxAmount=400
 
             # Min amount generation (per operation, sets the VeinData) 0 MIN
             I:MinAmount=0


### PR DESCRIPTION
Callisto: 200
Pluto: 300
Barnarde: 400

Instead of the awful original rates where it would be silly otherwise to go for this stuff, it's now a lot more worth while to go for