### PR TITLE
Increase max distance between traversable anchors

### DIFF
--- a/config/enderio/EnderIO.cfg
+++ b/config/enderio/EnderIO.cfg
@@ -27,7 +27,7 @@
     I:travelAnchorCooldown=40
 
     # Maximum number of blocks that can be traveled from one travel anchor to another.
-    I:travelAnchorMaxDistance=128
+    I:travelAnchorMaxDistance=512
 
     # Travel Anchors send a chat warning when skipping inaccessible anchors
     B:travelAnchorSkipWarning=true


### PR DESCRIPTION
The 128 limitation actually presents issues with larger bases