### PR TITLE
make 5.2 the default lua version

### DIFF
--- a/config/OpenComputers.cfg
+++ b/config/OpenComputers.cfg
@@ -193,7 +193,7 @@ opencomputers {
 
       # Whether to make the Lua 5.3 architecture the default architecture.
       # If enabled, a crafted CPU will first be the Lua 5.3 architecture.
-      defaultLua53=true
+      defaultLua53=false
 
       # Whether to make the Lua 5.3 architecture available. If enabled, you
       # can reconfigure any CPU to use the Lua 5.3 architecture.


### PR DESCRIPTION
finally adress https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8048: lua will by default be 5.2 but users will still be able to use 5.3 and newly crafted cpus will need to be changed to 5.3 manually, the same way it needs to be changed to 5.2 currently.