### PR TITLE
Add a shapeless recipe to clear RIO location chip

### DIFF
--- a/scripts/RemoteIO.zs
+++ b/scripts/RemoteIO.zs
@@ -162,6 +162,8 @@ recipes.addShaped(<RIO:intelligentWorkbench>, [
 // --- Items ---
 
 
+// --- Location Chip
+recipes.addShapeless(Location, [<RIO:item.chip.location>]);
 
 // --- IO Tool
 recipes.addShaped(IOTool, [


### PR DESCRIPTION
context: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10348

This is a feature that is already available in the RIO

https://github.com/GTNewHorizons/RemoteIO/blob/7d9df57c47f8832302ebeda9f9cd6630fd7f4e6f/src/main/java/remoteio/common/RemoteIO.java#L62-L63
```java
// Used for clearing location chips
GameRegistry.addShapelessRecipe(new ItemStack(ModItems.locationChip), new ItemStack(ModItems.locationChip));
```