### PR TITLE
Halve all Molecular Transformer recipe times

### DIFF
--- a/config/AdvancedSolarPanel_MTRecipes.cfg
+++ b/config/AdvancedSolarPanel_MTRecipes.cfg
@@ -11,23 +11,23 @@ version=1.0
 ##################################################################################################
 
 #redstone -> ruby
-minecraft:redstone:1; gregtech:gt.metaitem.01-2502:1; 5000000
+minecraft:redstone:1; gregtech:gt.metaitem.01-2502:1; 2500000
 #GT Cheese(and pams chesse) -> GalactiCraft Chese
-gregtech:gt.metaitem.02-32558:1; GalacticraftCore:item.cheeseCurd:1; 5000000
-harvestcraft:cheeseItem:1; GalacticraftCore:item.cheeseCurd:1; 5000000
+gregtech:gt.metaitem.02-32558:1; GalacticraftCore:item.cheeseCurd:1; 2500000
+harvestcraft:cheeseItem:1; GalacticraftCore:item.cheeseCurd:1; 2500000
 #certus <-> nether quartz
-gregtech:gt.metaitem.01-2522:1; gregtech:gt.metaitem.01-2516:1; 500000
-gregtech:gt.metaitem.01-2516:1; gregtech:gt.metaitem.01-2522:1; 500000
+gregtech:gt.metaitem.01-2522:1; gregtech:gt.metaitem.01-2516:1; 250000
+gregtech:gt.metaitem.01-2516:1; gregtech:gt.metaitem.01-2522:1; 250000
 # copper -> Nickel
-gregtech:gt.metaitem.01-2035:1; gregtech:gt.metaitem.01-2034:1; 5000000
+gregtech:gt.metaitem.01-2035:1; gregtech:gt.metaitem.01-2034:1; 2500000
 # Tin -> Silver
-gregtech:gt.metaitem.01-2057:1; gregtech:gt.metaitem.01-2054:1; 5000000
+gregtech:gt.metaitem.01-2057:1; gregtech:gt.metaitem.01-2054:1; 2500000
 # Silver -> Gold
-gregtech:gt.metaitem.01-2054:1; gregtech:gt.metaitem.01-2086:1; 10000000
+gregtech:gt.metaitem.01-2054:1; gregtech:gt.metaitem.01-2086:1; 5000000
 #Gold -> Platinum
-gregtech:gt.metaitem.01-2086:1; gregtech:gt.metaitem.01-2085:1; 80000000
+gregtech:gt.metaitem.01-2086:1; gregtech:gt.metaitem.01-2085:1; 40000000
 # Yellow garnet <-> Red Garnet
-gregtech:gt.metaitem.01-2527:1; gregtech:gt.metaitem.01-2528:1; 5000000
-gregtech:gt.metaitem.01-2528:1; gregtech:gt.metaitem.01-2527:1; 5000000
+gregtech:gt.metaitem.01-2527:1; gregtech:gt.metaitem.01-2528:1; 2500000
+gregtech:gt.metaitem.01-2528:1; gregtech:gt.metaitem.01-2527:1; 2500000
 #Carbon -> graphene
-gregtech:gt.metaitem.01-2010:1; gregtech:gt.metaitem.01-2819:1; 10000000
+gregtech:gt.metaitem.01-2010:1; gregtech:gt.metaitem.01-2819:1; 5000000


### PR DESCRIPTION
Originally the MT had a 2x speed boost that was unintended. Even with this boost, the multi wasn't considered very good, but it got fixed since it was still unintended. This effectively brings back that speed boost as a buff.

Sunnarium will be changed separately.