### PR TITLE
Add missing recipes to OC

### DIFF
--- a/config/opencomputers/gtnh.recipes
+++ b/config/opencomputers/gtnh.recipes
@@ -329,3 +329,7 @@ chipDiamond = false
 gemDiamond = false
 
 beekeeperUpgrade = true
+
+configuratorUpgrade = true
+
+ritegUpgrade = true


### PR DESCRIPTION
[Server thread/WARN] [OpenComputers/OpenComputers]: No recipe for 'configuratorUpgrade', you will not be able to craft this item. To suppress this warning, disable the recipe (assign `false` to it).
[Server thread/WARN] [OpenComputers/OpenComputers]: No recipe for 'ritegUpgrade', you will not be able to craft this item. To suppress this warning, disable the recipe (assign `false` to it).

It also leads to a message being sent to the player after joining: "There were errors loading one or more recipes. Some items may be uncraftable. Please check your log file for more information."