### PR TITLE
Enable static loading on new space stations

### DIFF
--- a/config/Galacticraft/core.conf
+++ b/config/Galacticraft/core.conf
@@ -18,7 +18,7 @@ dimensions {
     B:"Disable rockets from returning to Overworld"=false
 
     # Set this to true to have an automatic /gckeeploaded for any new Space Station created.
-    B:"Set new Space Stations to be static loaded"=false
+    B:"Set new Space Stations to be static loaded"=true
 
     # IDs to load at startup, and keep loaded until server stops. Can be added via /gckeeploaded
     I:"Static Loaded Dimensions" <


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10512.

Tested in a creative world by running /gckeeploaded on a space station that was previously affected by this bug then reloading the world, which kept the space station loaded.