### PR TITLE
Fixed advanced Mutatron recipe

### DIFF
--- a/scripts/Gendustry.zs
+++ b/scripts/Gendustry.zs
@@ -303,7 +303,7 @@ mods.avaritia.ExtremeCrafting.addShaped(AdvMutatron, [
 [null, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gendustry:Replicator>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gendustry:Liquifier>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, Labware, GeneticsProcessor, <gregtech:gt.metaitem.01:32656>, GeneticsProcessor, Labware, <gregtech:gt.metaitem.01:21070>, null],
-[null, <gregtech:gt.metaitem.01:21070>, <gendustry:Sampler>, <gregtech:gt.comb:85>, <gendustry:MutatronAdv>, <gregtech:gt.comb:85>, <gendustry:Imprinter>, <gregtech:gt.metaitem.01:21070>, null],
+[null, <gregtech:gt.metaitem.01:21070>, <gendustry:Sampler>, <gregtech:gt.comb:85>, <Genetics:misc:11>, <gregtech:gt.comb:85>, <gendustry:Imprinter>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, Labware, GeneticsProcessor, <gregtech:gt.metaitem.01:32656>, GeneticsProcessor, Labware, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gendustry:Transposer>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gendustry:Extractor>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, null],

--- a/scripts/Gendustry.zs
+++ b/scripts/Gendustry.zs
@@ -303,7 +303,7 @@ mods.avaritia.ExtremeCrafting.addShaped(AdvMutatron, [
 [null, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gendustry:Replicator>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gendustry:Liquifier>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, Labware, GeneticsProcessor, <gregtech:gt.metaitem.01:32656>, GeneticsProcessor, Labware, <gregtech:gt.metaitem.01:21070>, null],
-[null, <gregtech:gt.metaitem.01:21070>, <gendustry:Sampler>, <gregtech:gt.comb:85>, <Genetics:misc:11>, <gregtech:gt.comb:85>, <gendustry:Imprinter>, <gregtech:gt.metaitem.01:21070>, null],
+[null, <gregtech:gt.metaitem.01:21070>, <gendustry:Sampler>, <gregtech:gt.comb:85>, Mutatron, <gregtech:gt.comb:85>, <gendustry:Imprinter>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, Labware, GeneticsProcessor, <gregtech:gt.metaitem.01:32656>, GeneticsProcessor, Labware, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gendustry:Transposer>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gregtech:gt.metaitem.01:21327>, <gendustry:Extractor>, <gregtech:gt.metaitem.01:21070>, null],
 [null, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, <gregtech:gt.metaitem.01:21070>, null],

--- a/scripts/Gendustry.zs
+++ b/scripts/Gendustry.zs
@@ -266,9 +266,9 @@ mods.avaritia.ExtremeCrafting.addShaped(MutagenProducer, [
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, MutagenTank, <ore:plateBlackPlutonium>, PowerModule, <ore:plateBlackPlutonium>, MutagenTank, null, null],
-[null, null, <gregtech:gt.metaitem.01:32617>, <gregtech:gt.metaitem.01:32657>, GeneticsProcessor, <gregtech:gt.metaitem.01:32657>, <gregtech:gt.metaitem.01:32617>, null, null],
+[null, null, <gregtech:gt.metaitem.01:32616>, <gregtech:gt.metaitem.01:32656>, GeneticsProcessor, <gregtech:gt.metaitem.01:32656>, <gregtech:gt.metaitem.01:32616>, null, null],
 [null, null, BeeReceptacle, OsmiumGear, HardCasing, OsmiumGear, BeeReceptacle, null, null],
-[null, null, <gregtech:gt.metaitem.01:32617>, <gregtech:gt.metaitem.01:32608>, GeneticsProcessor, <gregtech:gt.metaitem.01:32608>, <gregtech:gt.metaitem.01:32617>, null, null],
+[null, null, <gregtech:gt.metaitem.01:32616>, <gregtech:gt.metaitem.01:32607>, GeneticsProcessor, <gregtech:gt.metaitem.01:32607>, <gregtech:gt.metaitem.01:32616>, null, null],
 [null, null, MutagenTank, <ore:plateBlackPlutonium>, PowerModule, <ore:plateBlackPlutonium>, MutagenTank, null, null],
 [null, null, null, null, null, null, null, null, null],
 [null, null, null, null, null, null, null, null, null]]);


### PR DESCRIPTION
instead of requiring the advanced mutatron in the recipe FOR the advanced mutatron, I switched it to an integrated casing. Oops-

![image](https://user-images.githubusercontent.com/48415331/182333099-985d0eaf-82ea-4114-ac64-d98d775da399.png)

+ mutagen producer:
![image](https://user-images.githubusercontent.com/48415331/182333155-82627ee9-83ad-4c6d-80b8-fd707c486635.png)
