### PR TITLE
Modifying Industrial Apiary

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -278,6 +278,7 @@ modules {
             com.supsolpans.tiles.TilePhotonicSolarPanel
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
+            gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_IndustrialApiary
          >
     }
 

--- a/scripts/Gendustry.zs
+++ b/scripts/Gendustry.zs
@@ -382,9 +382,9 @@ recipes.addShaped(<gendustry:ApiaryUpgrade:5>, [
 
 // --- Automation Upgrade
 recipes.addShaped(<gendustry:ApiaryUpgrade:14>, [
-[PalladiumSmallGear, TitaniumGear, PalladiumSmallGear],
-[<minecraft:redstone_torch>, UpFrame, <minecraft:redstone_torch>],
-[OsmiumSmallGear, EVPiston, OsmiumSmallGear]]);
+[<gregtech:gt.metaitem.01:32640>, <Genetics:misc:10>, <gregtech:gt.metaitem.01:32640>],
+[<Genetics:misc:10>, UpFrame, <Genetics:misc:10>],
+[<gregtech:gt.metaitem.01:32650>, <Genetics:misc:10>, <gregtech:gt.metaitem.01:32650>]]);
 
 // --- Humidifier Upgrade
 recipes.addShaped(<gendustry:ApiaryUpgrade:4>, [
@@ -539,14 +539,7 @@ Assembler.addRecipe(EnviroProcessor, <dreamcraft:item.EnvironmentalCircuit>, <gr
 Assembler.addRecipe(EnviroProcessor, <dreamcraft:item.EnvironmentalCircuit>, <gregtech:gt.metaitem.03:32089>, <liquid:liquiddna> * 500, 400, 1920);
 
 // --- Upgrade Frame
-Assembler.addRecipe(UpFrame, <dreamcraft:item.IndustryFrame>, <gregtech:gt.metaitem.03:32087>, 400, 1920);
-// -
-Assembler.addRecipe(UpFrame, <dreamcraft:item.IndustryFrame>, <gregtech:gt.metaitem.03:32092>, 400, 1920);
-// -
-Assembler.addRecipe(UpFrame, <dreamcraft:item.IndustryFrame>, <gregtech:gt.metaitem.03:32096>, 400, 1920);
-// -
-Assembler.addRecipe(UpFrame, <dreamcraft:item.IndustryFrame>, <gregtech:gt.metaitem.01:32706>, 400, 1920);
-
+Assembler.addRecipe(UpFrame, <gregtech:gt.metaitem.03:32007>, <Genetics:misc:10>, 200, 24);
 
 // --- Item Ijector Cover
 Assembler.addRecipe(<gendustry:EjectCover>, <gregtech:gt.metaitem.01:17052>, <IC2:upgradeModule:3>, 200, 1920);

--- a/scripts/Genetics.zs
+++ b/scripts/Genetics.zs
@@ -207,8 +207,7 @@ Assembler.addRecipe(<Genetics:misc:9>, <Forestry:chipsets:1>,  <gregtech:gt.meta
 Assembler.addRecipe(<Genetics:misc:11>, [<Forestry:hardenedMachine>, <Genetics:misc:10> * 2, <gregtech:gt.integrated_circuit:2> * 0], <liquid:molten.glowstone> * 288, 1500, 480);
 
 // --- Integrated CPU
-Assembler.addRecipe(<Genetics:misc:10>, [<gregtech:gt.metaitem.03:32106>, <ore:circuitData> * 2, <gregtech:gt.integrated_circuit:2> * 0], <liquid:molten.glowstone> * 144, 600, 480);
-
+Assembler.addRecipe(<Genetics:misc:10>, [<gregtech:gt.metaitem.03:32106>, <Forestry:thermionicTubes:5>, <gregtech:gt.integrated_circuit:2> * 0], <liquid:molten.glowstone> * 144, 600, 30);
 
 // --- Mixer Recipes ---
 

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -570,16 +570,10 @@ recipes.addShaped(<gregtech:gt.metaitem.02:22532>, [[<ore:stickEnderPearl>, <ore
 recipes.addShaped(<gregtech:gt.metaitem.02:22533>, [[<ore:stickEnderEye>, <ore:craftingToolHardHammer>, <ore:stickEnderEye>]]);
 
 // --- Industrial Apiary
-mods.avaritia.ExtremeCrafting.addShaped(<gregtech:gt.blockmachines:9399>, [
-[null, null, null, null, null, null, null, null, null],
-[null, null, null, null, null, null, null, null, null],
-[null, null,  <ore:gearTungstenSteel>, <Forestry:alveary:6>, <gregtech:gt.metaitem.01:32604>, <Forestry:alveary:6>,  <ore:gearTungstenSteel>, null, null],
-[null, null, <Forestry:alveary:5>, <Forestry:alveary>, <Forestry:alveary:7>, <Forestry:alveary>, <Forestry:alveary:4>, null, null],
-[null, null, <gregtech:gt.metaitem.01:32604>, <Forestry:alveary:2>, <Forestry:apiculture>, <Forestry:alveary:2>, <gregtech:gt.metaitem.01:32604>, null, null],
-[null, null, <Forestry:alveary:5>, <Forestry:alveary>, <Forestry:alveary:7>, <Forestry:alveary>, <Forestry:alveary:4>, null, null],
-[null, null, <ore:gearTungstenSteel>, <Forestry:alveary:3>, <gregtech:gt.metaitem.01:32674>, <Forestry:alveary:3>,  <ore:gearTungstenSteel>, null, null],
-[null, null, null, null, null, null, null, null, null],
-[null, null, null, null, null, null, null, null, null]]);
+recipes.addShaped(<gregtech:gt.blockmachines:9399>, [
+[<ExtraBees:alveary:1>, <Forestry:chipsets:1>, <ExtraBees:alveary:1>],
+[<gregtech:gt.metaitem.01:32650>, <Forestry:sturdyMachine>, <gregtech:gt.metaitem.01:32650>],
+[<ExtraBees:alveary:3>, <Forestry:alveary:7>, <ExtraBees:alveary:3>]]);
 
 // --- Solar Panel LV 32 EU
 mods.avaritia.ExtremeCrafting.addShaped(<gregtech:gt.metaitem.01:32752>, [


### PR DESCRIPTION
Blacklisted from World Accelerator
Moved down to LV
New Recipes:

Industrial Apiary:
![image](https://user-images.githubusercontent.com/48415331/182704989-d7a1537f-9b83-4bd2-b0e5-9396752a213c.png)
Automation upgrade:
![image](https://user-images.githubusercontent.com/48415331/182705045-de6fc3a4-8d09-47a7-8593-99007687158f.png)
Integrated Circuit:
![image](https://user-images.githubusercontent.com/48415331/182705080-bcc53630-27f6-4f15-85f6-fe5af84b7c80.png)
Upgrade Frame:
![image](https://user-images.githubusercontent.com/48415331/182705159-f02ec30b-9b96-4349-b290-a8e1c96cdc38.png)
