### PR TITLE
Blacklist Gendustry Industrial Apiary from acceleration

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -278,7 +278,6 @@ modules {
             com.supsolpans.tiles.TilePhotonicSolarPanel
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
-            gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_IndustrialApiary
          >
     }
 

--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -279,6 +279,7 @@ modules {
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
             net.bdew.gendustry.machines.apiary.TileApiary
+            forestry.apiculture.tiles.TileApiary
          >
     }
 

--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -278,6 +278,7 @@ modules {
             com.supsolpans.tiles.TilePhotonicSolarPanel
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
+            net.bdew.gendustry.machines.apiary.TileApiary
          >
     }
 


### PR DESCRIPTION
Blacklist Gendustry Industrial Apiary from acceleration to force people to use the new version
Also why there was **gregtech** apiary ? Removed it.