### PR TITLE
Greatly reduce damage reduction on GS bosses

### DIFF
--- a/config/GalaxySpace/core.conf
+++ b/config/GalaxySpace/core.conf
@@ -135,7 +135,7 @@ general {
     D:crystalBossInvisibilityProbability=0.5
 
     # How much damage the player can deal at most to Evolved Crystal Boss, Evolved Blaze Boss and Evolved Ghast Boss (These bosses are supposed to be beaten by their own fireballs!)
-    D:baseBossDamage=3.0
+    D:baseBossDamage=100.0
 }
 
 


### PR DESCRIPTION
Despite what the config says, reflecting the fireballs back at these bosses does basically no damage. With the current damage limit of 3, these bosses end up being 5+ minutes of left click spam, which is very tedious.

Increasing the damage maximum to 100 makes them less of a useless time sink.