### PR TITLE
Modify Fluid Manipulator

### DIFF
--- a/scripts/Galacticraft.zs
+++ b/scripts/Galacticraft.zs
@@ -1090,7 +1090,7 @@ recipes.addShaped(<GalacticraftMars:item.itemBasicAsteroids:8>, [
 // --- Fluid Manipulator
 recipes.addShaped(<GalacticraftMars:item.null:6>, [
 [<gregtech:gt.metaitem.01:32612>, <gregtech:gt.blockmachines:5135>, <gregtech:gt.metaitem.01:32612>],
-[<gregtech:gt.blockmachines:5135>, <GalacticraftCore:item.oilCanisterPartial:1001>, <gregtech:gt.blockmachines:5135>],
+[<gregtech:gt.blockmachines:5135>, <IC2:itemCellEmpty>, <gregtech:gt.blockmachines:5135>],
 [<gregtech:gt.metaitem.01:32612>, <gregtech:gt.blockmachines:5135>, <gregtech:gt.metaitem.01:32612>]]);
 
 // --- Energy Beam Reflector


### PR DESCRIPTION
The Galacticraft cannister doesn't behave well with ae2, thus I changed it to a normal ic2 empty cell. 