### PR TITLE
add circuit alternatives for hyperrationing pipe

### DIFF
--- a/scripts/Extra-Utilities.zs
+++ b/scripts/Extra-Utilities.zs
@@ -1239,6 +1239,10 @@ Assembler.addRecipe(EExtractionPipe, <gregtech:gt.metaitem.01:17303> * 2, Energy
 Assembler.addRecipe(HyperRationingPipe, RationingPipe, <gregtech:gt.metaitem.01:32708>, 400, 64);
 // -
 Assembler.addRecipe(HyperRationingPipe, RationingPipe, <gregtech:gt.metaitem.01:32704>, 200, 64);
+// -
+Assembler.addRecipe(HyperRationingPipe, RationingPipe, <gregtech:gt.metaitem.03:32083>, 200, 64);
+// -
+Assembler.addRecipe(HyperRationingPipe, RationingPipe, <gregtech:gt.metaitem.03:32085>, 200, 64);
 
 // --- Trash Can
 Assembler.addRecipe(<ExtraUtilities:trashcan>, <gregtech:gt.metaitem.01:17032> * 4, <minecraft:ender_pearl>, 200, 30);


### PR DESCRIPTION
Just added the other EV circuits as options. That is already how it works for the other pipes.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10844