### PR TITLE
Blacklist GG Essentia Hatch

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -280,6 +280,7 @@ modules {
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
             net.bdew.gendustry.machines.apiary.TileApiary
             forestry.apiculture.tiles.TileApiary
+            goodgenerator.blocks.tileEntity.EssentiaHatch
          >
     }
 


### PR DESCRIPTION
Its a power generation option. Those are usually blacklisted.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10558