### PR TITLE
Add alternative algae recipe for glow coral

### DIFF
--- a/scripts/Biome-o-Plenty.zs
+++ b/scripts/Biome-o-Plenty.zs
@@ -123,6 +123,7 @@ recipes.addShapeless(<BiomesOPlenty:rocks>, [<BiomesOPlenty:rocks:1>]);
 
 // --- Glowing Coral
 recipes.addShapeless(<BiomesOPlenty:coral1:15>, [<BiomesOPlenty:coral2:8>, <ore:dustGlowstone>]);
+recipes.addShapeless(<BiomesOPlenty:coral1:15>, [<miscutils:item.BasicAgrichemItem:1>, <ore:dustGlowstone>]);
 
 // --- Pink Coral
 recipes.addShapeless(<BiomesOPlenty:coral1:12>, [<BiomesOPlenty:coral2:8>, <ore:dustGlowstone>, <ore:dyePink>]);


### PR DESCRIPTION
Adds an additional recipe for glow coral that uses gt++ algae instead of bop.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10422.