### PR TITLE
Removed Apiary from World acceleration

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -279,7 +279,6 @@ modules {
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
             net.bdew.gendustry.machines.apiary.TileApiary
-            forestry.apiculture.tiles.TileApiary
             goodgenerator.blocks.tileEntity.EssentiaHatch
          >
     }


### PR DESCRIPTION
Normal Apiary isn't meant for production but rather as a pre alveary way of mutating bees. Adding it to the blacklist removes another useful feature from the apiary and making bee mutation way worse. 

Oblivion Frames can be found, which is annoying
Mutagenic frames need plutonium 241, which is annoying.
The only remaining usefull bee mutation device is the mutator and alveary

Since Industrial Apiary is HV, there is no need to blacklist the normal apiary