### PR TITLE
Updated Infinity Line

### DIFF
--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,8 +182,8 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
-	"gendustry.bee.CosmicNeutronium" = DISABLED
-	"gendustry.bee.InfinityCatalyst" = DISABLED
-	"gendustry.bee.Infinity" = DISABLED
+	"gregtech.bee.speciesCosmicneutronium" = REQUIREMENTS
+	"gregtech.bee.speciesInfinityCatalyst" = REQUIREMENTS
+	"gregtech.bee.speciesInfinity" = REQUIREMENTS
   }
 }


### PR DESCRIPTION
Blacklisted infinity, infinity catalyst and cosmic neutronium from mutatron (didn't work prior) also changed it to REQUIREMENTS instead of DISABLED since their combs will be used as a catalyst in DTPF recipes and not for primarly centrifuging recipes anymore. 