### PR TITLE
input filter default off

### DIFF
--- a/config/GregTech/Client.cfg
+++ b/config/GregTech/Client.cfg
@@ -24,7 +24,7 @@ colormodulation {
 
 
 preference {
-    B:mInputBusInitialFilter_true=true
+    B:mInputBusInitialFilter_true=false
     B:mSingleBlockInitialFilter_false=false
 }
 


### PR DESCRIPTION
turns out input filter default behavior is controlled by a config, so i updated it to reflect the change we wanted to do in code
(see https://github.com/GTNewHorizons/GT5-Unofficial/pull/1167)