### PR TITLE
Mutatron update

### DIFF
--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,16 +182,11 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
-<<<<<<< Updated upstream
-	"gregtech.bee.speciesCosmicneutronium" = REQUIREMENTS
-	"gregtech.bee.speciesInfinityCatalyst" = REQUIREMENTS
-	"gregtech.bee.speciesInfinity" = REQUIREMENTS
-=======
+    "extrabees.species.chad" = REQUIREMENTS
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinityCatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED
 	"gregtech.bee.speciesIndium" = DISABLED
 	"gregtech.bee.speciesAmericium" = DISABLED
->>>>>>> Stashed changes
   }
 }

--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,7 +182,6 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
-    "extrabees.species.chad" = REQUIREMENTS
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinityCatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED

--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,8 +182,16 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
+<<<<<<< Updated upstream
 	"gregtech.bee.speciesCosmicneutronium" = REQUIREMENTS
 	"gregtech.bee.speciesInfinityCatalyst" = REQUIREMENTS
 	"gregtech.bee.speciesInfinity" = REQUIREMENTS
+=======
+	"gregtech.bee.speciesCosmicneutronium" = DISABLED
+	"gregtech.bee.speciesInfinityCatalyst" = DISABLED
+	"gregtech.bee.speciesInfinity" = DISABLED
+	"gregtech.bee.speciesIndium" = DISABLED
+	"gregtech.bee.speciesAmericium" = DISABLED
+>>>>>>> Stashed changes
   }
 }


### PR DESCRIPTION
Add Americium and Indium bee to blacklist. 
Modified Infinity bees to be disabled from mutatron, which means that they have to be bred by hand now.