### PR TITLE
Fix #11851

### DIFF
--- a/config/defaultserverlist.json
+++ b/config/defaultserverlist.json
@@ -22,7 +22,7 @@
     "MMC No TP (Am+Aus2)": "gtnh-im-na.moddedminecraft.club",
     "Earthquake GTNH (US West)": "aragil.ddns.net",
     "Zephyrus (NL)": "gtnh.zephyrus-mc.com",
-    "MineYourMine GTNH (EU)": "horizons.mineyourmind.net"
+    "MineYourMine GTNH (EU)": "horizons.mineyourmind.net",
     "ValhallaMC (EU)": "gtnh.valhallamc.io"
   },
   "DO_NOT_EDIT_prevDefaultServers": []

--- a/servers.json
+++ b/servers.json
@@ -17,5 +17,6 @@
     "Earthquake GTNH (US West)": "aragil.ddns.net",
     "Zephyrus (NL)": "gtnh.zephyrus-mc.com",
     "MineYourMine GTNH (EU)": "horizons.mineyourmind.net",
-	"Arcturus Network GTNH (EU)": "play.arcturus-official.eu"
+    "Arcturus Network GTNH (EU)": "play.arcturus-official.eu",
+    "ValhallaMC (EU)": "gtnh.valhallamc.io"
 }


### PR DESCRIPTION
Remember:
- Entries in a list must be separated by commas
- `servers.json` is the master list, not `config/defaultserverlist.json`

(@superhealing @Dream-Master )