### PR TITLE
remove normal apiary from WA blacklist

### DIFF
--- a/config/GTNewHorizons/dreamcraft.cfg
+++ b/config/GTNewHorizons/dreamcraft.cfg
@@ -279,7 +279,6 @@ modules {
             gtPlusPlus.core.tileentities.general.TileEntityFishTrap
             gtPlusPlus.core.tileentities.general.TileEntityDecayablesChest
             net.bdew.gendustry.machines.apiary.TileApiary
-            forestry.apiculture.tiles.TileApiary
             goodgenerator.blocks.tileEntity.EssentiaHatch
          >
     }


### PR DESCRIPTION
Let's remove normal apiary from WA blacklist. If early game the player wants to pay EUs in exchange of extra speed, that is fine, especially for breeding purposes (rip the player if he does it on a radioactive bee). If player wants to abuse it for production, there are way better solutions than this, so if he wants to shoot a bullet in the foot, that's up to them.