### PR TITLE
Add assembler recipes for Apiary, Scented Paneling, all Alveary upgrades

### DIFF
--- a/scripts/Extra-Bees.zs
+++ b/scripts/Extra-Bees.zs
@@ -4,6 +4,7 @@
 
 // --- Imports ---
 
+import mods.gregtech.Assembler;
 import mods.forestry.Squeezer;
 import mods.gregtech.Pulverizer;
 import mods.gregtech.Extractor;
@@ -214,6 +215,29 @@ mods.thaumcraft.Research.addArcanePage("SOULFRAME", <ExtraBees:hiveFrame.soul>);
 mods.thaumcraft.Warp.addToResearch("SOULFRAME", 1);
 
 
+// --- Assembler Recipes
+
+
+// -- Mutator
+Assembler.addRecipe(<ExtraBees:alveary>, [<Forestry:alveary>, <Forestry:thermionicTubes:12> * 4, <gregtech:gt.metaitem.01:17533> * 2, <gregtech:gt.metaitem.01:17532> * 2, <ExtraBees:hiveFrame.soul>], <liquid:for.honey> * 3750, 1200, 120);
+
+// -- Frame Housing
+Assembler.addRecipe(<ExtraBees:alveary:1>, [<Forestry:alveary>, <Forestry:thermionicTubes:10> * 4, <Forestry:frameProven>, <Forestry:frameProven>, <Forestry:frameProven>, <Forestry:frameProven>, <gregtech:gt.blockmachines:4985>], <liquid:for.honey> * 3750, 1200, 120);
+
+// -- Rain Shield
+Assembler.addRecipe(<ExtraBees:alveary:2>, [<Forestry:alveary>, <Forestry:thermionicTubes:8> * 4, <IC2:blockRubber> * 4, <minecraft:brick_block>], <liquid:for.honey> * 3750, 1200, 120);
+
+// --- Alveary Lighting
+Assembler.addRecipe(<ExtraBees:alveary:3>, [<Forestry:alveary>, <Forestry:thermionicTubes:2> * 4, <minecraft:stained_glass:*> * 4, <minecraft:redstone_lamp>], <liquid:for.honey> * 3750, 1200, 120);
+
+// --- Electrical Stimulator
+Assembler.addRecipe(<ExtraBees:alveary:4>, [<Forestry:alveary>, <Forestry:thermionicTubes:1> * 4, <gregtech:gt.blockmachines:1460> * 2, <Forestry:chipsets:2> * 2, <gregtech:gt.metaitem.01:32602>], <liquid:for.honey> * 3750, 1200, 120);
+
+// --- Hatchery
+Assembler.addRecipe(<ExtraBees:alveary:5>, [<Forestry:alveary>, <Forestry:thermionicTubes:3> * 4, <gregtech:gt.metaitem.01:17810> * 2, <gregtech:gt.metaitem.01:32631> * 2, <Forestry:apiculture>], <liquid:for.honey> * 3750, 1200, 120);
+
+// -- Alveary Transmission
+Assembler.addRecipe(<ExtraBees:alveary:6>, [<Forestry:alveary>, <Forestry:thermionicTubes> * 4, <ore:circuitAdvanced>, <gregtech:gt.blockmachines:1587> * 3, <gregtech:gt.blockmachines:13>], <liquid:for.honey> * 3750, 1200, 120);
 
 
 // --- Pulverizer Recipes ---

--- a/scripts/Forestry.zs
+++ b/scripts/Forestry.zs
@@ -2751,6 +2751,30 @@ Assembler.addRecipe(<Forestry:cart.beehouse:1>, <Forestry:apiculture>, <minecraf
 // --- Worktable
 Assembler.addRecipe(<Forestry:factory2:2>, [<minecraft:book>, <minecraft:crafting_table>, <minecraft:chest>, <gregtech:gt.integrated_circuit:1> * 0], null, 200, 30);
 
+// --- Apiary
+Assembler.addRecipe(<Forestry:apiculture>, [<Forestry:frameImpregnated>, <gregtech:gt.metaitem.01:27305> * 2, <minecraft:wooden_slab:*> * 2, <Forestry:beeCombs:*>, <minecraft:fence> * 2], <liquid:seedoil> * 1000, 1200, 64);
+
+// --- Scented Paneling
+Assembler.addRecipe(<Forestry:craftingMaterial:6>, [<gregtech:gt.metaitem.02:19086> * 2, <Forestry:royalJelly>, <Forestry:oakStick> * 3, <Forestry:beeswax> * 2, <Forestry:pollen:*>], <liquid:for.honey> * 1000, 1200, 64);
+
+// --- Alveary Heater
+Assembler.addRecipe(<Forestry:alveary:4>, [<Forestry:alveary>, <Forestry:thermionicTubes:7> * 4, <dreamcraft:item.SteelBars>, <IC2:itemRecipePart> * 3, <gregtech:gt.metaitem.01:32601>], <liquid:for.honey> * 2500, 1200, 120);
+
+// --- Alveary Fan
+Assembler.addRecipe(<Forestry:alveary:3>, [<Forestry:alveary>, <Forestry:thermionicTubes:11> * 4, <dreamcraft:item.SteelBars> * 3, <gregtech:gt.metaitem.02:21300>, <gregtech:gt.metaitem.01:32601>], <liquid:for.honey> * 2500, 1200, 120);
+
+// --- Alveary Hygroregulator
+Assembler.addRecipe(<Forestry:alveary:5>, [<Forestry:alveary>, <Forestry:thermionicTubes:6> * 4, <ore:circuitGood>, <gregtech:gt.blockmachines:5142>, <BuildCraft|Factory:tankBlock> * 2, <gregtech:gt.metaitem.01:17308>], <liquid:for.honey> * 2500, 1200, 120);
+
+// --- Alveary Stabiliser
+Assembler.addRecipe(<Forestry:alveary:6>, [<Forestry:alveary>, <Forestry:thermionicTubes:4> * 4, <dreamcraft:item.ChargedCertusQuartzPlate> * 2, <gregtech:gt.metaitem.01:32729> * 2, <Forestry:royalJelly>], <liquid:for.honey> * 2500, 1200, 120);
+
+// --- Alveary Sieve
+Assembler.addRecipe(<Forestry:alveary:7>, [<Forestry:alveary>, <Forestry:thermionicTubes:9> * 4, <Forestry:craftingMaterial:3> * 4, <Forestry:pollenFertile:*>], <liquid:for.honey> * 2500, 1200, 120);
+
+// --- Swarmer (Alveary)
+Assembler.addRecipe(<Forestry:alveary:2>, [<Forestry:alveary>, <Forestry:thermionicTubes:5> * 4, <gregtech:gt.metaitem.01:29351> * 2, <Forestry:royalJelly> * 2, <Forestry:frameProven>], <liquid:for.honey> * 2500, 1200, 120);
+
 
 // --- Centrifuge Recipes ---
 


### PR DESCRIPTION
This is my attempt to add 15 new recipes to GT assembling machine, which all are tiered at MV. All the recipes here take 60 seconds at MV tier, to avoid making Carpenter immediately obsolete as it's still cheaper and faster in terms of time/EU. All alveary upgrades' honey cost also are halved (open to feedback). At higher tiers becomes painful to automate carpenters as you need to spam them and automate each, and so on which I think takes a lot more effort, so those recipes are more or less useful for later in the game.

![image](https://user-images.githubusercontent.com/38641296/206827683-681771e6-9f9b-4095-a351-bb5ddd5d08a4.png)
![image](https://user-images.githubusercontent.com/38641296/206827708-c71d6d91-d490-4597-a193-5885482d5d41.png)
![image](https://user-images.githubusercontent.com/38641296/206827699-808c3e79-d3b3-45eb-b1b7-ff0d4f7fac51.png)
