### PR TITLE
Fix - Made obsidian stick recipe unique from others

### DIFF
--- a/scripts/Tinkers-Construct.zs
+++ b/scripts/Tinkers-Construct.zs
@@ -2391,9 +2391,9 @@ recipes.addShaped(<gregtech:gt.metaitem.01:2019>, [
 // --- Obsidian Sticks
 recipes.addShapeless(<TConstruct:toolRod:6>, [<RandomThings:ingredient:1>]);
 // -
-recipes.addShapeless(<RandomThings:ingredient:1>, [<TConstruct:toolRod:6>]);
+recipes.addShapeless(<RandomThings:ingredient:1>, [<TConstruct:toolRod:6>, <TConstruct:toolRod:6>]);
 // -
-recipes.addShapeless(<RandomThings:ingredient:1>, [<gregtech:gt.metaitem.01:23804>]);
+recipes.addShapeless(<RandomThings:ingredient:1>, [<gregtech:gt.metaitem.01:23804>, <gregtech:gt.metaitem.01:23804>]);
 // -
 recipes.addShapeless(<gregtech:gt.metaitem.01:23804>, [<RandomThings:ingredient:1>]);
 // -


### PR DESCRIPTION
Fixes #10011

- Made obsidian stick from RandomThings take two rods instead of one to differentiate between the exchanging recipes between Tinkers' Obsidian Rods and GregTech Obsidian Rods.
![image](https://user-images.githubusercontent.com/16232674/206917760-9c788d44-fabe-47f9-a5d3-52ed19991439.png)
