### PR TITLE
Update Warp-Theory.zs impure tear infusion not starting

### DIFF
--- a/scripts/Warp-Theory.zs
+++ b/scripts/Warp-Theory.zs
@@ -77,8 +77,8 @@ mods.thaumcraft.Research.addPrereq("PURETEARMINOR", "ELDRITCHMINOR", false);
 mods.thaumcraft.Research.addPrereq("PURETEARMINOR", "warptheory.paper", false);
 mods.thaumcraft.Research.addPage("PURETEARMINOR", "research.warptheory.warpcleanserminor");
 mods.thaumcraft.Infusion.addRecipe("PURETEARMINOR", <BiomesOPlenty:hardIce>,
-[<thaumicbases:resource:5>, <gregtech:gt.metaitem.02:32553>, <thaumicbases:quicksilverBlock>, <IC2:itemFluidCell>.withTag({Fluid: {FluidName: "lifeessence", Amount: 1000}}), <AWWayofTime:magicales>, <witchery:ingredient:36>, 
-<thaumicbases:resource:5>, <gregtech:gt.metaitem.02:32553>, <thaumicbases:quicksilverBlock>, <IC2:itemFluidCell>.withTag({Fluid: {FluidName: "lifeessence", Amount: 1000}}), <AWWayofTime:magicales>, <witchery:ingredient:36>],
+[<thaumicbases:resource:5>, <gregtech:gt.metaitem.02:32553>, <thaumicbases:quicksilverBlock>, <gregtech:gt.metaitem.01:30694>, <AWWayofTime:magicales>, <witchery:ingredient:36>, 
+<thaumicbases:resource:5>, <gregtech:gt.metaitem.02:32553>, <thaumicbases:quicksilverBlock>, <gregtech:gt.metaitem.01:30694>, <AWWayofTime:magicales>, <witchery:ingredient:36>],
 "auram 64, desidia 16, fames 16, gelum 16, permutatio 32, praecantatio 32, venenum 32", <WarpTheory:item.warptheory.cleanserminor>, 10);
 mods.thaumcraft.Research.addInfusionPage("PURETEARMINOR", <WarpTheory:item.warptheory.cleanserminor>);
 


### PR DESCRIPTION
Changed **<IC2:itemFluidCell>.withTag({Fluid: {FluidName: "lifeessence", Amount: 1000}})** to **<gregtech:gt.metaitem.01:30694>**; using the GT cell version of life essence instead of IC2. fixes the issue some people were having with the infusion not starting. Because you can only fill GT cells up to 1000mB this should be the same portions in the recipe as before

-unsure problems: unsure if initial method returned empty IC2 cell or not; including this here to make it known and to point it out if it did or not