### PR TITLE
Add GT Type Filter ItemSink module craft

### DIFF
--- a/scripts/Logistics-Pipes.zs
+++ b/scripts/Logistics-Pipes.zs
@@ -136,6 +136,12 @@ FormingPress.addRecipe(<LogisticsPipes:item.itemModule:207>, <LogisticsPipes:ite
 // --- Electric Manager Module
 FormingPress.addRecipe(<LogisticsPipes:item.itemModule:300>, <LogisticsPipes:item.itemModule:1>, <ore:batteryBasic>, 600, 30);
 
+// GT Type Filter ItemSink Module
+Assembler.addRecipe(<LogisticsPipes:item.itemModule:17> * 2, [<LogisticsPipes:item.itemModule:1> * 2, <gregtech:gt.metaitem.01:32630>, <LogisticsPipes:item.logisticsParts:5>, <gregtech:gt.metaitem.01:17305>, <ProjRed|Core:projectred.core.part:30>], <liquid:molten.lead> * 144, 600, 30);
+Assembler.addRecipe(<LogisticsPipes:item.itemModule:17> * 2, [<LogisticsPipes:item.itemModule:1> * 2, <gregtech:gt.metaitem.01:32630>, <LogisticsPipes:item.logisticsParts:5>, <gregtech:gt.metaitem.01:17305>, <ProjRed|Core:projectred.core.part:30>], <liquid:molten.tin> * 72, 600, 30);
+Assembler.addRecipe(<LogisticsPipes:item.itemModule:17> * 2, [<LogisticsPipes:item.itemModule:1> * 2, <gregtech:gt.metaitem.01:32630>, <LogisticsPipes:item.logisticsParts:5>, <gregtech:gt.metaitem.01:17305>, <ProjRed|Core:projectred.core.part:30>], <liquid:molten.solderingalloy> * 36, 600, 30);
+
+
 
 // ||||| Upgrade Chips |||||
 // --- Gold Upgrade Chip


### PR DESCRIPTION
Should only be accepted when [this](https://github.com/GTNewHorizons/LogisticsPipes/pull/14) pull request is merged.

Adds the craft for GT Type Filter ItemSink module.

Crafting way:
![image](https://user-images.githubusercontent.com/25156941/212493022-e114ebd7-8ebf-4432-b860-bfa94143a26f.png)
The same for tin & soldering alloy.