### PR TITLE
Update WorldGeneration.cfg

### DIFF
--- a/config/GregTech/WorldGeneration.cfg
+++ b/config/GregTech/WorldGeneration.cfg
@@ -781,7 +781,7 @@ worldgen {
                 B:GalaxySpace_Io_false=true
                 I:MaxHeight_120=40
                 I:MinHeight_55=5
-                I:RandomWeight_5=10
+                I:RandomWeight_5=5
             }
 			rutile {
                 B:GalaxySpace_Titan_false=true

--- a/config/GregTech/WorldGeneration.cfg
+++ b/config/GregTech/WorldGeneration.cfg
@@ -779,6 +779,9 @@ worldgen {
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Ganymede_false=true
                 B:GalaxySpace_Io_false=true
+                I:MaxHeight_120=40
+                I:MinHeight_55=5
+                I:RandomWeight_5=10
             }
 			rutile {
                 B:GalaxySpace_Titan_false=true


### PR DESCRIPTION
Increase weight of richnuclear vein, as well as change height to make it actually spawn
Noticed this today as all of the plutonium veins that I found didn't exist, given that ground level on those planets is around 70 blocks.  
Weight was increased by 5 to make it slightly easier to find, however it is still very rare.  
Closes issues #9331 and #7252