### PR TITLE
change default position of waila hud and remove background

### DIFF
--- a/config/Waila.cfg
+++ b/config/Waila.cfg
@@ -1,7 +1,7 @@
 # Configuration file
 
 general {
-    I:waila.cfg.alpha=62
+    I:waila.cfg.alpha=0
     I:waila.cfg.bgcolor=1048592
     I:waila.cfg.fontcolor=10526880
     I:waila.cfg.gradient1=5243135
@@ -12,9 +12,9 @@ general {
     I:waila.cfg.maxhpbeforetext=40
     B:waila.cfg.metadata=false
     B:waila.cfg.newfilters=true
-    I:waila.cfg.posx=10000
-    I:waila.cfg.posy=10000
-    I:waila.cfg.scale=88
+    I:waila.cfg.posx=5000
+    I:waila.cfg.posy=800
+    I:waila.cfg.scale=100
     B:waila.cfg.shiftblock=false
     B:waila.cfg.shiftents=false
     B:waila.cfg.show=true


### PR DESCRIPTION
The goal is to make the game look nicer and more appealing, I changed the default position to be centered at the top but below the boss bar and removed the background because it takes too much space on the screen

![2023-01-16_15 22 38](https://user-images.githubusercontent.com/57050655/212703307-9f46e086-968e-4f82-a7d1-ad8c85439ffc.png)
