### PR TITLE
Update zen scripts for improved automation of I18N

### DIFF
--- a/scripts/AE2.zs
+++ b/scripts/AE2.zs
@@ -17,6 +17,7 @@ import minetweaker.item.IItemStack;
 import minetweaker.item.IIngredient;
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_AE2_0 = "Universal Storage Housing";
 
 // --- Variables ---

--- a/scripts/Adv-Solar-Panel.zs
+++ b/scripts/Adv-Solar-Panel.zs
@@ -10,6 +10,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Adv_Solar_Panel_0 = "Irradiant Reinforced Iridium Plate";
 
 

--- a/scripts/Automagy.zs
+++ b/scripts/Automagy.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Automagy_0 = "Infused Gold";
 val I18N_Automagy_1 = "[AM] Infuse Gold with magic.";
 val I18N_Automagy_2 = "You found a way to fuse gold and thaumium to create a new metal INFUSED GOLD";

--- a/scripts/Blood-Magic-Thaumcraft.zs
+++ b/scripts/Blood-Magic-Thaumcraft.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Blood_Magic_Thaumcraft_0 = "Blood Magic";
 val I18N_Blood_Magic_Thaumcraft_1 = "Blood Altar";
 val I18N_Blood_Magic_Thaumcraft_2 = "[BM] Paying the highest price.";

--- a/scripts/CoreMod.zs
+++ b/scripts/CoreMod.zs
@@ -26,6 +26,7 @@ import mods.gregtech.Wiremill;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_CoreMod_0 = "New Horizons";
 val I18N_CoreMod_1 = "Wither Protection Ring";
 val I18N_CoreMod_2 = "[NH] Wither...? It is star farming time";

--- a/scripts/Emt.zs
+++ b/scripts/Emt.zs
@@ -16,6 +16,7 @@ import mods.gregtech.Pulverizer;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Emt_0 = "Electric Magic Tools";
 val I18N_Emt_1 = "Who says magic and technology can't go together?";
 val I18N_Emt_2 = "Who says magic can't work with technology? Our researchers have collaborated with the top mages of the school of Thaumaturgy to bring you the effectiveness of magic coupled with the convenience of electric tools.";

--- a/scripts/Ender-IO.zs
+++ b/scripts/Ender-IO.zs
@@ -14,6 +14,7 @@ import mods.gregtech.Pulverizer;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Ender_IO_0 = "Cooldown 2 seconds";
 
 

--- a/scripts/Extra-Bees.zs
+++ b/scripts/Extra-Bees.zs
@@ -12,6 +12,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Extra_Bees_0 = "Healing Frame";
 val I18N_Extra_Bees_1 = "[EB] The Bees will never die ?";
 val I18N_Extra_Bees_2 = "The Healing Frame is an Item used in an Apiary, which increases a Queens lifespan at the cost of a lesser productivity and a decreased mutation rate. It increases a bees lifespan 50% while reducing its productivity to 75% and the chance of mutation to only 50%. It is constructed using Clay and an Impregnated Frame. In an Alveary structure, the Frame Housing can be added to make use of the Frame.";

--- a/scripts/Extra-Utilities.zs
+++ b/scripts/Extra-Utilities.zs
@@ -18,6 +18,7 @@ import mods.thaumcraft.Warp;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Extra_Utilities_0 = "Be free like a bird ... (Theorie)";
 val I18N_Extra_Utilities_1 = "[ExU] The way to the sky! - Part I";
 val I18N_Extra_Utilities_2 = "Happy to have crafted or looted your first Copter Pack or in general having access to Jetpacks?<BR>Annoyed about the fact that you need some type of fuel or energy for your Jetpack to work?<BR>What would a Thaumaturge give to achieve the ability to fly without these restrictions?<BR>Maybe some §oWarp§r? Not at this point yet, maybe later?<BR>But what should you do now to achieve §oFreedom like a bird§r? Maybe you remember Icarus and what happened to him?";
@@ -1374,37 +1375,37 @@ Infusion.addRecipe("EXURINGS_CRAFTING", ARInvisableWings, [SalisMundus, RoseGold
 
 // --- Research I: Flavor Text
 Research.addResearch("EXURINGS", "ARTIFICE", "praecantatio 10, volatus 10, tempestas 100, nebrisum 10, motus 10, terminus 10", 1, -5 as int, 16, TravelWingsImage);
-game.setLocalization("en_US", "tc.research_name.EXURINGS", I18N_Extra_Utilities_0);
-game.setLocalization("en_US", "tc.research_text.EXURINGS", I18N_Extra_Utilities_1);
+game.setLocalization(_I18N_Lang, "tc.research_name.EXURINGS", I18N_Extra_Utilities_0);
+game.setLocalization(_I18N_Lang, "tc.research_text.EXURINGS", I18N_Extra_Utilities_1);
 Research.setRound("EXURINGS", true);
 Research.setConcealed("EXURINGS", true);
 Research.addPrereq("EXURINGS", "INFUSION", true);
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.1");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.1", I18N_Extra_Utilities_2);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.1", I18N_Extra_Utilities_2);
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.2");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.2", I18N_Extra_Utilities_3);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.2", I18N_Extra_Utilities_3);
 
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.3");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.3", I18N_Extra_Utilities_4);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.3", I18N_Extra_Utilities_4);
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.4");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.4", I18N_Extra_Utilities_5);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.4", I18N_Extra_Utilities_5);
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.5");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.5", I18N_Extra_Utilities_6);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.5", I18N_Extra_Utilities_6);
 Research.addPage("EXURINGS", "tc.research_page.EXURINGS.6");
-game.setLocalization("en_US", "tc.research_page.EXURINGS.6", I18N_Extra_Utilities_7);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS.6", I18N_Extra_Utilities_7);
 
 // --- Research II: Angel Rings (crafting)
 Research.addResearch("EXURINGS_CRAFTING", "ARTIFICE", "praecantatio 10, volatus 10, tempestas 10, nebrisum 10, motus 10, terminus 10", -1 as int, -5 as int, 16, ARInvisableWings);
-game.setLocalization("en_US", "tc.research_name.EXURINGS_CRAFTING", I18N_Extra_Utilities_8);
-game.setLocalization("en_US", "tc.research_text.EXURINGS_CRAFTING", I18N_Extra_Utilities_9);
+game.setLocalization(_I18N_Lang, "tc.research_name.EXURINGS_CRAFTING", I18N_Extra_Utilities_8);
+game.setLocalization(_I18N_Lang, "tc.research_text.EXURINGS_CRAFTING", I18N_Extra_Utilities_9);
 Research.addPrereq("EXURINGS_CRAFTING", "EXURINGS", false);
 Research.setConcealed("EXURINGS_CRAFTING", true);
 Warp.addToResearch("EXURINGS_CRAFTING", 16);
 Research.addPage("EXURINGS_CRAFTING", "tc.research_page.EXURINGS_CRAFTING.1");
-game.setLocalization("en_US", "tc.research_page.EXURINGS_CRAFTING.1", I18N_Extra_Utilities_10);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS_CRAFTING.1", I18N_Extra_Utilities_10);
 Research.addInfusionPage("EXURINGS_CRAFTING", ARInvisableWings);
 Research.addPage("EXURINGS_CRAFTING", "tc.research_page.EXURINGS_CRAFTING.2");
-game.setLocalization("en_US", "tc.research_page.EXURINGS_CRAFTING.2", I18N_Extra_Utilities_11);
+game.setLocalization(_I18N_Lang, "tc.research_page.EXURINGS_CRAFTING.2", I18N_Extra_Utilities_11);
 Research.addInfusionPage("EXURINGS_CRAFTING", ARFeatheryWings);
 Research.addInfusionPage("EXURINGS_CRAFTING", ARFairyWings);
 Research.addInfusionPage("EXURINGS_CRAFTING", ARDragonWings);

--- a/scripts/Forbidden-Magic-01-Wands.zs
+++ b/scripts/Forbidden-Magic-01-Wands.zs
@@ -6,6 +6,7 @@ import mods.thaumcraft.Research;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Forbidden_Magic_01_Wands_0 = "A long Journey";
 val I18N_Forbidden_Magic_01_Wands_1 = "[FM] There must be more Magic!";
 val I18N_Forbidden_Magic_01_Wands_2 = "The Thaumonomicon told you about purple trees with white leaves and about colorful sparkeling flowers, but you simple were unable to find them in the world, it seems that they don't exist.<BR> You decited to create these Objects yourself. You're a Thaumaturge, you don't care if things exist or not, you can simpley create them on your own, but it will take further investigation to do so.";
@@ -78,10 +79,10 @@ mods.thaumcraft.Infusion.addRecipe("ROD_witchwood", <witchery:ingredient:82>,
 
 // Journey
 mods.thaumcraft.Research.addResearch("JOURNEY", "FORBIDDEN", "iter 5, praecantatio 10, instrumentum 3", -3 as int, 1, 8, <BiomesOPlenty:food:7>);
-game.setLocalization("en_US", "tc.research_name.JOURNEY", I18N_Forbidden_Magic_01_Wands_0);
-game.setLocalization("en_US", "tc.research_text.JOURNEY", I18N_Forbidden_Magic_01_Wands_1);
+game.setLocalization(_I18N_Lang, "tc.research_name.JOURNEY", I18N_Forbidden_Magic_01_Wands_0);
+game.setLocalization(_I18N_Lang, "tc.research_text.JOURNEY", I18N_Forbidden_Magic_01_Wands_1);
 mods.thaumcraft.Research.addPage("JOURNEY", "derp.research_page.JOURNEY");
-game.setLocalization("en_US", "derp.research_page.JOURNEY", I18N_Forbidden_Magic_01_Wands_2);
+game.setLocalization(_I18N_Lang, "derp.research_page.JOURNEY", I18N_Forbidden_Magic_01_Wands_2);
 mods.thaumcraft.Research.addPrereq("JOURNEY", "SCHOOLS", false);
 mods.thaumcraft.Research.setRound("JOURNEY",true);
 mods.thaumcraft.Research.setStub("JOURNEY",true);
@@ -89,10 +90,10 @@ mods.thaumcraft.Research.setAutoUnlock("JOURNEY",true);
 
 // Livingwood Wand Rod
 mods.thaumcraft.Research.addResearch("ROD_livingwood", "FORBIDDEN", "victus 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", -1 as int, 3, 8, <ForbiddenMagic:WandCores:7>);
-game.setLocalization("en_US", "tc.research_name.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_3);
-game.setLocalization("en_US", "tc.research_text.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_4);
+game.setLocalization(_I18N_Lang, "tc.research_name.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_3);
+game.setLocalization(_I18N_Lang, "tc.research_text.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_4);
 mods.thaumcraft.Research.addPage("ROD_livingwood", "derp.research_page.ROD_livingwood");
-game.setLocalization("en_US", "derp.research_page.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_5);
+game.setLocalization(_I18N_Lang, "derp.research_page.ROD_livingwood", I18N_Forbidden_Magic_01_Wands_5);
 mods.thaumcraft.Research.addInfusionPage("ROD_livingwood",<ForbiddenMagic:WandCores:7>);
 mods.thaumcraft.Research.setConcealed("ROD_livingwood", true);
 mods.thaumcraft.Research.addPrereq("ROD_livingwood", "JOURNEY", false);
@@ -106,10 +107,10 @@ mods.thaumcraft.Research.orphanResearch("ROD_dreamwood");
 mods.thaumcraft.Research.removeResearch("ROD_dreamwood");
 mods.thaumcraft.Research.addResearch("ROD_dreamwood_v2", "FORBIDDEN", "auram 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", 1, 4, 8, <ForbiddenMagic:WandCores:11>);
 
-game.setLocalization("en_US", "tc.research_name.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_6);
-game.setLocalization("en_US", "tc.research_text.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_7);
+game.setLocalization(_I18N_Lang, "tc.research_name.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_6);
+game.setLocalization(_I18N_Lang, "tc.research_text.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_7);
 mods.thaumcraft.Research.addPage("ROD_dreamwood_v2", "derp.research_page.ROD_dreamwood_v2");
-game.setLocalization("en_US", "derp.research_page.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_8);
+game.setLocalization(_I18N_Lang, "derp.research_page.ROD_dreamwood_v2", I18N_Forbidden_Magic_01_Wands_8);
 mods.thaumcraft.Research.addInfusionPage("ROD_dreamwood_v2",<ForbiddenMagic:WandCores:12>);
 mods.thaumcraft.Research.setConcealed("ROD_dreamwood_v2", true);
 mods.thaumcraft.Research.addPrereq("ROD_dreamwood_v2", "ROD_livingwood", false);
@@ -127,10 +128,10 @@ mods.thaumcraft.Arcane.addShaped("ROD_dreamwood_staff_v2", <ForbiddenMagic:WandC
 [<Thaumcraft:blockCrystal:2>, <ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:3>],
 [<ForbiddenMagic:WandCores:11>, <Thaumcraft:blockCrystal:4>,<Thaumcraft:blockCrystal:5>]]);
 
-game.setLocalization("en_US", "tc.research_name.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_9);
-game.setLocalization("en_US", "tc.research_text.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_10);
+game.setLocalization(_I18N_Lang, "tc.research_name.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_9);
+game.setLocalization(_I18N_Lang, "tc.research_text.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_10);
 mods.thaumcraft.Research.addPage("ROD_dreamwood_staff_v2", "derp.research_page.ROD_dreamwood_staff_v2");
-game.setLocalization("en_US", "derp.research_page.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_11);
+game.setLocalization(_I18N_Lang, "derp.research_page.ROD_dreamwood_staff_v2", I18N_Forbidden_Magic_01_Wands_11);
 mods.thaumcraft.Research.addPrereq("ROD_dreamwood_staff_v2", "ROD_dreamwood_v2", false);
 mods.thaumcraft.Research.addArcanePage("ROD_dreamwood_staff_v2",<ForbiddenMagic:WandCores:13>);
 mods.thaumcraft.Research.setSpikey("ROD_dreamwood_staff_v2", true);
@@ -144,10 +145,10 @@ mods.thaumcraft.Research.addResearch("CAP_manasteel", "FORBIDDEN", "metallum 5, 
 mods.thaumcraft.Infusion.addRecipe("CAP_manasteel", <Thaumcraft:WandCap:4>, [<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>,<gregtech:gt.metaitem.01:2333>,<Botania:manaResource:0>],
  "potentia 64, praecantatio 48, electrum 32, instrumentum 24, machina 24", capManaInert, 6);
 
-game.setLocalization("en_US", "tc.research_name.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_12);
-game.setLocalization("en_US", "tc.research_text.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_13);
+game.setLocalization(_I18N_Lang, "tc.research_name.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_12);
+game.setLocalization(_I18N_Lang, "tc.research_text.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_13);
 mods.thaumcraft.Research.addPage("CAP_manasteel", "derp.research_page.CAP_manasteel");
-game.setLocalization("en_US", "derp.research_page.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_14);
+game.setLocalization(_I18N_Lang, "derp.research_page.CAP_manasteel", I18N_Forbidden_Magic_01_Wands_14);
 mods.thaumcraft.Research.addInfusionPage("CAP_manasteel",capManaInert);
 mods.thaumcraft.Research.setConcealed("CAP_manasteel", true);
 mods.thaumcraft.Research.addPrereq("CAP_manasteel", "ROD_livingwood", false);
@@ -161,10 +162,10 @@ mods.thaumcraft.Research.addResearch("CAP_terrasteel", "FORBIDDEN", "terra 5, pr
 mods.thaumcraft.Infusion.addRecipe("CAP_terrasteel", capMana, [<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.01:17339>,<Botania:manaResource:4>,<Thaumcraft:blockCrystal:3>,<gregtech:gt.metaitem.02:30501>,<Thaumcraft:blockCrystal:3>,<Botania:manaResource:4>,<gregtech:gt.metaitem.01:17339>,<Thaumcraft:blockCrystal:3>],
 "praecantatio 256, ordo 64, metallum 64, superbia 20, strontio 10", capTerra, 6);
 
-game.setLocalization("en_US", "tc.research_name.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_15);
-game.setLocalization("en_US", "tc.research_text.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_16);
+game.setLocalization(_I18N_Lang, "tc.research_name.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_15);
+game.setLocalization(_I18N_Lang, "tc.research_text.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_16);
 mods.thaumcraft.Research.addPage("CAP_terrasteel", "derp.research_page.CAP_terrasteel");
-game.setLocalization("en_US", "derp.research_page.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_17);
+game.setLocalization(_I18N_Lang, "derp.research_page.CAP_terrasteel", I18N_Forbidden_Magic_01_Wands_17);
 mods.thaumcraft.Research.addInfusionPage("CAP_terrasteel",capTerra);
 mods.thaumcraft.Research.setConcealed("CAP_terrasteel", true);
 mods.thaumcraft.Research.addPrereq("CAP_terrasteel", "CAP_manasteel", false);
@@ -180,10 +181,10 @@ mods.thaumcraft.Arcane.addShaped("CAP_elementium", capElementiumInert, "terra 40
 [<ore:ingotElvenElementium>, <ore:elvenPixieDust>, <ore:ingotElvenElementium>],
 [<ore:screwTungstenSteel>, <ore:ingotElvenElementium>, <ore:screwTungstenSteel>]]);
 
-game.setLocalization("en_US", "tc.research_name.CAP_elementium", I18N_Forbidden_Magic_01_Wands_18);
-game.setLocalization("en_US", "tc.research_text.CAP_elementium", I18N_Forbidden_Magic_01_Wands_19);
+game.setLocalization(_I18N_Lang, "tc.research_name.CAP_elementium", I18N_Forbidden_Magic_01_Wands_18);
+game.setLocalization(_I18N_Lang, "tc.research_text.CAP_elementium", I18N_Forbidden_Magic_01_Wands_19);
 mods.thaumcraft.Research.addPage("CAP_elementium", "derp.research_page.CAP_elementium");
-game.setLocalization("en_US", "derp.research_page.CAP_elementium", I18N_Forbidden_Magic_01_Wands_20);
+game.setLocalization(_I18N_Lang, "derp.research_page.CAP_elementium", I18N_Forbidden_Magic_01_Wands_20);
 mods.thaumcraft.Research.addPrereq("CAP_elementium", "CAP_manasteel", false);
 mods.thaumcraft.Research.addArcanePage("CAP_elementium",capElementiumInert);
 mods.thaumcraft.Research.addInfusionPage("CAP_elementium",capElementium);
@@ -191,10 +192,10 @@ mods.thaumcraft.Research.setConcealed("CAP_elementium", true);
 
 // Vinteum 
 mods.thaumcraft.Research.addResearch("VINTEUM", "FORBIDDEN", "metallum 5, permutatio 10, praecantatio 3, lucrum 2", -4 as int, 2, 8, <gregtech:gt.metaitem.01:8529>);
-game.setLocalization("en_US", "tc.research_name.VINTEUM", I18N_Forbidden_Magic_01_Wands_21);
-game.setLocalization("en_US", "tc.research_text.VINTEUM", I18N_Forbidden_Magic_01_Wands_22);
+game.setLocalization(_I18N_Lang, "tc.research_name.VINTEUM", I18N_Forbidden_Magic_01_Wands_21);
+game.setLocalization(_I18N_Lang, "tc.research_text.VINTEUM", I18N_Forbidden_Magic_01_Wands_22);
 mods.thaumcraft.Research.addPage("VINTEUM", "derp.research_page.VINTEUM");
-game.setLocalization("en_US", "derp.research_page.VINTEUM", I18N_Forbidden_Magic_01_Wands_23);
+game.setLocalization(_I18N_Lang, "derp.research_page.VINTEUM", I18N_Forbidden_Magic_01_Wands_23);
 mods.thaumcraft.Research.addCruciblePage("VINTEUM",<gregtech:gt.metaitem.01:9529>);
 mods.thaumcraft.Research.setConcealed("VINTEUM", true);
 mods.thaumcraft.Research.addPrereq("VINTEUM", "JOURNEY", false);
@@ -204,10 +205,10 @@ mods.thaumcraft.Warp.addToResearch("VINTEUM",1);
 
 // Vinteum Caps
 mods.thaumcraft.Research.addResearch("CAP_vinteum", "FORBIDDEN", "permutatio 5, praecantatio 10,lucrum 3,instrumentum 4, metallum 5", -5 as int, 3, 8, capVinteum);
-game.setLocalization("en_US", "tc.research_name.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_24);
-game.setLocalization("en_US", "tc.research_text.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_25);
+game.setLocalization(_I18N_Lang, "tc.research_name.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_24);
+game.setLocalization(_I18N_Lang, "tc.research_text.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_25);
 mods.thaumcraft.Research.addPage("CAP_vinteum", "derp.research_page.CAP_vinteum");
-game.setLocalization("en_US", "derp.research_page.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_26);
+game.setLocalization(_I18N_Lang, "derp.research_page.CAP_vinteum", I18N_Forbidden_Magic_01_Wands_26);
 mods.thaumcraft.Research.addArcanePage("CAP_vinteum",capVinteum);
 mods.thaumcraft.Research.setConcealed("CAP_vinteum", true);
 mods.thaumcraft.Research.addPrereq("CAP_vinteum", "VINTEUM", false);
@@ -216,10 +217,10 @@ mods.thaumcraft.Warp.addToResearch("CAP_vinteum",3);
 
 // Witchwood Wand Rod
 mods.thaumcraft.Research.addResearch("ROD_witchwood", "FORBIDDEN", "victus 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", -4 as int, 0, 8, <ForbiddenMagic:WandCores:4>);
-game.setLocalization("en_US", "tc.research_name.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_27);
-game.setLocalization("en_US", "tc.research_text.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_28);
+game.setLocalization(_I18N_Lang, "tc.research_name.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_27);
+game.setLocalization(_I18N_Lang, "tc.research_text.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_28);
 mods.thaumcraft.Research.addPage("ROD_witchwood", "derp.research_page.ROD_witchwood");
-game.setLocalization("en_US", "derp.research_page.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_29);
+game.setLocalization(_I18N_Lang, "derp.research_page.ROD_witchwood", I18N_Forbidden_Magic_01_Wands_29);
 mods.thaumcraft.Research.addInfusionPage("ROD_witchwood",<ForbiddenMagic:WandCores:4>);
 mods.thaumcraft.Research.setConcealed("ROD_witchwood", true);
 mods.thaumcraft.Research.addPrereq("ROD_witchwood", "VINTEUM", false);
@@ -229,10 +230,10 @@ mods.thaumcraft.Warp.addToResearch("ROD_witchwood",2);
 
 // Witchwood Staff Rod
 mods.thaumcraft.Research.addResearch("ROD_witchwood_staff", "FORBIDDEN", "victus 5, praecantatio 10, herba 3,instrumentum 4, arbor 5", -2 as int, 0, 8, <ForbiddenMagic:WandCores:10>);
-game.setLocalization("en_US", "tc.research_name.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_30);
-game.setLocalization("en_US", "tc.research_text.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_31);
+game.setLocalization(_I18N_Lang, "tc.research_name.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_30);
+game.setLocalization(_I18N_Lang, "tc.research_text.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_31);
 mods.thaumcraft.Research.addPage("ROD_witchwood_staff", "derp.research_page.ROD_witchwood_staff");
-game.setLocalization("en_US", "derp.research_page.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_32);
+game.setLocalization(_I18N_Lang, "derp.research_page.ROD_witchwood_staff", I18N_Forbidden_Magic_01_Wands_32);
 mods.thaumcraft.Research.addArcanePage("ROD_witchwood_staff",<ForbiddenMagic:WandCores:10>);
 mods.thaumcraft.Research.setSpikey("ROD_witchwood_staff", true);
 mods.thaumcraft.Research.setConcealed("ROD_witchwood_staff", true);

--- a/scripts/Forestry-Frames.zs
+++ b/scripts/Forestry-Frames.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Forestry_Frames_0 = "<Hold Shift>";
 val I18N_Forestry_Frames_1 = "Durability:";
 val I18N_Forestry_Frames_2 = "Territory:";

--- a/scripts/Forestry.zs
+++ b/scripts/Forestry.zs
@@ -17,6 +17,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Forestry_0 = "Proven Frame";
 val I18N_Forestry_1 = "[FR] Better than Impregnated Frames";
 val I18N_Forestry_2 = "The Proven Frame is an item used in an Apiary. Each frame doubles the bees productivity. Out of the three Forestry frames (Untreated, Impregnated and Proven), the Proven Frame has the longest durability.<BR> Proven Frames are normally only obtainable through trading with an Apiarist Villager. The Villager will trade six Proven Frames for one Emerald.<BR> Now you find a magical way put different Bee products and infuse a impregnated Frame to get a Proven Frame. In an Alveary structure, the Frame Housing can be added to make use of the Frame.";

--- a/scripts/GraviSuite.zs
+++ b/scripts/GraviSuite.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_GraviSuite_0 = "Superconductor Cover";
 val I18N_GraviSuite_1 = "Superconductor";
 val I18N_GraviSuite_2 = "Cooling Core";

--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -29,6 +29,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Gregtech_0 = "Work Area 16 Blocks Radius = 4 Chunks";
 val I18N_Gregtech_1 = "Work Area 32 Blocks Radius = 16 Chunks";
 val I18N_Gregtech_2 = "Work Area 48 Blocks Radius = 36 Chunks";

--- a/scripts/Magic-Bees.zs
+++ b/scripts/Magic-Bees.zs
@@ -11,6 +11,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Magic_Bees_0 = "Magic Apiary";
 val I18N_Magic_Bees_1 = "[MB] Magical Apiary.";
 val I18N_Magic_Bees_2 = "The Magic Apiary works similarly to the regular Apiary, with 1x base Territory, Mutation, Lifespan, and Flowering modifiers, 0.9x Production modifier, and 0.8 Genetic Decay modifier. When an Apiary Booster of any type is placed nearby, the Apiary will consume aspects to enable 2x (or 1/2) boosts for, in order from left to right: Mutation, Death Rate, Production. Enabling death rate will halve lifespan. Its useful when all youre interested in is breeding, and dont have access to Oblivion Frames.";

--- a/scripts/Minecraft.zs
+++ b/scripts/Minecraft.zs
@@ -20,6 +20,7 @@ import mods.gregtech.Slicer;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Minecraft_0 = "Compressed Meteoric Iron Plate";
 val I18N_Minecraft_1 = "Compressed Copper Plate";
 val I18N_Minecraft_2 = "Compressed Tin Plate";

--- a/scripts/Open-Blocks.zs
+++ b/scripts/Open-Blocks.zs
@@ -13,6 +13,7 @@ import mods.gregtech.Mixer;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Open_Blocks_0 = "Golden Egg";
 val I18N_Open_Blocks_1 = "[OB] Make A MiniMe";
 val I18N_Open_Blocks_2 = "The Golden Egg is a block from the OpenBlocks mod. This block is used to summon the Baby Mini Me. Before it hatches, it will begin to slowly spin in circles. After many spins, it will grow and emit large amounts of light. It will then float into the air, and explode. The explosion is minor, and should only break a single layer of standard resistance blocks. Right before it explodes, it will lift surrounding blocks into the air, then drop them back into place. Pictures of the hatching process can be found below.";

--- a/scripts/Railcraft.zs
+++ b/scripts/Railcraft.zs
@@ -20,6 +20,7 @@ import mods.gregtech.Wiremill;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Railcraft_0 = "Lapatron Loader Upgrade";
 val I18N_Railcraft_1 = "Lead Plate";
 

--- a/scripts/Renaming.zs
+++ b/scripts/Renaming.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Renaming_0 = "Personal Ender Chest";
 val I18N_Renaming_1 = "Only For Personal Use";
 val I18N_Renaming_2 = "Infinity Engine";

--- a/scripts/Tainted-Magic-1.zs
+++ b/scripts/Tainted-Magic-1.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Tainted_Magic_1_0 = "Shadowmetal";
 val I18N_Tainted_Magic_1_1 = "I have seen the truth";
 val I18N_Tainted_Magic_1_2 = "Unbalanced Shards";

--- a/scripts/Thaumcraft-01-Basic.zs
+++ b/scripts/Thaumcraft-01-Basic.zs
@@ -12,6 +12,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Thaumcraft_01_Basic_0 = "Warp Warnings";
 val I18N_Thaumcraft_01_Basic_1 = "[WT] Wither in the Overworld";
 val I18N_Thaumcraft_01_Basic_2 = "Thaumcraft offers considerable power from its devices and tools. But power comes with a price.... That price is represented by Warp: A corruption of the character's mind and soul, inflicting progressively more dire effects upon them. While the effects of warp can range from annoying to deadly, accumulating enough of it can also grant you access to greater power... at the cost of increasing madness, and attention from dark powers. At least, others may call it madness... but is it truly insanity, when the voices in your head grant useful knowledge, and the monsters that appear before you leave remains behind?";

--- a/scripts/Thaumcraft-03-Alchemy.zs
+++ b/scripts/Thaumcraft-03-Alchemy.zs
@@ -11,6 +11,7 @@ import mods.gregtech.Pulverizer;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Thaumcraft_03_Alchemy_0 = "Charcoal dust and Lignite dust works well too. They are not shown in the recipe because of Mod Tweaker";
 
 // --- Variables ---

--- a/scripts/Thaumic-Bases-01-Main.zs
+++ b/scripts/Thaumic-Bases-01-Main.zs
@@ -12,6 +12,7 @@ import mods.gregtech.CuttingSaw;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Thaumic_Bases_01_Main_0 = "No activation here!";
 val I18N_Thaumic_Bases_01_Main_1 = "A thaumaturge always seeks for a way to give discovered materials a real purpose. That metal you've just unlocked, thauminite works just as thaumium, so why not use it as a wand cap ? Well, thauminite doesn't seem to be as bendable as thaumium, due to the high amount of vitreus in it. However, that property can be used to enhance regular thaumium caps. The infusion is capable of turning the thauminite into small pieces, making it able to re-crystalise directly on the thaumium caps. To ensure that cap and thauminite are bound together for  ...forever you'll also need some quicksilver and also a bit of salis mundus to reduce thauminites crystalisation time.";
 val I18N_Thaumic_Bases_01_Main_2 = "These new caps seem to better than thaumium caps, but you feel something within them... maybe there is something more to them?";
@@ -593,10 +594,10 @@ Research.refreshResearchRecipe("TB.NodeFoci.Taint");
 
 // --- Taint Flask
 Research.addResearch("TB.TaintFlask", "THAUMICBASES", "vitium 10, alienis 15, perditio 8, permutatio 12", 1, -1 as int, 8, <thaumicbases:concentratedTaint>);
-game.setLocalization("en_US", "tc.research_name.TB.TaintFlask", I18N_Thaumic_Bases_01_Main_3);
-game.setLocalization("en_US", "tc.research_text.TB.TaintFlask", I18N_Thaumic_Bases_01_Main_4);
+game.setLocalization(_I18N_Lang, "tc.research_name.TB.TaintFlask", I18N_Thaumic_Bases_01_Main_3);
+game.setLocalization(_I18N_Lang, "tc.research_text.TB.TaintFlask", I18N_Thaumic_Bases_01_Main_4);
 mods.thaumcraft.Research.addPage("TB.TaintFlask", "tb.rec.TB.TaintFlask.page.NH.0");
-game.setLocalization("en_US", "tb.rec.TB.TaintFlask.page.NH.0", I18N_Thaumic_Bases_01_Main_5);
+game.setLocalization(_I18N_Lang, "tb.rec.TB.TaintFlask.page.NH.0", I18N_Thaumic_Bases_01_Main_5);
 mods.thaumcraft.Research.addInfusionPage("TB.TaintFlask", <thaumicbases:concentratedTaint>);
 mods.thaumcraft.Research.addPrereq("TB.TaintFlask", "TB.INFUSION", false);
 mods.thaumcraft.Research.addPrereq("TB.TaintFlask", "BOTTLETAINT", true);

--- a/scripts/Thaumic-Exploration-01.zs
+++ b/scripts/Thaumic-Exploration-01.zs
@@ -2,6 +2,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Thaumic_Exploration_01_0 = "Shard Rings";
 val I18N_Thaumic_Exploration_01_1 = "Conserving vis";
 val I18N_Thaumic_Exploration_01_2 = "Seal of Jar Binding";

--- a/scripts/ThaumicTinkerer-01.zs
+++ b/scripts/ThaumicTinkerer-01.zs
@@ -14,6 +14,7 @@ import mods.gregtech.PrecisionLaser;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_ThaumicTinkerer_01_0 = "Tome of Knowledge Sharing";
 val I18N_ThaumicTinkerer_01_1 = "[TT] A Goldfish's Diary";
 val I18N_ThaumicTinkerer_01_2 = "Smokey Quartz";

--- a/scripts/ThaumicTinkerer-02-Kami.zs
+++ b/scripts/ThaumicTinkerer-02-Kami.zs
@@ -10,6 +10,7 @@ import mods.ic2.Compressor;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_ThaumicTinkerer_02_Kami_0 = "Dimensional Shards";
 val I18N_ThaumicTinkerer_02_Kami_1 = "[TT] Rarities of the Otherworld";
 val I18N_ThaumicTinkerer_02_Kami_2 = "Similarly to the overworld, the Nether and the End also have their specific shards, these are rarely held by either Zombie Pigmen living in the Nether or Endermen living in the End.<BR> You find a way to get this Shards with a Infusion recipe also.<BR><BR><IMG>ttinkerer:textures/items/netherShard.png:0:0:255:255:0.0625</IMG><IMG>ttinkerer:textures/items/enderShard.png:0:0:255:255:0.0625</IMG>";

--- a/scripts/Tinkers-Construct.zs
+++ b/scripts/Tinkers-Construct.zs
@@ -11,6 +11,7 @@ import mods.nei.NEI;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Tinkers_Construct_0 = "Can be placed on a empty IC2 Crop.";
 
 // --- Variables ---

--- a/scripts/Warp-Theory.zs
+++ b/scripts/Warp-Theory.zs
@@ -6,6 +6,7 @@
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Warp_Theory_0 = "Impure Tear";
 val I18N_Warp_Theory_1 = "Magical-ish Medicine";
 val I18N_Warp_Theory_2 = "Pure Tear";

--- a/scripts/Witchery.zs
+++ b/scripts/Witchery.zs
@@ -11,6 +11,7 @@ import mods.gregtech.CuttingSaw;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_Witchery_0 = "Witchery";
 val I18N_Witchery_1 = "Anointing Paste";
 val I18N_Witchery_2 = "[WI] Magical Paste";

--- a/scripts/ZZ-Client-Only.zs
+++ b/scripts/ZZ-Client-Only.zs
@@ -10,6 +10,7 @@ import mods.gregtech.FormingPress;
 
 
 // --- I18N ---
+val _I18N_Lang = "en_US";
 val I18N_ZZ_Client_Only_0 = "Hellbark Case";
 
 


### PR DESCRIPTION
defined a variable `_I18N_Lang` with a value of `"en_US"` to facilitate the replacement of its value with other values such as `"zh_CN"` during the automation process
only extracted the variable, without increasing the complexity of scripts.