### PR TITLE
Fix ore chunk text formatting

### DIFF
--- a/config/InGameInfo.xml
+++ b/config/InGameInfo.xml
@@ -196,7 +196,7 @@
                         <num>16</num>
                         <num>16</num>
                     </icon>
-                    <str>  This is an {darkgreen}{underline}ore {white}chunk.</str>
+                    <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
                 </concat>
             </if>
         </line>


### PR DESCRIPTION
![0024368](https://user-images.githubusercontent.com/29953391/217639682-427e2bc4-5ed1-49a4-8768-2187b34497be.png)
Space after the word was also underlined.