### PR TITLE
Remove Tinkers channel->nether brick faucet recipe

### DIFF
--- a/scripts/Tinkers-Construct.zs
+++ b/scripts/Tinkers-Construct.zs
@@ -489,6 +489,8 @@ recipes.remove(<TConstruct:SearedBlockNether:2>);
 
 // --- Casting Channel
 recipes.remove(<TConstruct:CastingChannel>);
+// -
+recipes.remove(<TConstruct:CastingChannel:1>);
 
 // --- Casting Faucet
 recipes.remove(<TConstruct:SearedBlock:1>);
@@ -1543,9 +1545,16 @@ recipes.addShaped(<TConstruct:CastingChannel>, [
 [<TConstruct:materials:2>, null, <TConstruct:materials:2>],
 [<TConstruct:materials:2>, null, <TConstruct:materials:2>],
 [<TConstruct:materials:2>, <TConstruct:materials:2>, <TConstruct:materials:2>]]);
+// -
+recipes.addShaped(<TConstruct:CastingChannel:1>, [
+[<TConstruct:materials:37>, null, <TConstruct:materials:37>],
+[<TConstruct:materials:37>, null, <TConstruct:materials:37>],
+[<TConstruct:materials:37>, <TConstruct:materials:37>, <TConstruct:materials:37>]]);
 
 // --- Casting Faucet
 recipes.addShaped(<TConstruct:SearedBlock:1> * 2, [[<ore:craftingToolSaw>, <TConstruct:CastingChannel>]]);
+// -
+recipes.addShaped(<TConstruct:SearedBlockNether:1> * 2, [[<ore:craftingToolSaw>, <TConstruct:CastingChannel:1>]]);
 // -
 recipes.addShaped(<TConstruct:SearedBlock:1>, [
 [null, null, null],

--- a/scripts/Tinkers-Construct.zs
+++ b/scripts/Tinkers-Construct.zs
@@ -1547,8 +1547,6 @@ recipes.addShaped(<TConstruct:CastingChannel>, [
 // --- Casting Faucet
 recipes.addShaped(<TConstruct:SearedBlock:1> * 2, [[<ore:craftingToolSaw>, <TConstruct:CastingChannel>]]);
 // -
-recipes.addShaped(<TConstruct:SearedBlockNether:1> * 2, [[<TConstruct:CastingChannel>, <ore:craftingToolSaw>]]);
-// -
 recipes.addShaped(<TConstruct:SearedBlock:1>, [
 [null, null, null],
 [<TConstruct:materials:2>, null, <TConstruct:materials:2>],


### PR DESCRIPTION
Fixes #9484.

Removes this recipe:
![](https://user-images.githubusercontent.com/40274384/221375280-74704274-907a-495b-bc54-98d33bac7829.png)

I can't figure out how to build the modpack to test yet, but it should work fine.