### PR TITLE
Added alternative gated recipes for ritual stones

### DIFF
--- a/scripts/Blood-Magic-Thaumcraft.zs
+++ b/scripts/Blood-Magic-Thaumcraft.zs
@@ -439,7 +439,7 @@ mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPER
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.1", I18N_Blood_Magic_Thaumcraft_37_a);
 mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPERFECTRITUALSTONE.2");
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.2", I18N_Blood_Magic_Thaumcraft_37_b);
-mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>, "aer 15, ignis 15, aqua 15, terra 15, ordo 15, perditio 15", [
+mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>, "aer 7.5, ignis 7.5, aqua 7.5, terra 7.5, ordo 7.5, perditio 7.5", [
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>],
 [<AWWayofTime:blankSlate>, <BloodArsenal:blood_stone>, <AWWayofTime:blankSlate>],
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>]]);
@@ -454,9 +454,9 @@ mods.thaumcraft.Research.addPrereq("RITUALSTONE", "IMPERFECTRITUALSTONE", false)
 mods.thaumcraft.Research.setConcealed("RITUALSTONE", true);
 mods.thaumcraft.Research.addPage("RITUALSTONE", "tc.research_page.RITUALSTONE");
 game.setLocalization("tc.research_page.RITUALSTONE", I18N_Blood_Magic_Thaumcraft_40);
-mods.thaumcraft.Infusion.addRecipe("RITUALSTONE", <AWWayofTime:imperfectRitualStone>, 
-[<AWWayofTime:terrae>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>, <AWWayofTime:terrae>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>], 
-"terra 24, ignis 18, tenebrae 12, praecantatio 6, aer 3", <AWWayofTime:ritualStone>, 6);
+mods.thaumcraft.Infusion.addRecipe("RITUALSTONE", <AWWayofTime:imperfectRitualStone>,
+[<AWWayofTime:terrae>, <AWWayofTime:terrae>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>],
+"terra 12, ignis 9, tenebrae 6, praecantatio 3, aer 2", <AWWayofTime:ritualStone>, 6);
 mods.thaumcraft.Research.addInfusionPage("RITUALSTONE", <AWWayofTime:ritualStone>);
 mods.thaumcraft.Warp.addToResearch("RITUALSTONE", 1);
 

--- a/scripts/Blood-Magic-Thaumcraft.zs
+++ b/scripts/Blood-Magic-Thaumcraft.zs
@@ -439,7 +439,7 @@ mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPER
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.1", I18N_Blood_Magic_Thaumcraft_37_a);
 mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPERFECTRITUALSTONE.2");
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.2", I18N_Blood_Magic_Thaumcraft_37_b);
-mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>, "aer 7.5, ignis 7.5, aqua 7.5, terra 7.5, ordo 7.5, perditio 7.5", [
+mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>, "aer 8, ignis 8, aqua 8, terra 8, ordo 8, perditio 8", [
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>],
 [<AWWayofTime:blankSlate>, <BloodArsenal:blood_stone>, <AWWayofTime:blankSlate>],
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>]]);

--- a/scripts/Blood-Magic-Thaumcraft.zs
+++ b/scripts/Blood-Magic-Thaumcraft.zs
@@ -439,10 +439,14 @@ mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPER
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.1", I18N_Blood_Magic_Thaumcraft_37_a);
 mods.thaumcraft.Research.addPage("IMPERFECTRITUALSTONE", "tc.research_page.IMPERFECTRITUALSTONE.2");
 game.setLocalization("tc.research_page.IMPERFECTRITUALSTONE.2", I18N_Blood_Magic_Thaumcraft_37_b);
-mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>, "aer 8, ignis 8, aqua 8, terra 8, ordo 8, perditio 8", [
+mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE1", <AWWayofTime:imperfectRitualStone>, "aer 1, ignis 6, terra 8", [
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>],
 [<AWWayofTime:blankSlate>, <BloodArsenal:blood_stone>, <AWWayofTime:blankSlate>],
 [<minecraft:obsidian>, <AWWayofTime:blankSlate>, <minecraft:obsidian>]]);
+mods.thaumcraft.Arcane.addShaped("IMPERFECTRITUALSTONE2", <AWWayofTime:imperfectRitualStone>, "aer 2, ignis 12, terra 16", [
+[<minecraft:air>, <minecraft:obsidian>, <minecraft:air>],
+[<AWWayofTime:imbuedSlate>, <Railcraft:brick.bloodstained:2>, <AWWayofTime:imbuedSlate>],
+[<minecraft:air>, <minecraft:obsidian>, <minecraft:air>]]);
 mods.thaumcraft.Research.addArcanePage("IMPERFECTRITUALSTONE", <AWWayofTime:imperfectRitualStone>);
 
 // --- Ritual Stone
@@ -454,9 +458,13 @@ mods.thaumcraft.Research.addPrereq("RITUALSTONE", "IMPERFECTRITUALSTONE", false)
 mods.thaumcraft.Research.setConcealed("RITUALSTONE", true);
 mods.thaumcraft.Research.addPage("RITUALSTONE", "tc.research_page.RITUALSTONE");
 game.setLocalization("tc.research_page.RITUALSTONE", I18N_Blood_Magic_Thaumcraft_40);
-mods.thaumcraft.Infusion.addRecipe("RITUALSTONE", <AWWayofTime:imperfectRitualStone>,
+mods.thaumcraft.Infusion.addRecipe("RITUALSTONE1", <AWWayofTime:imperfectRitualStone>,
 [<AWWayofTime:terrae>, <AWWayofTime:terrae>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>, <Thaumcraft:blockCosmeticSolid:1>, <AWWayofTime:reinforcedSlate>],
 "terra 12, ignis 9, tenebrae 6, praecantatio 3, aer 2", <AWWayofTime:ritualStone>, 6);
+mods.thaumcraft.Arcane.addShaped("RITUALSTONE2", <AWWayofTime:ritualStone>, "aer 3, ignis 18, terra 24", [
+[<minecraft:obsidian>, <AWWayofTime:terrae>, <minecraft:obsidian>],
+[<AWWayofTime:demonicSlate>, <AWWayofTime:imperfectRitualStone>, <AWWayofTime:demonicSlate>],
+[<minecraft:obsidian>, <AWWayofTime:demonicSlate>, <minecraft:obsidian>]]);
 mods.thaumcraft.Research.addInfusionPage("RITUALSTONE", <AWWayofTime:ritualStone>);
 mods.thaumcraft.Warp.addToResearch("RITUALSTONE", 1);
 

--- a/scripts/Blood-Magic.zs
+++ b/scripts/Blood-Magic.zs
@@ -310,8 +310,6 @@ recipes.remove(<AWWayofTime:AlchemicalWizardrybloodRune:5>);
 
 // --- Awakened Activation Crystal
 mods.bloodmagic.Alchemy.removeRecipe(<AWWayofTime:activationCrystal:1>);
-// -
-mods.bloodmagic.Alchemy.removeRecipe(<AWWayofTime:activationCrystal:1>);
 
 // --- Standart Filling Agent
 mods.bloodmagic.Alchemy.removeRecipe(<AWWayofTime:standardFillingAgent>);
@@ -953,15 +951,17 @@ mods.bloodmagic.Altar.addRecipe(<AWWayofTime:enhancedTelepositionFocus>, <AWWayo
 // --- Blood Soaked Thaumium Block
 mods.bloodmagic.Altar.addRecipe(<dreamcraft:tile.BloodyThaumium>, <Thaumcraft:blockCosmeticSolid:4>, 2, 5000);
 
-// --- Blood Soaked Thaumium Block
+// --- Blood Soaked Void Block
 mods.bloodmagic.Altar.addRecipe(<dreamcraft:tile.BloodyVoid>, <thaumicbases:voidBlock>, 3, 10000);
 
-// --- Blood Soaked Thaumium Block
+// --- Blood Soaked Ichorium Block
 mods.bloodmagic.Altar.addRecipe(<dreamcraft:tile.BloodyIchorium>, <gregtech:gt.blockmetal8:13>, 5, 50000);
 
 // --- Bound Diamond
 mods.bloodmagic.Altar.addRecipe(<BloodArsenal:blood_infused_diamond_bound>, <BloodArsenal:blood_infused_diamond_active>, 5, 10000);
 
+// --- Blood Stained Block
+mods.bloodmagic.Altar.addRecipe(<Railcraft:brick.bloodstained:2>, <minecraft:stone>, 2, 3500);
 
 
 

--- a/scripts/Railcraft.zs
+++ b/scripts/Railcraft.zs
@@ -598,6 +598,9 @@ recipes.remove(<Railcraft:machine.gamma:10>);
 // --- Redstone Flux Unloader
 recipes.remove(<Railcraft:machine.gamma:11>);
 
+// --- Blood Stained Block
+recipes.remove(<Railcraft:brick.bloodstained:2>);
+
 
 
 


### PR DESCRIPTION
Not sure why this PR is showing all 3 commits on this branch when the last PR was merged, hopefully it causes no issues. This PR is a little more dicey than my last since it's doing more major things to the ritual stone recipes, notify me if something needs to be changed. I also fixed a couple of errors and made the imperfect ritual stone recipe's vis cost more in-line with the ritual stone's essentia cost.