### PR TITLE
Small LV solar recipe adjustment

### DIFF
--- a/scripts/CoreMod.zs
+++ b/scripts/CoreMod.zs
@@ -676,7 +676,7 @@ Assembler.addRecipe(<dreamcraft:item.EngineeringProcessorItemAdvEmeraldCore>, <a
 Assembler.addRecipe(<dreamcraft:item.LeadNickelPlate> * 2, <GalaxySpace:item.CompressedPlates:3>, <GalaxySpace:item.CompressedPlates:6>, <liquid:ic2coolant> * 2000, 600, 1024);
 
 // --- Irradiant Reinforced Aluminium Plate
-Assembler.addRecipe(<dreamcraft:item.IrradiantReinforcedAluminiumPlate>, [<dreamcraft:item.ReinforcedAluminiumIronPlate>, <ore:craftingSunnariumPart>, <IC2:itemPartIndustrialDiamond>, <ore:plateRedAlloy> * 2, <ore:screwRedAlloy> * 4], <liquid:molten.solderingalloy> * 144, 600, 120);
+Assembler.addRecipe(<dreamcraft:item.IrradiantReinforcedAluminiumPlate>, [<dreamcraft:item.ReinforcedAluminiumIronPlate>, <minecraft:glowstone>, <IC2:itemPartIndustrialDiamond>, <ore:plateRedAlloy> * 2, <ore:screwRedAlloy> * 4], <liquid:molten.solderingalloy> * 144, 600, 120);
 
 // --- Irradiant Reinforced Titanium Plate
 Assembler.addRecipe(<dreamcraft:item.IrradiantReinforcedTitaniumPlate>, [<dreamcraft:item.ReinforcedTitaniumIronPlate>, <AdvancedSolarPanel:asp_crafting_items>, <ore:plateMeteoricSteel>, <ore:plateLapis> * 2, <ore:screwRedAlloy> * 4], <liquid:molten.solderingalloy> * 288, 600, 480);


### PR DESCRIPTION
Change:
LV Solars no longer need Sunnarium. 

MV+ Solars still do need Sunnarium as before. And LV solars still need a Direcrafting table, MV SCs, Phosphor doped wafers, PTFE, etc.

Impact:
LV Solars will be available in late HV instead of mid EV, but will still be very expensive.

Reasoning:
As also explained in meta-dev, solars should be very expensive and hard to get as when you actually have them, they are easy free power. The interesting infrastructure and expenses are solely up front. However, they should still be in the realm of doable and at most delayed to tier+2 (tier+1 later), to not be completely irrelevant. Indeed the LV solar is currently only available in tier+3=EV and indeed completely irrelevant.
Indeed for a long time sunnarium was HV, but it was moved to EV.