### PR TITLE
Lootgames rebalance

### DIFF
--- a/config/TooMuchLoot/loot/chest1.xml
+++ b/config/TooMuchLoot/loot/chest1.xml
@@ -1,45 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <LootGroup category="chest1" loading_mode="OVERRIDE" count_min="2" count_max="4">
 
-	<loot item="gregtech:gt.blockmachines" damage="5113" weight="15" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5114" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockcasings" damage="10" weight="10" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17300" weight="25" count_min="10" count_max="20"/>
-	<loot item="gregtech:gt.blockmachines" damage="5124" weight="15" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockmachines" damage="5122" weight="15" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.blockmachines" damage="2" weight="10" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="4" weight="10" count_min="1" count_max="2"/>
-	<loot item="IC2:blockMachine" damage="1" weight="20" count_min="2" count_max="4"/>
-	<loot item="minecraft:piston" damage="0" weight="20" count_min="4" count_max="6"/>
-	<loot item="IC2:itemCasing" damage="0" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="1" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="2" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="3" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="4" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="5" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemCasing" damage="6" weight="20" count_min="4" count_max="8"/>
-	<loot item="IC2:itemTreetap" damage="0" weight="25" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockmachines" damage="1" weight="20" count_min="1" count_max="4"/>
-	<loot item="gregtech:gt.metaitem.02" damage="21057" weight="25" count_min="4" count_max="6"/>
-	<loot item="gregtech:gt.blockmachines" damage="1240" weight="20" count_min="8" count_max="12"/>
-	<loot item="gregtech:gt.blockmachines" damage="1246" weight="15" count_min="8" count_max="12"/>
-	<loot item="gregtech:gt.blockmachines" damage="1360" weight="20" count_min="8" count_max="12"/>
-	<loot item="gregtech:gt.blockmachines" damage="1386" weight="15" count_min="8" count_max="12"/>
-	<loot item="gregtech:gt.blockmetal2" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockmetal2" damage="7" weight="10" count_min="1" count_max="2"/>
-	<loot item="Railcraft:part.plate" damage="3" weight="20" count_min="8" count_max="16"/>
-	<loot item="Railcraft:part.plate" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17057" weight="25" count_min="10" count_max="20"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17304" weight="25" count_min="10" count_max="20"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17054" weight="25" count_min="10" count_max="20"/>
-	<loot item="gregtech:gt.metaitem.01" damage="21057" weight="15" count_min="4" count_max="6"/>
-	<loot item="gregtech:gt.metaitem.01" damage="21300" weight="15" count_min="4" count_max="6"/>
-	<loot item="gregtech:gt.metaitem.02" damage="31300" weight="20" count_min="8" count_max="10"/>
-	<loot item="gregtech:gt.metaitem.01" damage="31035" weight="20" count_min="8" count_max="10"/>
-	<loot item="gregtech:gt.metaitem.01" damage="11308" weight="25" count_min="8" count_max="10"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17308" weight="20" count_min="12" count_max="16"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32700" weight="10" count_min="4" count_max="8"/>
-	<loot item="minecraft:flint_and_steel" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:minecart" damage="0" weight="10" count_min="2" count_max="4"/>
 	<loot item="minecraft:hopper_minecart" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:furnace_minecart" damage="0" weight="10" count_min="1" count_max="2"/>
@@ -47,20 +8,43 @@
 	<loot item="minecraft:hopper" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:rail" damage="0" weight="15" count_min="16" count_max="32"/>
 	<loot item="minecraft:ladder" damage="0" weight="20" count_min="10" count_max="15"/>
-	<loot item="minecraft:bed" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="minecraft:bed" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:trapdoor" damage="0" weight="20" count_min="1" count_max="2"/>
 	<loot item="minecraft:iron_bars" damage="0" weight="25" count_min="6" count_max="12"/>
 	<loot item="minecraft:activator_rail" damage="0" weight="10" count_min="2" count_max="4"/>
 	<loot item="minecraft:wooden_door" damage="0" weight="20" count_min="2" count_max="4"/>
-	<loot item="minecraft:blaze_rod" damage="0" weight="10" count_min="2" count_max="4"/>
 	<loot item="minecraft:cauldron" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="minecraft:comparator" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="minecraft:repeater" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="JABBA:mover" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="JABBA:barrel" damage="0" weight="25" count_min="10" count_max="20"/>
-	<loot item="Railcraft:machine.beta" damage="3" weight="20" count_min="4" count_max="8"/>
-	<loot item="Railcraft:machine.beta" damage="4" weight="15" count_min="4" count_max="8"/>
-	<loot item="Railcraft:machine.beta" damage="5" weight="10" count_min="1" count_max="2"/>
-	<loot item="Railcraft:machine.beta" damage="6" weight="10" count_min="1" count_max="2"/>
+	<loot item="minecraft:comparator" damage="0" weight="15" count_min="1" count_max="2"/>
+	<loot item="minecraft:repeater" damage="0" weight="15" count_min="1" count_max="2"/>
+	<loot item="minecraft:bookshelf" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="minecraft:cookie" damage="0" weight="25" count_min="8" count_max="16"/>
+	<loot item="JABBA:barrel" damage="0" weight="25" count_min="2" count_max="3"/>
+	<loot item="Railcraft:machine.beta" damage="3" weight="20" count_min="2" count_max="4"/>
+	<loot item="Railcraft:machine.beta" damage="5" weight="5" count_min="1" count_max="2"/>
+	<loot item="IC2:itemTreetap" damage="0" weight="30" count_min="1" count_max="2"/>
+	<loot item="IC2:blockMachine" damage="1" weight="20" count_min="1" count_max="2"/>
 	<loot item="BuildCraft|Factory:tankBlock" damage="0" weight="20" count_min="2" count_max="4"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18035" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18057" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18300" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18086" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18032" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18305" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.02" damage="18089" weight="20" count_min="4" count_max="6"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17300" weight="25" count_min="5" count_max="10"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17032" weight="25" count_min="5" count_max="10"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17035" weight="25" count_min="5" count_max="10"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17057" weight="25" count_min="5" count_max="10"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17304" weight="25" count_min="5" count_max="10"/>
+	<loot item="harvestcraft:pamlemonSapling" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="harvestcraft:pammapleSapling" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="harvestcraft:pamoliveSapling" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="harvestcraft:pampeppercornSapling" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="harvestcraft:pamvanillaSapling" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="StorageDrawers:fullDrawers1" damage="0" weight="20" count_min="2" count_max="3"/>
+	<loot item="StorageDrawers:fullDrawers2" damage="0" weight="20" count_min="2" count_max="3"/>
+	<loot item="StorageDrawers:fullDrawers4" damage="0" weight="20" count_min="2" count_max="3"/>
+	<loot item="TConstruct:GravelOre" damage="4" weight="20" count_min="4" count_max="6"/>
+	<loot item="Forestry:factory2" damage="2" weight="10" count_min="1" count_max="1"/>
+	
 </LootGroup>

--- a/config/TooMuchLoot/loot/chest2.xml
+++ b/config/TooMuchLoot/loot/chest2.xml
@@ -1,87 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <LootGroup category="chest2" loading_mode="OVERRIDE" count_min="3" count_max="6">
 
-	<loot item="gregtech:gt.metaitem.01" damage="32600" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32610" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32630" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32650" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32680" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32690" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.blockmachines" damage="1246" weight="15" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.blockmachines" damage="1366" weight="10" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32640" weight="10" count_min="1" count_max="1"/>
-	<loot item="IC2:itemPartCircuit" damage="0" weight="15" count_min="2" count_max="4"/>
-	<loot item="IC2:itemDoorAlloy" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="IC2:itemPartAlloy" damage="0" weight="15" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32700" weight="15" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5113" weight="15" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5131" weight="20" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.blockmachines" damage="5132" weight="15" count_min="2" count_max="6"/>
-	<loot item="gregtech:gt.blockmachines" damage="5133" weight="10" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5134" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockmachines" damage="11" weight="5" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32710" weight="15" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32750" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32518" weight="12" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32517" weight="15" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32301" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32302" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32303" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32306" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32308" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32307" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32317" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32405" weight="15" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.blockmachines" damage="1367" weight="25" count_min="2" count_max="8"/>
-	<loot item="gregtech:gt.blockmachines" damage="1367" weight="25" count_min="2" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17019" weight="15" count_min="4" count_max="12"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17301" weight="15" count_min="4" count_max="12"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17343" weight="15" count_min="4" count_max="12"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32700" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32721" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32702" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32716" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="24500" weight="20" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="24502" weight="20" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="24532" weight="20" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="24533" weight="20" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17020" weight="15" count_min="4" count_max="12"/>
+	<loot item="gregtech:gt.blockmachines" damage="1" weight="20" count_min="1" count_max="4"/>
+	<loot item="gregtech:gt.blockmachines" damage="5124" weight="10" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.blockmachines" damage="5122" weight="15" count_min="4" count_max="8"/>
+	<loot item="gregtech:gt.blockmachines" damage="2" weight="15" count_min="2" count_max="4"/>
+	<loot item="gregtech:gt.blockmachines" damage="4" weight="10" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17054" weight="25" count_min="10" count_max="20"/>
+	<loot item="gregtech:gt.metaitem.01" damage="11308" weight="25" count_min="8" count_max="10"/>
+	<loot item="gregtech:gt.metaitem.01" damage="17308" weight="20" count_min="12" count_max="16"/>
 	<loot item="gregtech:gt.metaitem.01" damage="17880" weight="25" count_min="10" count_max="20"/>
 	<loot item="gregtech:gt.metaitem.01" damage="11880" weight="25" count_min="10" count_max="20"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17020" weight="15" count_min="4" count_max="12"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17020" weight="15" count_min="4" count_max="12"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32749" weight="10" count_min="1" count_max="2"/>
-	<loot item="Railcraft:part.plate" damage="1" weight="25" count_min="12" count_max="20"/>
+	<loot item="irontank:ironTank" damage="0" weight="20" count_min="2" count_max="4"/>
 	<loot item="Railcraft:track" damage="816" nbt="{track:&quot;railcraft:track.speed&quot;}" weight="10" count_min="12" count_max="24"/>
 	<loot item="Railcraft:track" damage="0" nbt="{track:&quot;railcraft:track.reinforced&quot;}" weight="10" count_min="12" count_max="24"/>
 	<loot item="Railcraft:track" damage="0" nbt="{track:&quot;railcraft:track.speed.boost&quot;}" weight="10" count_min="8" count_max="16"/>
 	<loot item="Railcraft:track" damage="26865" nbt="{track:&quot;railcraft:track.speed.transition&quot;}" weight="25" count_min="12" count_max="20"/>
 	<loot item="Railcraft:track.elevator" damage="0" weight="10" count_min="10" count_max="20"/>
-	<loot item="Railcraft:machine.alpha" damage="2" weight="10" count_min="1" count_max="1"/>
-	<loot item="Railcraft:machine.beta" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="Railcraft:machine.beta" damage="1" weight="20" count_min="2" count_max="4"/>
-	<loot item="Railcraft:machine.beta" damage="2" weight="20" count_min="2" count_max="4"/>
-	<loot item="Railcraft:machine.beta" damage="13" weight="10" count_min="8" count_max="16"/>
-	<loot item="Railcraft:machine.beta" damage="14" weight="10" count_min="2" count_max="4"/>
-	<loot item="Railcraft:machine.beta" damage="15" weight="10" count_min="2" count_max="4"/>
 	<loot item="Railcraft:cart.tank" damage="0" weight="25" count_min="1" count_max="2"/>
-	<loot item="minecraft:ghast_tear" damage="0" weight="10" count_min="1" count_max="2"/>
-	<loot item="minecraft:brewing_stand" damage="0" weight="5" count_min="1" count_max="1"/>
-	<loot item="minecraft:nether_star" damage="0" weight="5" count_min="1" count_max="1"/>
+	<loot item="Railcraft:machine.beta" damage="4" weight="15" count_min="4" count_max="8"/>
+	<loot item="Railcraft:machine.beta" damage="6" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:iron_door" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:tnt" damage="0" weight="15" count_min="4" count_max="8"/>
 	<loot item="minecraft:clock" damage="0" weight="15" count_min="1" count_max="1"/>
 	<loot item="minecraft:compass" damage="0" weight="15" count_min="1" count_max="1"/>
-	<loot item="minecraft:ender_eye" damage="0" weight="20" count_min="1" count_max="2"/>
+	<loot item="minecraft:piston" damage="0" weight="20" count_min="4" count_max="6"/>
+	<loot item="minecraft:flint_and_steel" damage="0" weight="10" count_min="1" count_max="2"/>
 	<loot item="minecraft:magma_cream" damage="0" weight="20" count_min="1" count_max="2"/>
-	<loot item="dreamcraft:item.AluminiumBars" damage="0" weight="20" count_min="4" count_max="8"/>
-	<loot item="dreamcraft:item.SteelBars" damage="0" weight="20" count_min="4" count_max="8"/>
-	<loot item="irontank:ironTank" damage="0" weight="20" count_min="2" count_max="4"/>
-	<loot item="EnderIO:blockTank" damage="0" weight="15" count_min="1" count_max="2"/>
-	<loot item="Forestry:ffarm" damage="0" nbt="{FarmBlock:0}" weight="20" count_min="1" count_max="2"/>
-	<loot item="Forestry:ffarm" damage="2" nbt="{FarmBlock:0}" weight="20" count_min="8" count_max="16"/>
-	<loot item="Forestry:ffarm" damage="3" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
-	<loot item="Forestry:ffarm" damage="4" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
-	<loot item="Forestry:ffarm" damage="5" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
-	<loot item="Forestry:factory" damage="1" weight="10" count_min="1" count_max="1"/>	
+	<loot item="TConstruct:materials" damage="43" weight="20" count_min="2" count_max="3"/>
+	<loot item="gregtech:gt.metaitem.02" damage="32261" weight="20" count_min="3" count_max="6"/>
+	<loot item="harvestcraft:neapolitanicecreamItem" damage="0" weight="20" count_min="3" count_max="6"/>
+	<loot item="Forestry:beehives" damage="1" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:beehives" damage="2" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:beehives" damage="3" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:beehives" damage="4" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:beehives" damage="6" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:beehives" damage="7" weight="20" count_min="1" count_max="2"/>
+	<loot item="TConstruct:slime.sapling" damage="0" weight="20" count_min="2" count_max="4"/>
+	<loot item="IronChest:BlockIronChest" damage="2" weight="20" count_min="1" count_max="2"/>
+	<loot item="StorageDrawers:upgradeTemplate" damage="0" weight="20" count_min="3" count_max="3"/>
+	<loot item="StorageDrawers:upgradeLock" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="IC2:itemArmorAlloyChestplate" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32301" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32302" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32303" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32306" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32307" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32308" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32317" weight="25" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.blockmachines" damage="5602" weight="25" count_min="8" count_max="16"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32721" weight="10" count_min="1" count_max="1"/>
+	<loot item="Railcraft:machine.beta" damage="0" weight="20" count_min="8" count_max="12"/>
+	<loot item="Railcraft:machine.beta" damage="1" weight="20" count_min="2" count_max="4"/>
+	<loot item="Railcraft:machine.beta" damage="2" weight="20" count_min="1" count_max="2"/>
+	
 </LootGroup>

--- a/config/TooMuchLoot/loot/chest3.xml
+++ b/config/TooMuchLoot/loot/chest3.xml
@@ -1,76 +1,60 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <LootGroup category="chest3" loading_mode="OVERRIDE" count_min="4" count_max="8">
     
-	<loot item="gregtech:gt.blockmachines" damage="12" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32717" weight="15" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32715" weight="10" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32711" weight="10" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32702" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32729" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32745" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32751" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32728" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32727" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32734" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32733" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32735" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32740" weight="10" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32762" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32691" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32681" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32611" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32631" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32601" weight="10" count_min="2" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32527" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32528" weight="10" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32407" weight="15" count_min="1" count_max="2"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32350" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32351" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32353" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32353" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32355" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32356" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32357" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32358" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32359" weight="25" count_min="1" count_max="1"/>	
-	<loot item="gregtech:gt.metaitem.01" damage="32360" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32361" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="32362" weight="25" count_min="1" count_max="1"/>												
-	<loot item="gregtech:gt.metaitem.01" damage="32363" weight="25" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17306" weight="20" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5141" weight="20" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5142" weight="15" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="5143" weight="10" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.blockmachines" damage="130" weight="5" count_min="1" count_max="1"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17379" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17364" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="21032" weight="20" count_min="2" count_max="4"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17378" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17365" weight="25" count_min="4" count_max="8"/>
-	<loot item="gregtech:gt.metaitem.01" damage="17381" weight="25" count_min="4" count_max="8"/>
+	<loot item="minecraft:ghast_tear" damage="0" weight="10" count_min="1" count_max="2"/>
+	<loot item="minecraft:blaze_rod" damage="0" weight="10" count_min="1" count_max="2"/>
+	<loot item="minecraft:cake" damage="0" weight="30" count_min="1" count_max="1"/>
+	<loot item="JABBA:mover" damage="0" weight="10" count_min="1" count_max="1"/>
+	<loot item="dreamcraft:item.SteelBars" damage="0" weight="20" count_min="4" count_max="8"/>
+	<loot item="Forestry:ffarm" damage="0" nbt="{FarmBlock:0}" weight="20" count_min="1" count_max="2"/>
+	<loot item="Forestry:ffarm" damage="2" nbt="{FarmBlock:0}" weight="20" count_min="8" count_max="16"/>
+	<loot item="Forestry:ffarm" damage="3" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
+	<loot item="Forestry:ffarm" damage="4" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
+	<loot item="Forestry:ffarm" damage="5" nbt="{FarmBlock:0}" weight="20" count_min="4" count_max="8"/>
+	<loot item="Forestry:factory" damage="1" weight="10" count_min="1" count_max="1"/>
+	<loot item="EnderIO:blockTank" damage="0" weight="15" count_min="1" count_max="2"/>	
 	<loot item="openmodularturrets:hardWallTierOne" damage="0" weight="25" count_min="10" count_max="20"/>
 	<loot item="openmodularturrets:hardWallTierTwo" damage="0" weight="15" count_min="10" count_max="20"/>
 	<loot item="openmodularturrets:fenceTierOne" damage="0" weight="25" count_min="10" count_max="20"/>
 	<loot item="openmodularturrets:fenceTierTwo" damage="0" weight="15" count_min="10" count_max="20"/>
-	<loot item="EnderIO:itemLiquidConduit" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="EnderIO:itemLiquidConduit" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="EnderIO:blockTank" damage="1" weight="10" count_min="1" count_max="2"/>
-	<loot item="EnderIO:itemMachinePart" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="EnderIO:itemRedstoneConduit" damage="0" weight="20" count_min="8" count_max="16"/>
-	<loot item="ProjRed|Transportation:projectred.transportation.pipe" damage="0" weight="20" count_min="4" count_max="8"/>
-	<loot item="ProjRed|Core:projectred.core.part" damage="44" weight="25" count_min="4" count_max="8"/>
-	<loot item="IC2:blockMiningPipe" damage="0" weight="25" count_min="16" count_max="32"/>
-	<loot item="IC2:itemPartCarbonPlate" damage="0" weight="25" count_min="4" count_max="8"/>
-	<loot item="IC2:itemBoat" damage="0" weight="15" count_min="1" count_max="2"/>
-	<loot item="IC2:itemBatCrystal" damage="26" nbt="{}" weight="5" count_min="1" count_max="1"/>
-	<loot item="minecraft:enchanting_table" damage="0" weight="5" count_min="1" count_max="1"/>
-	<loot item="minecraft:beacon" damage="0" weight="5" count_min="1" count_max="1"/>
-	<loot item="adventurebackpack:coalJetpack" damage="0" nbt="{jetpackData:{}}" weight="5" count_min="1" count_max="1"/>
-	<loot item="adventurebackpack:copterPack" damage="0" nbt="{}"  weight="5" count_min="1" count_max="1"/>
-	<loot item="dreamcraft:item.StainlessSteelBars" damage="0" weight="15" count_min="4" count_max="8"/>
-	<loot item="irontank:diamondTank" damage="0" weight="15" count_min="1" count_max="2"/>
-	<loot item="Forestry:chipsets" damage="0" nbt="{T:0s}" weight="10" count_min="1" count_max="2"/>
-	<loot item="Forestry:chipsets" damage="1" nbt="{T:1s}" weight="10" count_min="1" count_max="2"/>
-	<loot item="Forestry:chipsets" damage="2" nbt="{T:2s}" weight="10" count_min="1" count_max="2"/>
-	<loot item="Forestry:chipsets" damage="3" nbt="{T:3s}" weight="10" count_min="1" count_max="2"/>
+	<loot item="irontank:goldTank" damage="0" weight="20" count_min="2" count_max="4"/>
+	<loot item="Thaumcraft:ItemBootsRobe" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="Thaumcraft:ItemLeggingsRobe" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="Thaumcraft:ItemChestplateRobe" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="Thaumcraft:blockCustomPlant" damage="5" weight="25" count_min="5" count_max="10"/>
+	<loot item="Thaumcraft:blockJar" damage="0" weight="25" count_min="5" count_max="10"/>
+	<loot item="BiomesOPlenty:flowers2" damage="2" weight="15" count_min="10" count_max="10"/>
+	<loot item="TConstruct:materials" damage="8" weight="15" count_min="2" count_max="3"/>
+	<loot item="TConstruct:materials" damage="26" weight="15" count_min="1" count_max="1"/>
+	<loot item="kubatech:kubaitems" damage="14" weight="20" count_min="2" count_max="2"/>
+	<loot item="kubatech:kubaitems" damage="16" weight="20" count_min="2" count_max="2"/>
+	<loot item="kubatech:kubaitems" damage="19" weight="20" count_min="2" count_max="2"/>
+	<loot item="Forestry:beeCombs" damage="6" weight="20" count_min="10" count_max="20"/>
+	<loot item="Forestry:honeyDrop" damage="0" weight="20" count_min="16" count_max="32"/>
+	<loot item="Forestry:apiculture" damage="0" weight="20" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32405" weight="10" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32600" weight="10" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32610" weight="10" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32630" weight="10" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32640" weight="10" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32650" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32680" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32690" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32727" weight="20" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32730" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32731" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32732" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32733" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32734" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32740" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32745" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32749" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.blockmachines" damage="1246" weight="15" count_min="4" count_max="8"/>
+	<loot item="gregtech:gt.blockmachines" damage="1366" weight="15" count_min="2" count_max="4"/>
+	<loot item="gregtech:gt.blockmachines" damage="30727" weight="20" count_min="4" count_max="8"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32519" weight="20" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.blockmachines" damage="31066" weight="15" count_min="1" count_max="1"/>
+	<loot item="ExtraUtilities:spike_base_diamond" damage="0" weight="15" count_min="3" count_max="4"/>
+	<loot item="Forestry:frameImpregnated" damage="0" weight="15" count_min="3" count_max="3"/>
+
 </LootGroup>

--- a/config/TooMuchLoot/loot/chest4.xml
+++ b/config/TooMuchLoot/loot/chest4.xml
@@ -1,39 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <LootGroup category="chest4" loading_mode="OVERRIDE" count_min="5" count_max="10">
 
-		<loot item="gregtech:gt.metaitem.01" damage="32712" weight="15" count_min="1" count_max="2"/>
-	    <loot item="gregtech:gt.metaitem.01" damage="32718" weight="20" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32722" weight="10" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32752" weight="5" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32713" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32714" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32682" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32652" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32642" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32632" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32612" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32602" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32537" weight="10" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32538" weight="10" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32408" weight="5" count_min="1" count_max="1"/>
-		<loot item="IC2:itemPartCircuitAdv" damage="0" weight="10" count_min="1" count_max="1"/>
-		<loot item="IC2:itemBatLamaCrystal" damage="26" nbt="{}" weight="5" count_min="1" count_max="1"/>
-		<loot item="IC2:itemBatCrystal" damage="26" nbt="{}" weight="10" count_min="1" count_max="1"/>
-		<loot item="IC2:itemCropnalyzer" damage="26" nbt="{}" weight="10" count_min="1" count_max="1"/>
-		<loot item="IC2:itemScanner" damage="26" nbt="{}" weight="10" count_min="1" count_max="1"/>
-		<loot item="IC2:itemScannerAdv" damage="26" nbt="{}" weight="10" count_min="1" count_max="1"/>
-		<loot item="dreamcraft:item.NanoCrystal" damage="0" weight="5" count_min="1" count_max="1"/>												
-		<loot item="gregtech:gt.metaitem.02" damage="30500" weight="10" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.02" damage="30502" weight="10" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.02" damage="30501" weight="10" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.metaitem.01" damage="32692" weight="15" count_min="1" count_max="2"/>
-		<loot item="gregtech:gt.blockmachines" damage="13" weight="10" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.blockmachines" damage="131" weight="10" count_min="1" count_max="1"/>
-		<loot item="gregtech:gt.blockmachines" damage="5144" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockmachines" damage="1428" weight="25" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockmachines" damage="1423" weight="25" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockcasings5" damage="0" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockcasings" damage="11" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockcasings2" damage="0" weight="10" count_min="4" count_max="8"/>
-		<loot item="gregtech:gt.blockcasings4" damage="1" weight="10" count_min="4" count_max="8"/>		
+	<loot item="minecraft:brewing_stand" damage="0" weight="5" count_min="1" count_max="1"/>
+	<loot item="minecraft:enchanting_table" damage="0" weight="5" count_min="1" count_max="1"/>
+	<loot item="dreamcraft:item.AluminiumBars" damage="0" weight="20" count_min="4" count_max="8"/>
+	<loot item="ProjRed|Transportation:projectred.transportation.pipe" damage="0" weight="20" count_min="4" count_max="8"/>
+	<loot item="ProjRed|Core:projectred.core.part" damage="44" weight="20" count_min="4" count_max="8"/>
+	<loot item="Forestry:chipsets" damage="0" nbt="{T:0s}" weight="10" count_min="1" count_max="2"/>
+	<loot item="Forestry:chipsets" damage="1" nbt="{T:1s}" weight="10" count_min="1" count_max="2"/>
+	<loot item="Forestry:chipsets" damage="2" nbt="{T:2s}" weight="10" count_min="1" count_max="2"/>
+	<loot item="Forestry:chipsets" damage="3" nbt="{T:3s}" weight="10" count_min="1" count_max="2"/>
+	<loot item="irontank:diamondTank" damage="0" weight="15" count_min="1" count_max="2"/>
+	<loot item="adventurebackpack:coalJetpack" damage="0" nbt="{jetpackData:{}}" weight="5" count_min="1" count_max="1"/>
+	<loot item="adventurebackpack:copterPack" damage="0" nbt="{}"  weight="5" count_min="1" count_max="1"/>
+	<loot item="IC2:blockMiningPipe" damage="0" weight="25" count_min="16" count_max="32"/>
+	<loot item="IC2:itemPartCarbonPlate" damage="0" weight="25" count_min="4" count_max="8"/>
+	<loot item="IC2:itemBoat" damage="0" weight="15" count_min="1" count_max="2"/>
+	<loot item="TConstruct:materials" damage="6" weight="15" count_min="1" count_max="1"/>
+	<loot item="Avaritia:Cosmic_Meatballs" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="Avaritia:Ultimate_Stew" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="minecraft:golden_apple" damage="1" weight="15" count_min="1" count_max="1"/>
+	<loot item="Forestry:alveary" damage="0" weight="20" count_min="2" count_max="3"/>
+	<loot item="ExtraUtilities:divisionSigil" damage="0" weight="15" count_min="1" count_max="1"/>
+	<loot item="MagicBees:frameOblivion" damage="0" weight="5" count_min="1" count_max="1"/>
+	<loot item="ExtraBees:hiveFrame.soul" damage="0" weight="10" count_min="1" count_max="1"/>
+	<loot item="Forestry:frameProven" damage="0" weight="15" count_min="2" count_max="3"/>	
+	<loot item="gregtech:gt.metaitem.01" damage="32729" weight="15" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32407" weight="15" count_min="1" count_max="2"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32601" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32611" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32631" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32641" weight="5" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="32529" weight="15" count_min="1" count_max="1"/>
+	<loot item="gregtech:gt.metaitem.01" damage="2856" weight="15" count_min="32" count_max="32"/>	
+	<loot item="EnderIO:itemItemConduit" damage="0" weight="20" count_min="8" count_max="16"/>
+	<loot item="EnderIO:itemLiquidConduit" damage="0" weight="20" count_min="8" count_max="16"/>
+	<loot item="EnderIO:itemMachinePart" damage="0" weight="20" count_min="3" count_max="4"/>
+	<loot item="EnderIO:itemRedstoneConduit" damage="0" weight="20" count_min="8" count_max="16"/>
+	<loot item="EnderIO:blockReinforcedObsidian" damage="0" weight="15" count_min="4" count_max="6"/>
+	<loot item="OpenBlocks:fan" damage="0" weight="15" count_min="2" count_max="3"/>
+	<loot item="Thaumcraft:ItemSanitySoap" damage="0" weight="25" count_min="4" count_max="8"/>
+	<loot item="thaumicinsurgence:item.ItemSanitySoapAlpha" damage="0" weight="10" count_min="2" count_max="3"/>
+	<loot item="thaumicinsurgence:item.ItemSanitySoapBeta" damage="0" weight="5" count_min="1" count_max="2"/>
+	
 </LootGroup>


### PR DESCRIPTION
As discussed here and in the following pages on discord: https://discord.com/channels/181078474394566657/939305179524792340/1090192484115681320

This a rebalance of the loot obtained in game of light. (chest1/chest2/chest3/chest4) There was general consensus in the meta-dev channel that this is needed. (see more about the reasoning there)

General goals of the rebalance:
- reduce the overall power of lootgames in early game somewhat while still keeping things rewarding.
- reduce the tierskipping potential from rewards.
- broaden the rewards to non-tech parts of the early game
- clean up the files a bit . (duplicates and things that get autoconverted.)

How to achieve these goals:
- no more rewards that require HV+ technology.
- only limitted amounts that would need MV technology.
- addition various bee related and thaumcraft related rewards to help players get started in these directions. Also added some sapling for rare pam fruits and powerful food items, as well as a few other miscellanious items (kuba teas, openblock fan+diamond spike, etc) .
- some powerful drops remain/were added to the chest4 loot pool to keep lootgames' attraction: brewing stand/enchantment table/copterpack/oblivion frame/ball of moss/alveary block. These are all great without allowing the player to skip several tiers of technology.


How to test/play around with this: you can spawn in a chest at your position with
\loot spawnDebugChest chest4 ~ ~ ~
