### PR TITLE
Typo Fix (mineyourmine > mineyourmind)

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -15,7 +15,7 @@
     "MMC No TP (Eu+Asia2)": "gtnh-im.moddedminecraft.club",
     "MMC No TP (Am+Aus2)": "gtnh-im-na.moddedminecraft.club",
     "Earthquake GTNH (US West)": "aragil.ddns.net",
-    "MineYourMine GTNH (EU)": "horizons.mineyourmind.net",
+    "MineYourMind GTNH (EU)": "horizons.mineyourmind.net",
     "Arcturus Network GTNH (EU)": "play.arcturus-official.eu",
     "ValhallaMC (EU)": "gtnh.valhallamc.io"
 }


### PR DESCRIPTION
I believe it should be `mineyourmind`, but it is `mineyourmine`.