### PR TITLE
Enable T9 Oregen

### DIFF
--- a/config/GregTech/WorldGeneration.cfg
+++ b/config/GregTech/WorldGeneration.cfg
@@ -484,6 +484,7 @@ worldgen {
             }
 
             blackplutonium {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_BarnardC_false=true
                 B:GalaxySpace_CentauriA_false=true
                 B:GalaxySpace_MakeMake_false=true
@@ -496,6 +497,7 @@ worldgen {
             }
 
             cassiterite {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftCore_Moon_false=true
                 B:GalaxySpace_Io_false=true
                 B:GalaxySpace_Miranda_false=true
@@ -537,6 +539,8 @@ worldgen {
             }
 
             draconium {
+                B:GalacticraftAmunRa_Horus_false=true
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Mercury_false=true
                 B:GalaxySpace_Miranda_false=true
@@ -553,6 +557,7 @@ worldgen {
             }
 
             europa {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Europa_false=true
                 B:GalaxySpace_TcetiE_false=true
             }
@@ -578,6 +583,7 @@ worldgen {
             }
 
             garnet {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_BarnardF_false=true
                 B:GalaxySpace_MakeMake_false=true
                 B:GalaxySpace_VegaB_false=true
@@ -589,6 +595,7 @@ worldgen {
             }
 
             gold {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalacticraftMars_Asteroids_false=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_BarnardF_false=true
@@ -620,6 +627,7 @@ worldgen {
             }
 
             iridiummytryl {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_Enceladus_false=true
                 B:GalaxySpace_Io_false=true
                 B:GalaxySpace_Kuiperbelt_false=true
@@ -647,6 +655,7 @@ worldgen {
 
             lapis {
                 B:EndAsteroid_false=true
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Enceladus_false=true
@@ -655,6 +664,7 @@ worldgen {
             }
 
             ledox {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Enceladus_false=true
                 B:GalaxySpace_Europa_false=true
             }
@@ -664,6 +674,7 @@ worldgen {
             }
 
             magnetite {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Deimos_false=true
@@ -690,6 +701,8 @@ worldgen {
             }
 
             mineralsand {
+                B:GalacticraftAmunRa_Anubis_false=true
+                B:GalacticraftAmunRa_Maahes_false=true
                 B:GalaxySpace_BarnardC_false=true
                 B:GalaxySpace_Europa_false=true
             }
@@ -707,6 +720,7 @@ worldgen {
             }
 
             monazite {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalacticraftCore_Moon_false=true
                 B:GalaxySpace_BarnardF_false=true
                 B:GalaxySpace_Callisto_false=true
@@ -721,6 +735,7 @@ worldgen {
             }
 
             mytryl {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Io_false=true
             }
 
@@ -744,6 +759,7 @@ worldgen {
             }
 
             netherstar {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_Haumea_false=true
                 B:GalaxySpace_TcetiE_false=true
@@ -751,6 +767,7 @@ worldgen {
             }
 
             neutronium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_BarnardF_false=true
                 B:GalaxySpace_Haumea_false=true
@@ -763,6 +780,7 @@ worldgen {
             }
 
             nickel {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Kuiperbelt_false=true
@@ -787,6 +805,7 @@ worldgen {
 
             olivine {
                 B:EndAsteroid_false=true
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Haumea_false=true
@@ -795,11 +814,13 @@ worldgen {
             }
 
             oriharukon {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Phobos_false=true
             }
 
             osmium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_BarnardC_false=true
                 B:GalaxySpace_Enceladus_false=true
                 B:GalaxySpace_Kuiperbelt_false=true
@@ -830,9 +851,11 @@ worldgen {
 
             platinum {
                 B:EndAsteroid_false=true
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
             }
 
             platinumchrome {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_Callisto_false=true
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Ganymede_false=true
@@ -844,6 +867,7 @@ worldgen {
             }
 
             quartzspace {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalacticraftCore_Moon_false=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_CentauriA_false=true
@@ -855,6 +879,7 @@ worldgen {
             }
 
             quantium {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Venus_false=true
             }
 
@@ -904,15 +929,19 @@ worldgen {
             }
 
             sapphire {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             secondlanthanid {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalaxySpace_BarnardC_false=true
                 B:GalaxySpace_CentauriA_false=true
             }
 
             soapstone {
+                B:GalacticraftAmunRa_Anubis_false=true
+                B:GalacticraftAmunRa_Maahes_false=true
                 B:GalaxySpace_Ceres_false=true
                 B:"Twilight Forest_false"=true
             }
@@ -943,6 +972,7 @@ worldgen {
             }
 
             titaniumchrome {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftCore_Moon_false=true
                 B:GalacticraftMars_Asteroids_false=true
                 B:GalaxySpace_Callisto_false=true
@@ -983,6 +1013,7 @@ worldgen {
             }
 
             uranium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_Ceres_false=true
                 B:GalaxySpace_Deimos_false=true
@@ -1006,6 +1037,35 @@ worldgen {
             luvtantalite {
                 B:GalaxySpace_Io_false=true
                 B:GalaxySpace_Miranda_false=true
+            }
+
+            certusquartz {
+                B:GalacticraftAmunRa_Horus_false=true
+                B:GalacticraftAmunRa_Neper_false=true
+            }
+
+            infinitycatalyst {
+                B:GalacticraftAmunRa_Anubis_false=true
+            }
+
+            cosmicneutronium {
+                B:GalacticraftAmunRa_Horus_false=true
+            }
+
+            dilithium {
+                B:GalacticraftAmunRa_Neper_false=true
+            }
+
+            naquadria {
+                B:GalacticraftAmunRa_Maahes_false=true
+            }
+
+            awakeneddraconium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
+            }
+
+            tengam {
+                B:GalacticraftAmunRa_Seth_false=true
             }
 
         }

--- a/config/GregTech/WorldGeneration.cfg
+++ b/config/GregTech/WorldGeneration.cfg
@@ -14,6 +14,7 @@ worldgen {
             }
 
             tin {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Ganymede_false=true
@@ -108,6 +109,7 @@ worldgen {
             }
 
             nickel {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftMars_Asteroids_false=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_BarnardE_false=true
@@ -123,6 +125,7 @@ worldgen {
             }
 
             lapis {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_Enceladus_false=true
                 B:GalaxySpace_Ganymede_false=true
                 B:GalaxySpace_Io_false=true
@@ -145,46 +148,58 @@ worldgen {
             }
 
             emerald {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             ruby {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             sapphire {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             greensapphire {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             olivine {
+                B:GalacticraftAmunRa_Horus_false=true
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:"Twilight Forest_false"=true
             }
 
             topaz {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             tanzanite {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             amethyst {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             opal {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             jasper {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             bluetopaz {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
@@ -193,14 +208,17 @@ worldgen {
             }
 
             foolsruby {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             garnetred {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             garnetyellow {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
@@ -225,6 +243,7 @@ worldgen {
             }
 
             titanium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftMars_Asteroids_false=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_BarnardE_false=true
@@ -270,6 +289,7 @@ worldgen {
             }
 
             neutronium {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_BarnardF_false=true
                 B:GalaxySpace_Enceladus_false=true
@@ -286,6 +306,7 @@ worldgen {
             }
 
             chromite {
+                B:"GalacticraftAmunRa_Mehen Belt_false"=true
                 B:GalacticraftMars_Asteroids_false=true
                 B:GalacticraftMars_Mars_false=true
                 B:GalaxySpace_Callisto_false=true
@@ -352,6 +373,7 @@ worldgen {
             }
 
             mythril {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:GalaxySpace_Callisto_false=true
                 B:GalaxySpace_MakeMake_false=true
                 B:GalaxySpace_Miranda_false=true
@@ -379,6 +401,7 @@ worldgen {
             }
 
             draconium {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalaxySpace_Deimos_false=true
                 B:GalaxySpace_Ganymede_false=true
                 B:GalaxySpace_Haumea_false=true
@@ -390,6 +413,7 @@ worldgen {
             }
 
             awdraconium {
+                B:GalacticraftAmunRa_Seth_false=true
                 B:GalaxySpace_BarnardE_false=true
                 B:GalaxySpace_BarnardF_false=true
                 B:GalaxySpace_TcetiE_false=true
@@ -419,6 +443,7 @@ worldgen {
             }
 
             infinitycatalyst {
+                B:GalacticraftAmunRa_Anubis_false=true
                 B:GalaxySpace_VegaB_false=true
             }
 
@@ -432,15 +457,25 @@ worldgen {
             }
 
             certusquartz {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:Nether_false=true
             }
 
             jade {
+                B:GalacticraftAmunRa_Horus_false=true
                 B:"Twilight Forest_false"=true
             }
 
             deepiron {
                 B:GalaxySpace_Mercury_false=true
+            }
+
+            redgarnet {
+                B:GalacticraftAmunRa_Horus_false=true
+            }
+
+            chargedcertus {
+                B:GalacticraftAmunRa_Horus_false=true
             }
 
         }


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/1906 and https://github.com/GTNewHorizons/amunra/pull/4

Based on a modified version of the oregen spreadsheet: [GTNewHorizons.ods](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/files/11304816/GTNewHorizons.ods)

*Note: Not all T9 dimensions have a "full" (~12 veins) set of oreveins yet, partly because of a lack of creativity on my end, partly because I don't know enough about the late game to know what would be beneficial. Any Feedback is appreciatet.*