### PR TITLE
Update actions/stale to v8

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 3 days'
@@ -18,9 +18,8 @@ jobs:
         stale-issue-label: 'Status: stale'
         any-of-labels: "Server: Delta,Server: EU Live Server,Server: Epsilon,Server: Eta,Server: Prospercraft,Server: Zeta,Status: NO,Status: Need new Idea,Status: Open for discussion,Status: RFC (request for comment),Status: Waiting for Feedback,Status: mod remove,Status: need to be tested,Status: report it at original Repo,Type: Idea,Type: Info,Type: Need more Info,Type: Nerf,Type: New Quests,Type: New Tooltip,Type: New recipe,Type: Not a Bug,Type: Won't change,Type: addition,Type: additional Mod,Type: balancing,Type: config,Type: duplicate,Type: enhancement,Type: invalid,Type: not our fault,Type: question,Type: refactor,Type: script changes,Type: silly suggestion,Type: suggestion"
         exempt-issue-labels: 'Priority: CRITICAL,Priority: HIGH,Status: CodeComplete,Status: FixedInDev,Status: accepted,Status: work in progress,Status: waiting for fix,Type: bugMajor,Type: bugMinor,Type: exploit,Type: reminder,Type: urgent,Type: Crash'
-        close-issue-reason: 'not_planned'
         ascending: true
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 3 days'
@@ -30,9 +29,8 @@ jobs:
         stale-issue-label: 'Status: stale'
         any-of-labels: "Status: can't fix,Status: can't reproduce,Status: Nothing i can do here"
         exempt-issue-labels: 'Type: reminder,Type: Crash,Status: FixedInDev,Status: stale (FixedInDev)'
-        close-issue-reason: 'not_planned'
         ascending: true
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been FixedInDev for quite a while and nobody commented in 7 days. Remove FixedInDev label or comment or this will be closed in 1 days'
@@ -42,5 +40,4 @@ jobs:
         stale-issue-label: 'Status: stale (FixedInDev)'
         exempt-issue-labels: 'Status: stale'
         any-of-labels: "Status: FixedInDev"
-        close-issue-reason: 'not_planned'
         ascending: true


### PR DESCRIPTION
`close-issue-reason` is not included in v3. https://github.com/actions/stale/commit/06d2a3904b77e3b34b74319855eebe4627488d19
Also it's set to `not_planned` by default. https://github.com/actions/stale/commit/02e44c81cc3144e8817a5686f3d7c24658f6f1e6