### PR TITLE
Increased the number of chunks the mod can load

### DIFF
--- a/config/forgeChunkLoading.cfg
+++ b/config/forgeChunkLoading.cfg
@@ -1,5 +1,11 @@
 # Configuration file
 
+FTBU {
+    I:maximumChunksPerTicket=30000
+    I:maximumTicketCount=2000
+}
+
+
 ##########################################################################################################
 # Forge
 #--------------------------------------------------------------------------------------------------------#
@@ -11,10 +17,10 @@
 
 Forge {
     # Maximum chunks per ticket for the mod.
-    I:maximumChunksPerTicket=25
+    I:maximumChunksPerTicket=2500
 
     # Maximum ticket count for the mod. Zero disables chunkloading capabilities.
-    I:maximumTicketCount=200
+    I:maximumTicketCount=2000
 }
 
 
@@ -30,14 +36,14 @@ defaults {
 
     # The default maximum number of chunks a mod can force, per ticket, 
     # for a mod without an override. This is the maximum number of chunks a single ticket can force.
-    I:maximumChunksPerTicket=25
+    I:maximumChunksPerTicket=2500
 
     # The default maximum ticket count for a mod which does not have an override
     # in this file. This is the number of chunk loading requests a mod is allowed to make.
-    I:maximumTicketCount=200
+    I:maximumTicketCount=2000
 
     # The number of tickets a player can be assigned instead of a mod. This is shared across all mods and it is up to the mods to use it.
-    I:playerTicketCount=500
+    I:playerTicketCount=2000
 
     # Unloaded chunks can first be kept in a dormant cache for quicker
     # loading times. Specify the size (in chunks) of that cache here


### PR DESCRIPTION
When using the default parameters, multiplayer games, the player leaves the garden, and the garden stops working, even with anchors