### PR TITLE
Update quests about High Pressure steam machines

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeABetterCo-AAAAAAAAAAAAAAAAAAAANw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeABetterCo-AAAAAAAAAAAAAAAAAAAANw==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "An updated version of the steam compressor. Uses more steam, but is almost twice as fast."
+      "desc:8": "An updated version of the steam compressor. Uses the same total amount of steam as its predecessor but does the job twice as fast."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeBetterFur-AAAAAAAAAAAAAAAAAAAAQA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeBetterFur-AAAAAAAAAAAAAAAAAAAAQA==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "An updated version of the steam furnace. Uses more steam, but is almost twice as fast."
+      "desc:8": "An updated version of the steam furnace. Uses the same total amount of steam as its predecessor but does the job twice as fast."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeBetterMac-AAAAAAAAAAAAAAAAAAAAOg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeBetterMac-AAAAAAAAAAAAAAAAAAAAOg==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "An updated version of the steam macerator. Uses more steam, but is almost twice as fast."
+      "desc:8": "An updated version of the steam macerator. Uses the same total amount of steam as its predecessor but does the job twice as fast."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeExtractor-AAAAAAAAAAAAAAAAAAAAOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeExtractor-AAAAAAAAAAAAAAAAAAAAOQ==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "An updated version of the steam extractor. Uses more steam, but is almost twice as fast. You probably want to craft this, as the extractor does also extract your nerves..."
+      "desc:8": "An updated version of the steam extractor. Uses the same total amount of steam as its predecessor but does the job twice as fast.\n\nYou probably want to craft this, as the extractor does also extract your nerves..."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeForgeHamm-AAAAAAAAAAAAAAAAAAAAOA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeForgeHamm-AAAAAAAAAAAAAAAAAAAAOA==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "An updated version of the steam forge hammer. Uses more steam, but is almost twice as fast."
+      "desc:8": "An updated version of the steam forge hammer. Uses the same total amount of steam as its predecessor but does the job twice as fast."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeHighSpeed-AAAAAAAAAAAAAAAAAAAALw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/UpgradeHighSpeed-AAAAAAAAAAAAAAAAAAAALw==.json
@@ -41,7 +41,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Like most machines, there is a more advanced version of the alloy smelter. Keep in mind that this machine uses a lot of steam, so you better get some more boilers first."
+      "desc:8": "Like most machines, there is a more advanced version of the alloy smelter. It uses the same total amount of steam as its predecessor but does the job twice as fast.\n\nKeep in mind that it uses quite a lot of steam, so you better have enough of it in boilers, pipes, or tanks."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Clarify that high pressure variants spend the same total amount of steam when doing the job twice as fast. 

The test to verify that was done on GTNH 2.3.0 with High Pressure Compressor.