### PR TITLE
docs(quest): Rubber Sheets: mention Piston Boots

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/RubberSheets-AAAAAAAAAAAAAAAAAAACGA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/RubberSheets-AAAAAAAAAAAAAAAAAAACGA==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 1,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Let\u0027s make a mold for the rubber sheets. You can use them for cables. They are also needed for conveyors, a plunger, and some more recipes."
+      "desc:8": "Let\u0027s make a mold for the rubber sheets. They are mainly used for conveyors and cables.\n\nAt this stage, making cables by manually wrapping the sheets around wires is faster and cheaper in power than the Alloy Smelter recipe for cables.\n\nWith the sheets, you should be able to craft Piston Boots - a massive upgrade to your mobility. Check out the questline Getting Around Without Dying to find them."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Rephrase the Rubber Sheets quest to mention Piston Boots.

Also clarify the main usage of Rubber Sheets at this stage.

Remove the mention of other things that are crafted not as often.