### PR TITLE
docs(quests): BetterQuesting Readme: fix typos and improve wording

### DIFF
--- a/config/betterquesting/Readme.md
+++ b/config/betterquesting/Readme.md
@@ -46,7 +46,7 @@ https://try.github.io/
 
 1. Fork the GT-New-Horizons-Modpack repo to your github account. This is not actually needed if Dream has added you as a developer.
 2. Add the repo to your GitHub Desktop by clicking `Code` and then `Open with GitHub Desktop`. When asked, choose `contribute to parent repo`. That way new branches are automatically based on the GTNewHorizons/GT-New-Horizons-Modpack master branch.
-3. Before you being making changes you want to click `Fetch origin` to get the latest updates and then start a new branch (`Branch`, then `New Branch`). If you followed 2. that will automatically be based on the GTNewHorizons/GT-New-Horizons-Modpack master branch.
+3. Before you begin making changes, you want to click `Fetch origin` to get the latest updates and then start a new branch (`Branch`, then `New Branch`). If you followed 2. that will automatically be based on the GTNewHorizons/GT-New-Horizons-Modpack master branch.
 4. Start GTNH. You need the full game, not a development environment. You should also check that you are using the latest BQ from https://github.com/GTNewHorizons/BetterQuesting/releases (you should only use normal versions, not pre-versions).
 5. Replace the DefaultQuests folder in your config/betterquesting game files with the one from your github folder. That means to delete the existing folder and then copy in the one from github, do not merge them!
 6. Then do `/bq_admin default load` in the game.
@@ -72,7 +72,7 @@ https://try.github.io/
 4. Click Select Icon and choose an appropriate icon for the quest.
 5. To define requirements, select Edit, then Requirements, then search for the requirement quest on the right hand side with the quest ID or the title. Select + to add the quest to the requirements. The eye symbol lets you select if the connection is always shown/always hidden/only shown with hovering over or shift. Ideally you want to show dependencies but avoid always shown if it leads to excessive line crossing. You can right-click a quest and click "Copy Quest ID" to copy it to your clipboard.
 6. Select Open and open the quest for editing.
-7. Select Edit, then you will see the Quest Name and Description. When editing the quest Description text hit Aa to get a large window. Hit Enter two times once you have a few lines of data. This breaks up the text and makes it easier to read. Keep in mind that quest names in the GT Tier tabs are color coded.
+7. Select Edit, then you will see the Quest Name and Description. When editing the quest Description text press "Aa" to get a large window. Hit Enter two times once you have a few lines of data. This breaks up the text and makes it easier to read. Keep in mind that quest names in the GT Tier tabs are color coded.
 8. Form the Edit Quest window, select Tasks to add new tasks.
 9. For Tasks we usually use several optional retrieval and one retrieval. Other options are possible too but should only be used for a good reason.
 10. There are many more things to finetune: you can toggle if NBT data should matter, can delete parts of the NBT data of the required item, can allow for oredict substitutes, etc. For example, in a bee quest you should delete all NBT data except for the species and then make sure ignoreNBT is set to false.
@@ -86,9 +86,9 @@ https://try.github.io/
 2. Click the destination tab, and select the Add/Remove quests button.
 3. Search for the quest id or name on the right side, click + to add it to the quests for that tab.
 4. Go back to the original tab and select the Add/Remove quests button.
-5. Find the quest in the left side, and hit the - to remove it.
-6. Quests can be in more than one tab. Important information quests should get added to the Tips and Tricks tab. Just dont remove it from the original location in that case.
-7. However, for the most part quest should be in just one tab. This is first, to avoid clutter. We already have many quest even without having all twice! And second, certain things just don't work as well if a quest is in multiple tabs, e.g. dependency lines.
+5. Find the quest in the left side, and press "-" to remove it.
+6. In most cases, the quest should remain in one tab to avoid bloat and because dependency lines don't work well for a quest that is in multiple tabs at the same time.
+7. However, the quest can be in multiple tabs if necessary. Quests with important info should be added to the Tips and Tricks tab. Don't remove them from their original location in that case.
 
 
 # Deleting Quests 
@@ -100,7 +100,7 @@ https://try.github.io/
 
 1. To test quests you need to use `/bq_admin edit` to leave editing mode.
 2. Make sure to craft items and not just take them from NEI. Sometimes the ones in NEI are not quite correct (metadata, NBT, etc.).
-3. You might have to complete the prerequisites to unlock a quest and test it. You can quickly do so in the designer mode. Once the prereqs are unlocked you can use `/bq_admin edit` to leave editing mode.
+3. You might have to complete the prerequisites to unlock a quest and test it. You can quickly do so in the designer mode. Once the prerequisites are unlocked, you can use `/bq_admin edit` to leave editing mode.
 4. Do a `/bq_admin reset all` to reset your quests back.
 
 


### PR DESCRIPTION
Explaining lines 90-91:
Swap and reword the items 6 and 7 to change the intention from 
"a quest can be in multiple tabs but only if necessary" 
to
"a quest really should be in one tab, but can be in many if really necessary"

The rest is minor rewording and typo fixes.