### PR TITLE
docs(quest): CuttingaTreelogb: improve wording and formatting

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/CuttingaTreelogb-AAAAAAAAAAAAAAAAAAAC5w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/CuttingaTreelogb-AAAAAAAAAAAAAAAAAAAC5w==.json
@@ -63,7 +63,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "By making a lumber axe you are now able to cut down the entire tree in one hit. You can use iron, steel, or alumite poured from the Smeltery, it doesn\u0027t need to be steel. Higher tier metals require the MV extruder. Don\u0027t forget your backpack when you are cutting a sacred oak tree down.\n\n§6The quest should accept the tool whatever materials you used.\n\n§3Protip: Make one out of netherrack, the lower the mining speed, the less XP needed to level up. Use the modifier slots to add reinforced. Once you\u0027ve got it leveled up enough, change the parts out for better (and faster) ones. You can\u0027t use auto-smelt, so don\u0027t bother with that."
+      "desc:8": "By making a lumber axe, you are now able to cut down an entire tree in one hit. Don\u0027t forget your backpack when you\u0027re cutting a sacred oak down.\n\nProtip: With wooden equivalents of casts, make an lumber axe completely out of netherrack - lower mining speed means less XP needed to level it up. Use the modifier slots to add Reinforced. Once you\u0027ve leveled it up enough, upgrade the parts for better ones, such as steel, alumite, or others. The higher-level metals will require an MV Extruder. Keep in mind that the auto-smelt modifier doesn\u0027t work, so don\u0027t bother with it.\n\nThe quest will accept a lumber axe from any material."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
* Decolor orange because it's not a good match with the default background color.
* Decolor dark_aqua because it's just another tip.
* Explain how to make netherrack parts because they are not shown in NEI.
* Move the parts about upgraded materials and quest detection closer together to the end.