### PR TITLE
docs(quest): RubberSheets: update and reword

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/RubberSheets-AAAAAAAAAAAAAAAAAAACGA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/RubberSheets-AAAAAAAAAAAAAAAAAAACGA==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 1,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Let\u0027s make a mold for the rubber sheets. They are mainly used for conveyors and cables.\n\nAt this stage, making cables by manually wrapping the sheets around wires is faster and cheaper in power than the Alloy Smelter recipe for cables.\n\nWith the sheets, you should be able to craft Piston Boots - a massive upgrade to your mobility. Check out the questline Getting Around Without Dying to find them."
+      "desc:8": "Let\u0027s make a mold for the rubber sheets. They are mainly used for conveyors and cables.\n\nAt this stage, making cables by hand with rubber sheets is faster and cheaper in power than the Alloy Smelter recipe for the cables.\n\nWith the sheets, you should be able to craft Piston Boots - a massive upgrade to your mobility. Check out the questline Getting Around to find them."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
* Update the reference to the Getting Around questline because it was split in two.
* Simplify wording.