### PR TITLE
docs(quest): MushroomBiomes: explain sunflower and reword

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MushroomBiomesWh-AAAAAAAAAAAAAAAAAAAHKg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MushroomBiomesWh-AAAAAAAAAAAAAAAAAAAHKg==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "The GNTH pack is made for the RWG worldgen. If you run the vanilla biomes worldgen you get huge Mushroom biomes over the map. Go and generate a new world before you continue. If you run a server put the following into your server.properties file:\n\n§5 §5§4§3§2§3§b§4§3§2§3§4§5§l\"level-type\u003drwg\"."
+      "desc:8": "The GNTH pack is made for the Realistic World Generator (RWG). If you run the vanilla biomes worldgen you get huge Mushroom biomes over the map. Go and generate a new world before you continue. If you run a server, put \"level-type\u003drwg\" into your server.properties file.\n\nKeep in mind that RWG is different from the vanilla worldgen. For instance, RWG doesn\u0027t generate Sunflower Plains, so you will have to find sunflowers in Meadows or other biomes."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
* Decolor and move the code snippet for consistency.
* Explain that RWG is different from the vanilla worldgen. In particular Sunflower Plains are not generated.