### PR TITLE
Quest: JustLikeMomUsedt: mention kitchen multiblock

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/JustLikeMomUsedt-AAAAAAAAAAAAAAAAAAAHPg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/JustLikeMomUsedt-AAAAAAAAAAAAAAAAAAAHPg==.json
@@ -35,7 +35,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Jelly sandwiches are a great food source with decent saturation and are easy to make. Almost any fruit can be converted to jelly with sugar and a saucepan. There are a few different nut butters available. Peanuts can be found in Ground Gardens in forest, mountain, or taiga style biomes. Cashews are trees located in jungles or swamps. Chestnuts can be found in warmer forests. Pistachios can be found in jungles. Many of these saplings are also available for trade from villagers.\n\nUse a Forestry Worktable to keep all your recipes together in one spot for easy crafting.\n\nSome sandwiches have better saturation than others, so be sure to check before buying that sapling!"
+      "desc:8": "Jelly sandwiches are a great food source with decent saturation and are easy to make. Almost any fruit can be converted to jelly with sugar and a saucepan. There are a few different nut butters available. Peanuts can be found in Ground Gardens in forest, mountain, or taiga style biomes. Cashews are trees located in jungles or swamps. Chestnuts can be found in warmer forests. Pistachios can be found in jungles. Many of these saplings are also available for trade from villagers.\n\nTo keep all your recipes together, you can use either a Kitchen multiblock if you want to see all recipes available to you, or a Forestry Worktable if you\u0027re fine with the limit of nine recipes.\n\nSome sandwiches have better saturation than others, so be sure to check before buying that sapling!"
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Mentioning only Forestry Worktable as a way to store food recipes is questionable because the kitchen multiblock is overwhelmingly better for food in this regard.