### PR TITLE
Quest: Glue: add glue option

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Glue-AAAAAAAAAAAAAAAAAAAC6Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Glue-AAAAAAAAAAAAAAAAAAAC6Q==.json
@@ -3,6 +3,11 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
+      "questIDLow:4": 579,
+      "type:1": 1
+    },
+    "1:10": {
+      "questIDHigh:4": 0,
       "questIDLow:4": 539
     }
   },
@@ -24,14 +29,14 @@
       "snd_update:8": "random.levelup",
       "repeatTime:3": -1,
       "globalShare:1": 1,
-      "questLogic:8": "AND",
+      "questLogic:8": "OR",
       "repeat_relative:1": 1,
       "name:8": "§5§lGlue",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "If you centrifuge sticky resin, you get glue. Glue is very useful in the creation of good circuit boards.\n\n§3Note that this is GT glue, not TiC glue."
+      "desc:8": "To make Good Circuit Boards, you need either glue or refined glue. \n\nYou can obtain refined glue either by centrifuging sticky resin or distilling glue. Note that it is GT glue, not Tinkers\u0027 Construct glue.\n\nAlternatively, you can extract glue from slime trees that you can obtain from slime islands in the sky."
     }
   },
   "tasks:9": {
@@ -58,6 +63,23 @@
       "groupDetect:1": 0,
       "ignoreNBT:1": 0,
       "index:3": 1,
+      "consume:1": 0,
+      "requiredItems:9": {
+        "0:10": {
+          "id:8": "TConstruct:slime.gel",
+          "Count:3": 11,
+          "Damage:2": 1,
+          "OreDict:8": ""
+        }
+      },
+      "taskID:8": "bq_standard:optional_retrieval"
+    },
+    "2:10": {
+      "partialMatch:1": 1,
+      "autoConsume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 2,
       "consume:1": 0,
       "requiredItems:9": {
         "0:10": {


### PR DESCRIPTION
The quest mentions refined glue as an option to make Good Circuits. The usual glue can also be used to make Good Circuits.

What is more, manually farming glue from Slimy Trees is faster and easier than manually farming Sticky Resin from Rubber Trees.

If I understood the quest intention correctly, it is made to prepare a player for the creation of Good Circuits. If this is so, overlooking glue farming from Slimy Trees is an unaffordable luxury.

Therefore, I added glue as an option:
* Make Requirements disjunctive (OR) and add Fluid Extractor as a requirement that is visible on hover.
* Add Congealed Green Slime as an Optional Retrieval. The number to retrieve is 11 to give 6kL Glue, which is equivalent to 3kL Refined Glue if using Distillery.
11 Congealed > (Extractor) 44 Smlimeballs > (Fluid Extractor) 6336L of Glue.

All retrieval parts of the quest were tested.