### PR TITLE
Configure T9 Power Factors for Dyson Swarm

### DIFF
--- a/config/GalaxySpace/core.conf
+++ b/config/GalaxySpace/core.conf
@@ -85,6 +85,12 @@ dysonswarm {
         84:1.98
         85:1.34
         86:0.23
+        90:2.28
+        91:1.98
+        92:1.81
+        93:3.37
+        94:1.98
+        95:2.11
         SS_Overworld:1.1
         SS_planet.mars:0.89
         SS_planet.venus:1.94


### PR DESCRIPTION
Based on these calculations:
Distances are taken from [here](https://github.com/GTNewHorizons/amunra/blob/master/src/main/java/de/katzenpapst/amunra/AmunRa.java#L513-L618) (second to last parameter of `createPlanet` is distance in AU, moons use ther parent planet's distance to the sun).
![grafik](https://user-images.githubusercontent.com/35727266/236026861-691a1151-c51a-474d-acd9-0c512dc042f8.png)