### PR TITLE
Template crash markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/000-report-crash.yml
+++ b/.github/ISSUE_TEMPLATE/000-report-crash.yml
@@ -72,9 +72,9 @@ body:
   id: report
   attributes:
     label: Crash Report
-    label: <details><summary>Log</summary>
+    value: <details><summary>Log</summary>
     description: "If no crash report is created, attach `logs/fml-client-latest.log` or `logs/fml-server-latest.log`, depending on if it's a dedicated server crash or a client crash. You can also type in additional info that you consider important."
-    label: </details>
+    value: </details>
     placeholder: "Example: pastebin/something OR submit the file to github by dragging it to this textbox."
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/000-report-crash.yml
+++ b/.github/ISSUE_TEMPLATE/000-report-crash.yml
@@ -72,7 +72,9 @@ body:
   id: report
   attributes:
     label: Crash Report
+    label: <details><summary>Log</summary>
     description: "If no crash report is created, attach `logs/fml-client-latest.log` or `logs/fml-server-latest.log`, depending on if it's a dedicated server crash or a client crash. You can also type in additional info that you consider important."
+    label: </details>
     placeholder: "Example: pastebin/something OR submit the file to github by dragging it to this textbox."
   validations:
     required: true


### PR DESCRIPTION
If this works, it should markdown the crash log tab in the template for Crash Reporting.

<details>
  <summary>Log</summary>
  
I grew tired of walls of text in reported crash issues.
  
</details>

Needs testing.