### PR TITLE
Fix BQ default theme

### DIFF
--- a/config/betterquesting.cfg
+++ b/config/betterquesting.cfg
@@ -36,7 +36,7 @@ general {
     S:"Sound Update"=random.levelup
 
     # The current questing theme [default: betterquesting:light]
-    S:Theme=bq_standard:light
+    S:Theme=betterquesting:light
 
     # Jumps the user to the last opened quest [default: true]
     B:"Use Quest Bookmark"=true


### PR DESCRIPTION
Not sure when or why this happened, but the current default (as of [this nightly](https://discord.com/channels/181078474394566657/522098956491030558/1106543995896737823)) appears to be an invalid value, resulting in BQ using some weird messed up default theme.

In particular, this was reported to be causing scrollbars to render oddly, becoming very difficult to see when hovered over.