### PR TITLE
Adjust igi xml to new oregen pattern

### DIFF
--- a/config/InGameInfo.xml
+++ b/config/InGameInfo.xml
@@ -153,8 +153,13 @@
             <str>{black}</str>
         </line>
         <line>
-            <if>
-                <and>
+			<if>
+				<equal>
+					<var>gtnewore</var>
+					<str>true</str>
+                </equal>
+				<if>
+					<and>
                     <or>
                         <equal>
                             <modi>
@@ -188,17 +193,70 @@
                         </equal>
                     </or>
                 </and>
-                <concat>
-                    <icon>
-                        <str>textures/items/diamond_pickaxe.png</str>
-                        <num>0</num>
-                        <num>0</num>
-                        <num>16</num>
-                        <num>16</num>
-                    </icon>
-                    <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
-                </concat>
-            </if>
+					<concat>
+						<icon>
+							<str>textures/items/diamond_pickaxe.png</str>
+							<num>0</num>
+							<num>0</num>
+							<num>16</num>
+							<num>16</num>
+						</icon>
+						<str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+					</concat>
+				</if>
+			</if>
+			<if>
+				<equal>
+					<var>gtnewore</var>
+					<str>false</str>
+                </equal>
+				<if>
+					<and>
+                    <or>
+                        <equal>
+                            <modi>
+                                <var>chunkx</var>
+                                <num>3</num>
+                            </modi>
+                            <num>-1</num>
+                        </equal>
+                        <equal>
+                            <modi>
+                                <var>chunkx</var>
+                                <num>3</num>
+                            </modi>
+                            <num>1</num>
+                        </equal>
+                    </or>
+                    <or>
+                        <equal>
+                            <modi>
+                                <var>chunkz</var>
+                                <num>3</num>
+                            </modi>
+                            <num>-1</num>
+                        </equal>
+                        <equal>
+                            <modi>
+                                <var>chunkz</var>
+                                <num>3</num>
+                            </modi>
+                            <num>1</num>
+                        </equal>
+                    </or>
+                </and>
+					<concat>
+						<icon>
+							<str>textures/items/diamond_pickaxe.png</str>
+							<num>0</num>
+							<num>0</num>
+							<num>16</num>
+							<num>16</num>
+						</icon>
+						<str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+					</concat>
+				</if>
+			</if>
         </line>
         <line>
             <if>

--- a/config/InGameInfo.xml
+++ b/config/InGameInfo.xml
@@ -161,7 +161,7 @@
                                 <var>chunkx</var>
                                 <num>3</num>
                             </modi>
-                            <num>-1</num>
+                            <num>-2</num>
                         </equal>
                         <equal>
                             <modi>
@@ -177,7 +177,7 @@
                                 <var>chunkz</var>
                                 <num>3</num>
                             </modi>
-                            <num>-1</num>
+                            <num>-2</num>
                         </equal>
                         <equal>
                             <modi>

--- a/config/InGameInfo.xml
+++ b/config/InGameInfo.xml
@@ -153,65 +153,65 @@
             <str>{black}</str>
         </line>
         <line>
-			<if>
-				<equal>
-					<var>gtnewore</var>
-					<str>true</str>
+            <if>
+                <equal>
+                <var>gtnewore</var>
+                    <str>true</str>
                 </equal>
-				<if>
-					<and>
-                    <or>
-                        <equal>
-                            <modi>
-                                <var>chunkx</var>
-                                <num>3</num>
-                            </modi>
-                            <num>-2</num>
-                        </equal>
-                        <equal>
-                            <modi>
-                                <var>chunkx</var>
-                                <num>3</num>
-                            </modi>
-                            <num>1</num>
-                        </equal>
-                    </or>
-                    <or>
-                        <equal>
-                            <modi>
-                                <var>chunkz</var>
-                                <num>3</num>
-                            </modi>
-                            <num>-2</num>
-                        </equal>
-                        <equal>
-                            <modi>
-                                <var>chunkz</var>
-                                <num>3</num>
-                            </modi>
-                            <num>1</num>
-                        </equal>
-                    </or>
-                </and>
-					<concat>
-						<icon>
-							<str>textures/items/diamond_pickaxe.png</str>
-							<num>0</num>
-							<num>0</num>
-							<num>16</num>
-							<num>16</num>
-						</icon>
-						<str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
-					</concat>
-				</if>
-			</if>
-			<if>
-				<equal>
-					<var>gtnewore</var>
-					<str>false</str>
+                <if>
+                    <and>
+                        <or>
+                            <equal>
+                                <modi>
+                                    <var>chunkx</var>
+                                    <num>3</num>
+                                </modi>
+                                <num>-2</num>
+                            </equal>
+                            <equal>
+                                <modi>
+                                    <var>chunkx</var>
+                                    <num>3</num>
+                                </modi>
+                                <num>1</num>
+                            </equal>
+                        </or>
+                        <or>
+                            <equal>
+                                <modi>
+                                    <var>chunkz</var>
+                                    <num>3</num>
+                                </modi>
+                                <num>-2</num>
+                            </equal>
+                            <equal>
+                                <modi>
+                                    <var>chunkz</var>
+                                    <num>3</num>
+                                </modi>
+                                <num>1</num>
+                            </equal>
+                        </or>
+                    </and>
+                    <concat>
+                        <icon>
+                            <str>textures/items/diamond_pickaxe.png</str>
+                            <num>0</num>
+                            <num>0</num>
+                            <num>16</num>
+                            <num>16</num>
+                        </icon>
+                        <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+                    </concat>
+                </if>
+            </if>
+            <if>
+                <equal>
+                    <var>gtnewore</var>
+                    <str>false</str>
                 </equal>
-				<if>
-					<and>
+                <if>
+                    <and>
                     <or>
                         <equal>
                             <modi>
@@ -245,18 +245,18 @@
                         </equal>
                     </or>
                 </and>
-					<concat>
-						<icon>
-							<str>textures/items/diamond_pickaxe.png</str>
-							<num>0</num>
-							<num>0</num>
-							<num>16</num>
-							<num>16</num>
-						</icon>
-						<str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
-					</concat>
-				</if>
-			</if>
+                    <concat>
+                        <icon>
+                            <str>textures/items/diamond_pickaxe.png</str>
+                            <num>0</num>
+                            <num>0</num>
+                            <num>16</num>
+                            <num>16</num>
+                        </icon>
+                        <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+                    </concat>
+                </if>
+            </if>
         </line>
         <line>
             <if>


### PR DESCRIPTION
depends on https://github.com/GTNewHorizons/InGame-Info-XML/pull/18 and thus also https://github.com/GTNewHorizons/GT5-Unofficial/pull/2081.

use the new info about the gt oregen pattern to show correctly when the player is in a ore vein chunk.