### PR TITLE
Update Rocket Engine/Ion Thruster Fluids

### DIFF
--- a/config/GalacticraftAmunRa.cfg
+++ b/config/GalacticraftAmunRa.cfg
@@ -46,10 +46,10 @@ motherships {
     I:numMothershipsPerPlayer=-1
 
     # This fluid can be used by Ion Thrusters [default: liquidnitrogen]
-    S:validIonThrusterCoolant=liquid helium
+    S:validIonThrusterCoolant=xenon
 
     # This fluid can be used by Jet Engines [default: fuel]
-    S:validJetEngineFuel=naquadah based liquid fuel mkiii
+    S:validJetEngineFuel=naquadah based liquid fuel mkii
 }
 
 


### PR DESCRIPTION
According to @BlueWeabo Naq Fuel MK2 is the best one can do at UHV. Also, Xenon is apparently used in RL Ion Thrusters, so I want to change that too (it doesn't really matter at UHV I guess).