### PR TITLE
Update "Fast Fancy Stripes" Quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FastFancyStripes-zLE6OyCFT8ih5eSJVainBQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FastFancyStripes-zLE6OyCFT8ih5eSJVainBQ==.json
@@ -29,7 +29,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "The Ion Thruster is the advanced version of the Rocket Engine. Each Ion Thruster Base provides 25MN of force and holds up to 10,000L of Xenon. Electric power is needed, too."
+      "desc:8": "The Ion Thruster is the advanced version of the Rocket Engine. Each Ion Thruster Base provides 25MN of force and holds up to 2,000L of Xenon. Electric power is needed, too."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
The Ion Thruster actually has less capacity than the Rocket Engine (see [`TileEntityMothershipEngineIon#getTankCapacity`](https://github.com/GTNewHorizons/amunra/blob/master/src/main/java/de/katzenpapst/amunra/tile/TileEntityMothershipEngineIon.java#L137)).