### PR TITLE
Fix incorrect wording for smeltery quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/YouAreNotPrepare-AAAAAAAAAAAAAAAAAAALqQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/YouAreNotPrepare-AAAAAAAAAAAAAAAAAAALqQ==.json
@@ -33,7 +33,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Building a smeltery from ground up can be really tedious and time consuming. How about go borrow one from the locals? They will surely be happy to share it with an unfriendly adventurer that just dismantled their bricked railway station.\n\nThe villager are too dumb that they spent all their seared bricks without adding a few key components like faucets or drains. You still need to craft some smeltery bricks yourselves... \n\nTotally not useful tip: if you hold off building this long enough, you will be able to break down seared brick blocks into seared brick items with a forge hammer or extractor.\n\n§3Unfortunately, going down this path means we will not give you quest rewards, since you are already getting this important multiblock for free. Check the checkbox to signify your consent."
+      "desc:8": "Building a smeltery from ground up can be really tedious and time consuming. How about go borrow one from the locals? They will surely be happy to share it with an unfriendly adventurer that just dismantled their bricked railway station.\n\nThe villagers are so dumb they spent all their seared bricks without adding a few key components like faucets or drains. You still need to craft some smeltery bricks yourselves... \n\nTotally not useful tip: if you hold off building this long enough, you will be able to break down seared brick blocks into seared brick items with a forge hammer or extractor.\n\n§3Unfortunately, going down this path means we will not give you quest rewards, since you are already getting this important multiblock for free. Check the checkbox to signify your consent."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/YouAreNotPrepare-AAAAAAAAAAAAAAAAAAALqQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/YouAreNotPrepare-AAAAAAAAAAAAAAAAAAALqQ==.json
@@ -33,7 +33,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Building a smeltery from ground up can be really tedious and time consuming. How about go borrow one from the locals? They will surely be happy to share it with an unfriendly adventurer that just dismantled their bricked railway station.\n\nThe villagers are so dumb they spent all their seared bricks without adding a few key components like faucets or drains. You still need to craft some smeltery bricks yourselves... \n\nTotally not useful tip: if you hold off building this long enough, you will be able to break down seared brick blocks into seared brick items with a forge hammer or extractor.\n\n§3Unfortunately, going down this path means we will not give you quest rewards, since you are already getting this important multiblock for free. Check the checkbox to signify your consent."
+      "desc:8": "Building a smeltery from ground up can be really tedious and time consuming. How about go borrow one from the locals? They will surely be happy to share it with an unfriendly adventurer that just dismantled their bricked railway station.\n\nThe villagers are so dumb that they spent all their seared bricks without adding a few key components like faucets or drains. You still need to craft some smeltery bricks yourselves... \n\nTotally not useful tip: if you hold off building this long enough, you will be able to break down seared brick blocks into seared brick items with a forge hammer or extractor.\n\n§3Unfortunately, going down this path means we will not give you quest rewards, since you are already getting this important multiblock for free. Check the checkbox to signify your consent."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
This replaces “The villager are too dumb that they spent...”, which does not make sense in English, with “The villagers are so dumb that they spent...” in the “You Are Not Prepared... But They Are” quest.