### PR TITLE
Hide Hardness and Blast Resistance values in Waila

### DIFF
--- a/config/Waila.cfg
+++ b/config/Waila.cfg
@@ -126,8 +126,8 @@ modules {
     B:wawla.harvest.showTool=true
     B:wawla.horse.showJump=true
     B:wawla.horse.showSpeed=true
-    B:wawla.info.showHardness=true
-    B:wawla.info.showResistance=true
+    B:wawla.info.showHardness=false
+    B:wawla.info.showResistance=false
     B:wawla.light.lightLevel=false
     B:wawla.light.monsterSpawn=true
     B:wawla.light.showDay=true


### PR DESCRIPTION
I think this information is useless in 99.9% of cases but it still takes space and distracts from really important stuff.

<details><summary>Before/After</summary>

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/5096735/73ab18a8-e436-44a7-b82b-530994fb08b9)

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/5096735/3172d9d6-1dcb-4ed3-8751-ab7a41b8701d)
</details>

To Enable it back:
[Waila] Config screen (NUMPAD0 by default) -> Modules -> Wawla-General -> Set "Show Block Hardness?" and "Show Blast Resistance?" to Yes.