### PR TITLE
Fix plutonium icon

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/Plutonium239-AAAAAAAAAAAAAAAAAAAMZA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/Plutonium239-AAAAAAAAAAAAAAAAAAAMZA==.json
@@ -15,9 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:itemDustPlutonium239",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "Damage:2": 0,
+        "Damage:2": 2100,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",


### PR DESCRIPTION
Follow up to https://github.com/GTNewHorizons/GTplusplus/pull/698 that changes the plutonium quest icon to the gt variant.