### PR TITLE
Ore quest consistency

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/LeadGalenaSilver-AAAAAAAAAAAAAAAAAAACYg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/LeadGalenaSilver-AAAAAAAAAAAAAAAAAAACYg==.json
@@ -52,13 +52,13 @@
         "1:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
-          "Damage:2": 89,
+          "Damage:2": 54,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
-          "Damage:2": 54,
+          "Damage:2": 89,
           "OreDict:8": ""
         },
         "3:10": {

--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SourceofNickel-AAAAAAAAAAAAAAAAAAAGTQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SourceofNickel-AAAAAAAAAAAAAAAAAAAGTQ==.json
@@ -45,25 +45,25 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 906,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 34,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 827,
           "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 16,
           "Damage:2": 909,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
@@ -16,9 +16,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "gregtech:gt.metaitem.01",
+        "id:8": "gregtech:gt.blockores",
         "Count:3": 1,
-        "Damage:2": 2934,
+        "Damage:2": 934,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
@@ -45,25 +45,25 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 935,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 936,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 928,
           "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 16,
           "Damage:2": 934,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/HowtoMakeRubber-AAAAAAAAAAAAAAAAAAAB8A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/HowtoMakeRubber-AAAAAAAAAAAAAAAAAAAB8A==.json
@@ -49,7 +49,7 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 64,
           "Damage:2": 1022,
           "OreDict:8": ""
         },
@@ -61,7 +61,7 @@
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 16,
           "Damage:2": 1839,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/LapisLazuriteSod-AAAAAAAAAAAAAAAAAAADYw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/LapisLazuriteSod-AAAAAAAAAAAAAAAAAAADYw==.json
@@ -16,9 +16,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "minecraft:lapis_block",
+        "id:8": "gregtech:gt.blockores",
         "Count:3": 1,
-        "Damage:2": 0,
+        "Damage:2": 526,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",
@@ -45,19 +45,25 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 526,
+          "Count:3": 32,
+          "Damage:2": 524,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 524,
+          "Count:3": 32,
+          "Damage:2": 525,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
+          "Damage:2": 526,
+          "OreDict:8": ""
+        },
+        "3:10": {
+          "id:8": "gregtech:gt.blockores",
+          "Count:3": 16,
           "Damage:2": 823,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/OooShinyNotPlati-AAAAAAAAAAAAAAAAAAAB7w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/OooShinyNotPlati-AAAAAAAAAAAAAAAAAAAB7w==.json
@@ -16,9 +16,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "minecraft:diamond",
+        "id:8": "gregtech:gt.blockores",
         "Count:3": 1,
-        "Damage:2": 0,
+        "Damage:2": 500,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",
@@ -45,14 +45,14 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 500,
+          "Count:3": 64,
+          "Damage:2": 865,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 865,
+          "Count:3": 32,
+          "Damage:2": 500,
           "OreDict:8": ""
         },
         "2:10": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
@@ -47,25 +47,25 @@
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 855,
-          "OreDict:8": "oreChalcopyrite"
+          "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 32,
-          "OreDict:8": "oreIron"
+          "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 834,
-          "OreDict:8": "orePyrite"
+          "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 35,
-          "OreDict:8": "oreCopper"
+          "OreDict:8": ""
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
@@ -45,15 +45,27 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 24,
+          "Count:3": 32,
           "Damage:2": 855,
           "OreDict:8": "oreChalcopyrite"
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 24,
+          "Count:3": 32,
+          "Damage:2": 32,
+          "OreDict:8": "oreIron"
+        },
+        "2:10": {
+          "id:8": "gregtech:gt.blockores",
+          "Count:3": 32,
+          "Damage:2": 834,
+          "OreDict:8": "orePyrite"
+        },
+        "3:10": {
+          "id:8": "gregtech:gt.blockores",
+          "Count:3": 16,
           "Damage:2": 35,
-          "OreDict:8": "oreAnyCopper"
+          "OreDict:8": "oreCopper"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/IronOre-AAAAAAAAAAAAAAAAAAADOg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/IronOre-AAAAAAAAAAAAAAAAAAADOg==.json
@@ -47,31 +47,31 @@
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 917,
-          "OreDict:8": "oreBandedIron"
+          "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 32,
-          "OreDict:8": "oreIron"
+          "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 870,
-          "OreDict:8": "oreMagnetite"
+          "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 931,
-          "OreDict:8": "oreYellowLimonite"
+          "OreDict:8": ""
         },
         "4:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 930,
-          "OreDict:8": "oreBrownLimonite"
+          "OreDict:8": ""
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
@@ -47,25 +47,25 @@
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 930,
-          "OreDict:8": "oreBrownLimonite"
+          "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 931,
-          "OreDict:8": "oreYellowLimonite"
+          "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
           "Damage:2": 917,
-          "OreDict:8": "oreBandedIron"
+          "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
           "Damage:2": 871,
-          "OreDict:8": "oreMalachite"
+          "OreDict:8": ""
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
@@ -45,27 +45,27 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 871,
-          "OreDict:8": "oreMalachite"
+          "Count:3": 32,
+          "Damage:2": 930,
+          "OreDict:8": "oreBrownLimonite"
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 917,
-          "OreDict:8": "oreBandedIron"
+          "Count:3": 32,
+          "Damage:2": 931,
+          "OreDict:8": "oreYellowLimonite"
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 931,
-          "OreDict:8": "oreYellowLimonite"
+          "Count:3": 32,
+          "Damage:2": 917,
+          "OreDict:8": "oreBandedIron"
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
-          "Damage:2": 930,
-          "OreDict:8": "oreBrownLimonite"
+          "Damage:2": 871,
+          "OreDict:8": "oreMalachite"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
@@ -45,13 +45,13 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 64,
           "Damage:2": 810,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 502,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodium-AAAAAAAAAAAAAAAAAAACbQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodium-AAAAAAAAAAAAAAAAAAACbQ==.json
@@ -46,25 +46,25 @@
         "0:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
-          "Damage:2": 933,
+          "Damage:2": 877,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 909,
+          "Count:3": 32,
+          "Damage:2": 902,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 877,
+          "Count:3": 32,
+          "Damage:2": 933,
           "OreDict:8": ""
         },
         "3:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 16,
-          "Damage:2": 902,
+          "Damage:2": 909,
           "OreDict:8": ""
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MicaOre-AAAAAAAAAAAAAAAAAAALpw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MicaOre-AAAAAAAAAAAAAAAAAAALpw==.json
@@ -45,19 +45,19 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 901,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 924,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 824,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
@@ -45,7 +45,7 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 256,
+          "Count:3": 112,
           "Damage:2": 878,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
@@ -45,7 +45,7 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 112,
+          "Count:3": 128,
           "Damage:2": 878,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
@@ -57,7 +57,7 @@
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 48,
           "Damage:2": 1516,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
@@ -51,7 +51,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 1904,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/TetrahedriteStib-AAAAAAAAAAAAAAAAAAACVQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/TetrahedriteStib-AAAAAAAAAAAAAAAAAAACVQ==.json
@@ -49,20 +49,20 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 64,
           "Damage:2": 1840,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
           "Count:3": 32,
-          "Damage:2": 1945,
+          "Damage:2": 1035,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
-          "Damage:2": 1035,
+          "Count:3": 16,
+          "Damage:2": 1945,
           "OreDict:8": ""
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBastnasiteMo-AAAAAAAAAAAAAAAAAAAGTA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBastnasiteMo-AAAAAAAAAAAAAAAAAAAGTA==.json
@@ -51,13 +51,13 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 520,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 67,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBauxite-AAAAAAAAAAAAAAAAAAAD8w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBauxite-AAAAAAAAAAAAAAAAAAAD8w==.json
@@ -45,20 +45,20 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 822,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 19,
+          "Count:3": 48,
+          "Damage:2": 918,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
-          "Damage:2": 918,
+          "Count:3": 32,
+          "Damage:2": 19,
           "OreDict:8": ""
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindIlmenite-AAAAAAAAAAAAAAAAAAAFkA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindIlmenite-AAAAAAAAAAAAAAAAAAAFkA==.json
@@ -45,19 +45,19 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 918,
           "OreDict:8": ""
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 64,
+          "Count:3": 32,
           "Damage:2": 825,
           "OreDict:8": ""
         },
         "2:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 16,
+          "Count:3": 32,
           "Damage:2": 842,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PureUraniumOres-AAAAAAAAAAAAAAAAAAAFhw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PureUraniumOres-AAAAAAAAAAAAAAAAAAAFhw==.json
@@ -55,7 +55,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 48,
           "Damage:2": 98,
           "OreDict:8": ""
         }
@@ -78,7 +78,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 96,
+          "Count:3": 144,
           "Damage:2": 5098,
           "OreDict:8": ""
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/ReactorFuels-AAAAAAAAAAAAAAAAAAAE2w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/ReactorFuels-AAAAAAAAAAAAAAAAAAAE2w==.json
@@ -55,7 +55,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 48,
           "Damage:2": 4922,
           "OreDict:8": ""
         }
@@ -78,7 +78,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.blockores",
-          "Count:3": 32,
+          "Count:3": 48,
           "Damage:2": 922,
           "OreDict:8": ""
         }
@@ -101,7 +101,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 96,
+          "Count:3": 144,
           "Damage:2": 5922,
           "OreDict:8": ""
         }


### PR DESCRIPTION
Makes all ore quests that I found pretty much the same:
Main x32
Secondary x32
Between x32
Sporadic x16

Pictures:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/469826d2-27a4-4b63-b980-17a2026dc54f)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/1fb9c2f5-95a0-440d-991e-54363562cc4d)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/a88feee2-33fb-418c-a795-7a5bbc19fdf8)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/7e9b287a-4a3f-48f9-962a-4bc670382208)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/42b550d2-8c5a-4ffd-81ce-cdd976e3b175)


Quests that are not strictly about one vein remain unchanged, e.g. iron quest:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/46ddc6ee-af83-4c29-bbd9-4fab155d8ab4)
