### PR TITLE
Fix Default Configs messing up the OpenComputers config

### DIFF
--- a/config/localconfig.txt
+++ b/config/localconfig.txt
@@ -216,9 +216,26 @@ NotEnoughEnergistics.cfg/transfer/*
 
 oauth.cfg/oauth/*
 
-OpenComputers.cfg/opencomputers.client/* $format=simple
+# Everything from "opencomputers.client" except "nanomachineHudPos",
+# as Default Configs can't handle the list property.
+OpenComputers.cfg/opencomputers.client/beepRadius $format=simple
+OpenComputers.cfg/opencomputers.client/beepSampleRate $format=simple
+OpenComputers.cfg/opencomputers.client/beepVolume $format=simple
+OpenComputers.cfg/opencomputers.client/enableNanomachinePfx $format=simple
+OpenComputers.cfg/opencomputers.client/fontCharScale $format=simple
+OpenComputers.cfg/opencomputers.client/fontRenderer $format=simple
+OpenComputers.cfg/opencomputers.client/hologramFadeStartDistance $format=simple
+OpenComputers.cfg/opencomputers.client/hologramFlickerFrequency $format=simple
+OpenComputers.cfg/opencomputers.client/hologramRenderDistance $format=simple
+OpenComputers.cfg/opencomputers.client/maxScreenTextRenderDistance $format=simple
+OpenComputers.cfg/opencomputers.client/monochromeColor $format=simple
+OpenComputers.cfg/opencomputers.client/robotLabels $format=simple
+OpenComputers.cfg/opencomputers.client/screenTextFadeStartDistance $format=simple
+OpenComputers.cfg/opencomputers.client/soundVolume $format=simple
+OpenComputers.cfg/opencomputers.client/textAntiAlias $format=simple
+OpenComputers.cfg/opencomputers.client/textLinearFiltering $format=simple
 
-openmodularturrets.cfg/miscellaneous/"Enable/Disable turret alarm sound. True=enabled, false=disabled"
+openmodularturrets.cfg/miscellaneous/["Enable/Disable turret alarm sound. True=enabled, false=disabled"]
 openmodularturrets.cfg/miscellaneous/"Turret sound volume percentage (Between 0 - 100)"
 
 openprinter.cfg/options/Render3D


### PR DESCRIPTION
(Hopefully) fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14364.

Default Configs' [SimpleConfigHandler](https://github.com/GTNewHorizons/Default-Configs/blob/master/src/main/java/net/blay09/mods/defaultkeys/localconfig/SimpleConfigHandler.java) does not recognize the list syntax used by the OpenComputers config (specifically `OpenComputers.cfg/opencomputers.client/nanomachineHudPos`).

Unrelated: escape `/` in one OpenModularTurrets config property (`openmodularturrets.cfg/miscellaneous/"Enable/Disable turret alarm sound. True=enabled, false=disabled"`).