### PR TITLE
skip potassium nitrate with saltpeter

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/PotassiumNitrate-AAAAAAAAAAAAAAAAAAAGpw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/PotassiumNitrate-AAAAAAAAAAAAAAAAAAAGpw==.json
@@ -10,7 +10,7 @@
   "properties:10": {
     "betterquesting:10": {
       "snd_complete:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "partySingleReward:1": 0,
       "visibility:8": "UNLOCKED",
       "isMain:1": 1,
@@ -70,6 +70,23 @@
           "id:8": "gregtech:gt.metaitem.01",
           "Count:3": 10,
           "Damage:2": 2590,
+          "OreDict:8": ""
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "2:10": {
+      "partialMatch:1": 1,
+      "autoConsume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 2,
+      "consume:1": 0,
+      "requiredItems:9": {
+        "0:10": {
+          "id:8": "gregtech:gt.metaitem.01",
+          "Count:3": 10,
+          "Damage:2": 2836,
           "OreDict:8": ""
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/PotassiumNitrate-AAAAAAAAAAAAAAAAAAAGpw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/PotassiumNitrate-AAAAAAAAAAAAAAAAAAAGpw==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Potassium Nitrate is made from Potassium and Nitric Acid."
+      "desc:8": "Potassium Nitrate is made from Potassium and Nitric Acid.\nIf you have some saltpeter you can use that instead.\n\n\nPotassium nitrate can only be crafted while saltpeter has many different sources.\nPick the one you prefer, only one is needed to complete the quest."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Allows player to skip potassium nitrate with saltpeter (which is also accepted in dichromate recipe)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/9892e847-7e7c-43e6-ab39-1dd83127332d)
