### PR TITLE
Increase Dyson module consumption, especially without computation

### DIFF
--- a/config/GalaxySpace/core.conf
+++ b/config/GalaxySpace/core.conf
@@ -32,16 +32,16 @@ dysonswarm {
     S:coolantFluid=cryotheum
 
     # Each hour, n of m modules are destroyed according to this formula: n = (2 * base_chance) / (exp(-a * (m - 1))+exp(b * cps)), where cps is computation per second. This sets the parameter base_chance.
-    D:destroyModuleBase_chance=0.001
+    D:destroyModuleBase_chance=0.066
 
     # The maximum computation per second that will help prevent modules from collision
-    D:destroyModuleMaxCPS=1000000.0
+    D:destroyModuleMaxCPS=100000.0
 
     # Each hour, n of m modules are destroyed according to this formula: n = (2 * base_chance) / (exp(-a * (m - 1))+exp(b * cps)), where cps is computation per second. This sets the parameter a.
-    D:destroyModule_a=1.0E-4
+    D:destroyModule_a=0.00005
 
     # Each hour, n of m modules are destroyed according to this formula: n = (2 * base_chance) / (exp(-a * (m - 1))+exp(b * cps)), where cps is computation per second. This sets the parameter b.
-    D:destroyModule_b=5.0E-6
+    D:destroyModule_b=0.00003
 
     # How much EU the Dyson Swarm Command Center produces per module per tick. Default is 10,000,000 EU/t
     I:euPerModule=10000000


### PR DESCRIPTION
With the Dyson formula fixed, revisiting the consumption is in order, especially as the old balancing was done with an incorrect script (It had module count and consumption swapped).

"Current" values with existing coefficients and a fixed consumption function, although the consumption has always been at a static 1 module per hour due to a bug in the formula.

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/69092953/032f5a81-d95d-4b9a-8721-37e21c8facba)

Increasing computation is fairly inconsequential, and the module consumption still makes the Dyson spammable even without computation.

Module consumption with new values:

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/69092953/1bd749d8-c39f-4234-b62e-44a9dde17373)

Adding computation becomes almost mandatory, with each quantum computer (at 25k computation/s) reducing the module consumption by roughly 30% (additive). The computation is capped at 100 000/s to still keep a minimum running cost of 64 modules per hour (One recipe/hour)

This should reduce the viability of spamming dozens of Dysons, add some running cost to properly-supplied Dysons, while still keeping them a competitive option (Naqfuel I am looking at you).


