### PR TITLE
Fix QB crashing and spamming errors

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/AMERICA-Qrjs7uh5TcSveEbaFnXFog==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/AMERICA-Qrjs7uh5TcSveEbaFnXFog==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 94,
+        "Damage:2": 31103,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/BoronicFusion-Tfb8JzstRNuiSV6CKgTNRQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/BoronicFusion-Tfb8JzstRNuiSV6CKgTNRQ==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 4,
+        "Damage:2": 31009,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/CalciumBottlenec-9j1Iwd3KRG6jqLI9m6YDKQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/CalciumBottlenec-9j1Iwd3KRG6jqLI9m6YDKQ==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 19,
+        "Damage:2": 31026,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/MarieCurium-3r7tJ7_bTuePzsh-B_jyIQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/MarieCurium-3r7tJ7_bTuePzsh-B_jyIQ==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "miscutils:itemCellCurium",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 95,
+        "Damage:2": 0,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/Niobiumization-X_rOgp6GRKiyGzwRV_p7GA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/Niobiumization-X_rOgp6GRKiyGzwRV_p7GA==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 40,
+        "Damage:2": 31047,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/Zzzincing-Ng5Ldnf3TZCefB4Mr3u-rQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/Zzzincing-Ng5Ldnf3TZCefB4Mr3u-rQ==.json
@@ -15,14 +15,9 @@
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {
-        "id:8": "miscutils:particleIon",
+        "id:8": "gregtech:gt.metaitem.01",
         "Count:3": 1,
-        "tag:10": {
-          "Ion:10": {
-            "Charge:4": 0
-          }
-        },
-        "Damage:2": 29,
+        "Damage:2": 31036,
         "OreDict:8": ""
       },
       "snd_update:8": "random.levelup",


### PR DESCRIPTION
These icons were broken by Colens recent gt++ 'clean-up'. Even worse, BQ didnt handle it gracefully with placeholder items but spammed errors on the questline page and crashed when clicking the quest. This PR cleans that up by replacing those icons.