### PR TITLE
Fixing dyson and lategame power gen

### DIFF
--- a/config/GalaxySpace/core.conf
+++ b/config/GalaxySpace/core.conf
@@ -44,7 +44,7 @@ dysonswarm {
     D:destroyModule_b=0.00003
 
     # How much EU the Dyson Swarm Command Center produces per module per tick. Default is 10,000,000 EU/t
-    I:euPerModule=10000000
+    I:euPerModule=10000000000
 
     # The maximum number of modules the dyson swarm can take
     I:maxModules=10000


### PR DESCRIPTION
Players will finally be able to overclock their aal and coals.