### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/config/RTG/biomes/abyssalcraft.cfg
+++ b/config/RTG/biomes/abyssalcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,34 +110,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -147,13 +147,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -201,34 +201,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -238,13 +238,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -289,34 +289,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -332,13 +332,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -383,44 +383,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -465,44 +465,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/arsmagica.cfg
+++ b/config/RTG/biomes/arsmagica.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/atg.cfg
+++ b/config/RTG/biomes/atg.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/biomesoplenty.cfg
+++ b/config/RTG/biomes/biomesoplenty.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1267,44 +1267,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1349,44 +1349,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1434,44 +1434,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1519,44 +1519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1601,44 +1601,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1686,44 +1686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1771,44 +1771,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1853,44 +1853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1938,44 +1938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2023,44 +2023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2105,44 +2105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2187,44 +2187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2269,44 +2269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2354,44 +2354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2439,44 +2439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2521,44 +2521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2606,44 +2606,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2688,44 +2688,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2773,44 +2773,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2855,44 +2855,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2937,44 +2937,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3022,44 +3022,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3104,44 +3104,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3189,44 +3189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3271,44 +3271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3356,44 +3356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3438,44 +3438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3520,44 +3520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3602,44 +3602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3684,44 +3684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3769,44 +3769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3854,44 +3854,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3939,44 +3939,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4024,44 +4024,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4109,44 +4109,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4191,44 +4191,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4273,44 +4273,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4355,44 +4355,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4437,44 +4437,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4519,44 +4519,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4604,44 +4604,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4686,44 +4686,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4768,44 +4768,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4853,44 +4853,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4938,44 +4938,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5023,44 +5023,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5105,44 +5105,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5187,44 +5187,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5269,44 +5269,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5354,44 +5354,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5439,44 +5439,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5521,44 +5521,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5603,44 +5603,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5685,44 +5685,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5767,44 +5767,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5852,44 +5852,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5934,44 +5934,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6016,44 +6016,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6098,44 +6098,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6180,44 +6180,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6262,44 +6262,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6344,44 +6344,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/buildcraft.cfg
+++ b/config/RTG/biomes/buildcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/chromaticraft.cfg
+++ b/config/RTG/biomes/chromaticraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/enhancedbiomes.cfg
+++ b/config/RTG/biomes/enhancedbiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1015,44 +1015,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1097,44 +1097,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2090,44 +2090,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2172,44 +2172,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2503,44 +2503,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2588,44 +2588,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2670,44 +2670,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2752,44 +2752,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2834,44 +2834,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2916,44 +2916,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3247,44 +3247,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3329,44 +3329,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3411,44 +3411,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3493,44 +3493,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3575,44 +3575,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3657,44 +3657,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3739,44 +3739,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3821,44 +3821,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3903,44 +3903,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3985,44 +3985,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4067,44 +4067,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4149,44 +4149,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4231,44 +4231,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4313,44 +4313,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4395,44 +4395,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4477,44 +4477,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4559,44 +4559,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4641,44 +4641,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4723,44 +4723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4805,44 +4805,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4887,44 +4887,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4969,44 +4969,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5054,44 +5054,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5139,44 +5139,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5224,44 +5224,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5309,44 +5309,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5394,44 +5394,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5476,44 +5476,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5558,44 +5558,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5640,44 +5640,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5722,44 +5722,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5804,44 +5804,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5886,44 +5886,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5968,44 +5968,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6050,44 +6050,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6132,44 +6132,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6214,44 +6214,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6299,44 +6299,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6384,44 +6384,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6466,44 +6466,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6548,44 +6548,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6630,44 +6630,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6712,44 +6712,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6794,44 +6794,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6876,44 +6876,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -6958,44 +6958,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7040,44 +7040,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7122,44 +7122,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7204,44 +7204,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7286,44 +7286,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -7368,44 +7368,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/extrabiomes.cfg
+++ b/config/RTG/biomes/extrabiomes.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -684,44 +684,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -766,44 +766,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -848,44 +848,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -930,44 +930,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1012,44 +1012,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1094,44 +1094,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1176,44 +1176,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1258,44 +1258,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1340,44 +1340,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1422,44 +1422,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1507,44 +1507,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1756,44 +1756,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1838,44 +1838,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1920,44 +1920,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2002,44 +2002,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2084,44 +2084,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2166,44 +2166,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2248,44 +2248,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/flowercraft.cfg
+++ b/config/RTG/biomes/flowercraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/forgottennature.cfg
+++ b/config/RTG/biomes/forgottennature.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/growthcraft.cfg
+++ b/config/RTG/biomes/growthcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/highlands.cfg
+++ b/config/RTG/biomes/highlands.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -110,44 +110,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -192,44 +192,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -274,44 +274,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -356,44 +356,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -438,44 +438,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -520,44 +520,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -602,44 +602,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -687,44 +687,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -769,44 +769,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -851,44 +851,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -933,44 +933,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1018,44 +1018,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1100,44 +1100,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1182,44 +1182,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1264,44 +1264,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1346,44 +1346,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1428,44 +1428,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1510,44 +1510,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1592,44 +1592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1674,44 +1674,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1759,44 +1759,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1841,44 +1841,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1923,44 +1923,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2005,44 +2005,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2087,44 +2087,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2169,44 +2169,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2254,44 +2254,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2336,44 +2336,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2418,44 +2418,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2500,44 +2500,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2582,44 +2582,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2664,44 +2664,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2746,44 +2746,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2828,44 +2828,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2913,44 +2913,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2998,44 +2998,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3080,44 +3080,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3162,44 +3162,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3244,44 +3244,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3326,44 +3326,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3408,44 +3408,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3490,44 +3490,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/icecreammod.cfg
+++ b/config/RTG/biomes/icecreammod.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/industrialtechnologies.cfg
+++ b/config/RTG/biomes/industrialtechnologies.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,44 +113,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/ridiculousworld.cfg
+++ b/config/RTG/biomes/ridiculousworld.cfg
@@ -28,34 +28,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -65,13 +65,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -116,44 +116,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -198,44 +198,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -280,44 +280,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -362,44 +362,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -444,44 +444,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -526,44 +526,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/thaumcraft.cfg
+++ b/config/RTG/biomes/thaumcraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/tofucraft.cfg
+++ b/config/RTG/biomes/tofucraft.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -107,44 +107,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -189,44 +189,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -271,44 +271,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -353,44 +353,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -435,44 +435,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -517,44 +517,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -599,44 +599,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -681,44 +681,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/vampirism.cfg
+++ b/config/RTG/biomes/vampirism.cfg
@@ -25,44 +25,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/biomes/vanilla.cfg
+++ b/config/RTG/biomes/vanilla.cfg
@@ -28,44 +28,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -113,34 +113,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -150,13 +150,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -204,34 +204,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -241,13 +241,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -295,44 +295,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -380,34 +380,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -417,13 +417,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -468,44 +468,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -553,44 +553,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -638,44 +638,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -723,44 +723,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -805,34 +805,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -842,13 +842,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -893,44 +893,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -975,44 +975,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1057,44 +1057,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1142,34 +1142,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1185,13 +1185,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1239,34 +1239,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1282,13 +1282,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1333,34 +1333,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1376,13 +1376,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1430,34 +1430,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1467,13 +1467,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1518,34 +1518,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1555,13 +1555,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1609,34 +1609,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1646,13 +1646,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1700,34 +1700,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1737,13 +1737,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1791,34 +1791,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1828,13 +1828,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1879,34 +1879,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -1916,13 +1916,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -1967,44 +1967,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2049,34 +2049,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2092,13 +2092,13 @@ biome {
             S:"RTG Surface: Mix Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2146,44 +2146,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2240,44 +2240,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2328,34 +2328,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -2365,13 +2365,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2419,44 +2419,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2504,44 +2504,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2592,44 +2592,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2680,44 +2680,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2765,44 +2765,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2850,44 +2850,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -2935,44 +2935,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3017,44 +3017,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3099,44 +3099,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3181,44 +3181,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3263,44 +3263,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3345,44 +3345,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3427,44 +3427,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3509,44 +3509,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3591,44 +3591,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3673,34 +3673,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -3710,13 +3710,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3761,44 +3761,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3846,44 +3846,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -3928,44 +3928,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4016,34 +4016,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4053,13 +4053,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4107,34 +4107,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4144,13 +4144,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4198,34 +4198,34 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             #  [default: ]
@@ -4235,13 +4235,13 @@ biome {
             S:"RTG Surface: Mix Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4289,44 +4289,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4371,44 +4371,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4453,44 +4453,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4535,44 +4535,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4617,44 +4617,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4702,44 +4702,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4787,44 +4787,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4872,44 +4872,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -4957,44 +4957,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.
@@ -5042,44 +5042,44 @@ biome {
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff cobble block, enter a valid block ID here (e.g. minecraft:cobblestone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Cobble Block"=
 
             # If you're using a custom cliff cobble block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff cobble block, you would enter minecraft:wool for the Cliff Cobble Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Cobble Block Meta"=
 
             # Cliff blocks are the blocks that are used on the cliffs of mountains (usually a blend of stone & cobblestone).
             # If you want to change this biome's cliff stone block, enter a valid block ID here (e.g. minecraft:stone).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Cliff Stone Block"=
 
             # If you're using a custom cliff stone block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's cliff stone block, you would enter minecraft:wool for the Cliff Stone Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Cliff Stone Block Meta"=
 
             # If you want to change this biome's filler block (the block underneath the top block), enter a valid block ID here (e.g. minecraft:dirt).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Filler Block"=
 
             # If you're using a custom filler block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's filler block, you would enter minecraft:wool for the Filler Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Filler Block Meta"=
 
             # If you want to change this biome's top block, enter a valid block ID here (e.g. minecraft:grass).
-            # For more info, visit http://minecraft.gamepedia.com/Data_values#Block_IDs [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs [default: ]
             S:"RTG Surface: Top Block"=
 
             # If you're using a custom top block, enter its numeric data value here.
             # For example, if you want to use red wool for this biome's top block, you would enter minecraft:wool for the Top Block ID,
             # and you would enter 6 here, because red wool has a data value of 6. (For most blocks, this value will be 0.)
-            # For more info, visit http://minecraft.gamepedia.com/Data_values [default: ]
+            # For more info, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening [default: ]
             S:"RTG Surface: Top Block Meta"=
 
             # This setting controls the number of ravines that generate.

--- a/config/RTG/rtg.cfg
+++ b/config/RTG/rtg.cfg
@@ -387,7 +387,7 @@ trees {
     B:"Allow Trees to Generate on Sand"=false
 
     # Set this to FALSE to prevent the trunks of RTG trees from using the 'all-bark' texture model.
-    # For more information, visit http://minecraft.gamepedia.com/Wood#Block_data
+    # For more information, visit https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Wood
     #  [default: true]
     B:"Allow bark-covered logs"=true
 }


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.