### PR TITLE
Unbind craft presence key by default

### DIFF
--- a/config/craftpresence.json
+++ b/config/craftpresence.json
@@ -341,7 +341,7 @@
     "stripTranslationColors": false,
     "showLoggingInChat": false,
     "stripExtraGuiElements": false,
-    "configKeyCode": 41
+    "configKeyCode": 0
   },
   "displaySettings": {
     "presenceData": {


### PR DESCRIPTION
Unbind the craft presence config keybind by default.
Actually a pretty important fix so that new players can access the quest book without issues.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14006