### PR TITLE
Enable crashOnNullRecipeInput

### DIFF
--- a/config/GregTech/GregTech.cfg
+++ b/config/GregTech/GregTech.cfg
@@ -114,6 +114,7 @@ general {
     I:SkeletonsShootGTArrows=16
     I:TicksForLagAveragingWithScanner=25
     B:WoodNeedsSawForCrafting=true
+    B:crashOnNullRecipeInput=true
     S:ctm_block_blacklist <
         team.chisel.block.BlockRoadLine
      >


### PR DESCRIPTION
To make spotting recipe error easier. I can load the pack without issue.