### PR TITLE
Harvestcraft Config Update - Grinder

### DIFF
--- a/config/harvestcraft.cfg
+++ b/config/harvestcraft.cfg
@@ -1,5 +1,10 @@
 # Configuration file
 
+backports {
+    B:enablemeatGrinder=false
+}
+
+
 beekeeping {
     I:beehiveRarity=5
     B:enablebeehiveGeneration=false
@@ -93,6 +98,7 @@ gardens {
     B:enabletropicalgardenGeneration=true
     B:enablewatergardenGeneration=true
     I:gardenRarity=2
+    I:gardenSpreadLimit=5
     I:gardendropAmount=3
     B:gardensdropSeeds=false
     I:gardenspreadRate=100
@@ -100,6 +106,7 @@ gardens {
 
 
 general {
+    B:enablemrcrayfishcompatibility=true
     B:sheepdropMutton=true
     B:squiddropCalamari=true
 }
@@ -159,10 +166,12 @@ general {
     B:enableharvestcraftfish=true
     B:enablelistAllwaterfreshwater=true
     B:enablelistAllwatervanillawaterbucket=true
+    B:enablemachinerecipes=false
     B:enablesaltfromwaterbucketrecipe=false
     B:enabletofuasmeatinRecipes=true
     B:enabletofuasmilkinRecipes=true
     I:fishtrapbaitrecipeamount=4
+    B:forcecookinginmeatrecipes=false
     I:freshmilkfrombucket=1
     I:freshwaterfrombucket=1
     I:fruitbaitrecipeamount=4


### PR DESCRIPTION
Adds new entries from https://github.com/GTNewHorizons/harvestcraft/pull/48. 

`enablemachinerecipes` is set to false as requested.
New content is disabled for until it is properly integrated.

**Not to be merged until the associated PR is merged.**