### PR TITLE
Add more missing "hunter's drops" to forestry backpack

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -11678,6 +11678,7 @@ backpacks {
         # Add itemStacks for the hunter's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
         S:item.stacks <
 		    BiomesOPlenty:misc:10
+		    BloodArsenal:wolf_hide
             Botania:gaiaHead:0
             EnderZoo:enderFragment
             EnderZoo:confusingDust

--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -11680,6 +11680,8 @@ backpacks {
 		    BiomesOPlenty:misc:10
             Botania:gaiaHead:0
             EnderZoo:enderFragment
+            EnderZoo:confusingDust
+            EnderZoo:witheringDust
             HardcoreEnderExpansion:enderman_head:0
             harvestcraft:anchovyrawItem:0
             harvestcraft:bassrawItem:0
@@ -11725,6 +11727,7 @@ backpacks {
             minecraft:ender_pearl
             minecraft:feather
             minecraft:fermented_spider_eye
+            minecraft:fire_charge
             minecraft:fish
             minecraft:fish:1
             minecraft:fish:2
@@ -11748,6 +11751,7 @@ backpacks {
             minecraft:spider_eye
             minecraft:string
             minecraft:wool
+            RandomThings:ingredient:3
             witchery:wolfhead:0
             witchery:wolfhead:1
 			witchery:ingredient:25

--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -11752,9 +11752,11 @@ backpacks {
             minecraft:spider_eye
             minecraft:string
             minecraft:wool
+            Natura:barleyFood:7
             RandomThings:ingredient:3
             witchery:wolfhead:0
             witchery:wolfhead:1
+            witchery:ingredient:24
 			witchery:ingredient:25
          >
 


### PR DESCRIPTION
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7022

Natura:barleyFood:7 is flamestring
RandomThings:ingredient:3 is ectoplasm
witchery:ingredient:24 is wool of bat

others are self-explanatory.
