### PR TITLE
Remove Condition from `unbreakable_tconstruct_tool` Achievement

### DIFF
--- a/config/amazingtrophies/achievements/unbreakable_tconstruct_tool.json
+++ b/config/amazingtrophies/achievements/unbreakable_tconstruct_tool.json
@@ -1,10 +1,6 @@
 {
   "id": "unbreakable_tconstruct_tool",
-  "condition": {
-    "type": "item.pickup",
-    "item": "TConstruct:hammer",
-    "nbt": "{InfiTool: {Unbreaking: 10}}"
-  },
+  "_condition": "Handled via code (NHCore)",
   "page": "GT New Horizons",
   "x": 7,
   "y": 6,


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/776.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15070.

The condition would only be met, if a TiCon Hammer is picked up.