### PR TITLE
Change "These Items Will Not 'Be Back'" to better match items needed

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/KaaamiHaaaamiHA-AAAAAAAAAAAAAAAAAAAAGA==/TheseItemsWillNo-AAAAAAAAAAAAAAAAAAALRw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/KaaamiHaaaamiHA-AAAAAAAAAAAAAAAAAAAAGA==/TheseItemsWillNo-AAAAAAAAAAAAAAAAAAALRw==.json
@@ -17,7 +17,7 @@
       "simultaneous:1": 0,
       "icon:10": {
         "id:8": "Thaumcraft:blockMetalDevice",
-        "Count:3": 4,
+        "Count:3": 8,
         "Damage:2": 3,
         "OreDict:8": ""
       },
@@ -45,7 +45,7 @@
       "requiredItems:9": {
         "0:10": {
           "id:8": "Thaumcraft:blockMetalDevice",
-          "Count:3": 4,
+          "Count:3": 8,
           "Damage:2": 3,
           "OreDict:8": ""
         },


### PR DESCRIPTION
Updated the "These Items Will Not 'Be Back'" to require 8 Advanced Alchemical Constructs instead of 
4 to fix #15099


Before change
![Before2](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/67732946/a4132800-d3ff-4946-902a-5c95d39b4224)

After change
![After2](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/67732946/b0a282d0-4d17-4b64-b34b-adf06118e183)