### PR TITLE
Override xutils obsidian harvest levels

### DIFF
--- a/config/IguanaTinkerTweaks/BlockOverride.cfg
+++ b/config/IguanaTinkerTweaks/BlockOverride.cfg
@@ -29,6 +29,24 @@
 " info" {
 }
 
+blocks_pickaxe { 
+    I:"ExtraUtilities:color_obsidian:0"=5
+    I:"ExtraUtilities:color_obsidian:1"=5
+    I:"ExtraUtilities:color_obsidian:10"=5
+    I:"ExtraUtilities:color_obsidian:11"=5
+    I:"ExtraUtilities:color_obsidian:12"=5
+    I:"ExtraUtilities:color_obsidian:13"=5
+    I:"ExtraUtilities:color_obsidian:14"=5
+    I:"ExtraUtilities:color_obsidian:15"=5
+    I:"ExtraUtilities:color_obsidian:2"=5
+    I:"ExtraUtilities:color_obsidian:3"=5
+    I:"ExtraUtilities:color_obsidian:4"=5
+    I:"ExtraUtilities:color_obsidian:5"=5
+    I:"ExtraUtilities:color_obsidian:6"=5
+    I:"ExtraUtilities:color_obsidian:7"=5
+    I:"ExtraUtilities:color_obsidian:8"=5
+    I:"ExtraUtilities:color_obsidian:9"=5
+}
 
 ##########################################################################################################
 # generaloredict


### PR DESCRIPTION
Found a unused iguana config that can be used to override harvest levels for ARR mods. (from what I can tell the 'blockdefault' config is just a datadump that hasnt been regenerated in years and not a real config, but 'blockoverride' does indeed do what it says.)

Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/111 (hopefully these were the last ones).