### PR TITLE
Add  Thaumic Boots to Gravisuite Config

### DIFF
--- a/config/GraviSuite.cfg
+++ b/config/GraviSuite.cfg
@@ -4,6 +4,14 @@
     I:EpicLapPackChargeTickChance=10
     I:MaxToolLevelAvailable=9
     S:ThisIsAHackedMod=i know and its ok
+
+    # These items can be used in place of the Quantum Boots and still allow the usage of the Quantum Shield [default: [EMT:QuantumBootsTraveller]]
+    S:AllowedShieldBoots <
+        EMT:QuantumBootsTraveller
+        thaumicboots:item.ItemQuantumComet
+        thaumicboots:item.ItemQuantumVoid
+        thaumicboots:item.ItemQuantumMeteor
+     >
 }
 
 


### PR DESCRIPTION
Adds the 3 new Quantum tier of Thaumic Boots as valid boots for use with GraviSuite's Quantum Shield