### PR TITLE
Fix second AE2 quest prereq loop

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/ToolsoftheTrade-AAAAAAAAAAAAAAAAAAAJ6Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/ToolsoftheTrade-AAAAAAAAAAAAAAAAAAAJ6Q==.json
@@ -4,10 +4,6 @@
     "0:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 1292
-    },
-    "1:10": {
-      "questIDHigh:4": -1952656661982133357,
-      "questIDLow:4": -5638703973738633044
     }
   },
   "questIDLow:4": 2537,


### PR DESCRIPTION
Fix a second prereq loop caused by https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15112
First was fixed in [december.](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15171)
hope thats all now :(

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15494