### PR TITLE
Improve server utils config

### DIFF
--- a/serverutilities/server/ranks.txt
+++ b/serverutilities/server/ranks.txt
@@ -1,1 +1,33 @@
 // For more info visit https://github.com/GTNewHorizons/ServerUtilities
+
+[player]
+default_player_rank: true
+power: 1
+serverutilities.claims.max_chunks: 100
+serverutilities.chunkloader.max_chunks: 50
+serverutilities.homes.max: 1
+serverutilities.homes.warmup: 5
+serverutilities.homes.cooldown: 5
+serverutilities.homes.cross_dim: false
+
+[vip]
+power: 20
+serverutilities.chat.name_format: <&bVIP {name}&r>
+serverutilities.claims.max_chunks: 500
+serverutilities.chunkloader.max_chunks: 100
+serverutilities.homes.max: 1
+serverutilities.homes.warmup: 0
+serverutilities.homes.cooldown: 1
+serverutilities.homes.cross_dim: false
+
+[admin]
+default_op_rank: true
+power: 100
+serverutilities.chat.name_format: <&2{name}&r>
+serverutilities.claims.max_chunks: 1000
+serverutilities.chunkloader.max_chunks: 1000
+serverutilities.claims.bypass_limits: true
+serverutilities.homes.max: 1
+serverutilities.homes.warmup: 0
+serverutilities.homes.cooldown: 0
+serverutilities.homes.cross_dim: false

--- a/serverutilities/server/ranks.txt
+++ b/serverutilities/server/ranks.txt
@@ -6,8 +6,8 @@ power: 1
 serverutilities.claims.max_chunks: 100
 serverutilities.chunkloader.max_chunks: 50
 serverutilities.homes.max: 1
-serverutilities.homes.warmup: 5
-serverutilities.homes.cooldown: 5
+serverutilities.homes.warmup: 5s
+serverutilities.homes.cooldown: 5s
 serverutilities.homes.cross_dim: false
 
 [vip]
@@ -16,8 +16,8 @@ serverutilities.chat.name_format: <&bVIP {name}&r>
 serverutilities.claims.max_chunks: 500
 serverutilities.chunkloader.max_chunks: 100
 serverutilities.homes.max: 1
-serverutilities.homes.warmup: 0
-serverutilities.homes.cooldown: 1
+serverutilities.homes.warmup: 0s
+serverutilities.homes.cooldown: 1s
 serverutilities.homes.cross_dim: false
 
 [admin]
@@ -28,6 +28,6 @@ serverutilities.claims.max_chunks: 1000
 serverutilities.chunkloader.max_chunks: 1000
 serverutilities.claims.bypass_limits: true
 serverutilities.homes.max: 1
-serverutilities.homes.warmup: 0
-serverutilities.homes.cooldown: 0
+serverutilities.homes.warmup: 0s
+serverutilities.homes.cooldown: 0s
 serverutilities.homes.cross_dim: false

--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -74,7 +74,7 @@ commands {
     B:backup=false
     B:chunks=false
     B:dump_chunkloaders=false
-    B:dump_permissions=false
+    B:dump_permissions=true
     B:fly=false
     B:god=false
     B:heal=false
@@ -210,7 +210,7 @@ world {
      >
 
     # If set to DEFAULT, then teams can decide their Explosion setting.
-    S:enable_explosions=default
+    S:enable_explosions=true
 
     # If set to DEFAULT, then players can decide their PVP status.
     S:enable_pvp=true


### PR DESCRIPTION
- turn on dump_permission for some documentation
- add a basic ranks file. This makes it easier for people to configure their game! (ranks/chunkloading/claims/homes are still off in the config. but now its easy to change)
- turn on explosions

The goal here is to make it much easier to give instructions on how to use SU for chunkloading in SP or a local server without adding other cheats: 'turn on claims, chunkloading, and ranks in the config'. While at the same time also making it clearer how to enable and configure homes (for the teleport cheaters :P). And all that without changing the current defaults as claims/chunkloading/ranks/home is all off.