### PR TITLE
Increase execution time limit to 20s

### DIFF
--- a/config/OpenComputers.cfg
+++ b/config/OpenComputers.cfg
@@ -269,7 +269,7 @@ opencomputers {
     # programs blocking other computers by locking down the executor threads.
     # Note that changing this won't have any effect on computers that are
     # already running - they'll have to be rebooted for this to take effect.
-    timeout=5
+    timeout=20
   }
 
   # Settings that are intended for debugging issues, not for normal use.


### PR DESCRIPTION
Target this:https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15517
20sec should be adequate for general OC usage on large scale ME Networks and not get affected too hard from lnfinite loop apps.
Feel free to edit the number as long as AE2 getItemsInNetwork([filter:table]):table method does not fail in a Stargate base.