### PR TITLE
Remove magnesium chloride as a required item

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/Rutile-AAAAAAAAAAAAAAAAAAAD9A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/Rutile-AAAAAAAAAAAAAAAAAAAD9A==.json
@@ -121,12 +121,6 @@
           "Count:3": 16,
           "Damage:2": 12028,
           "OreDict:8": ""
-        },
-        "1:10": {
-          "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 96,
-          "Damage:2": 2377,
-          "OreDict:8": ""
         }
       },
       "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
Removes magnesium chloride requirement to complete the quest so that players who loop it won't have to gather it
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/81298696/c1bdbc7f-c165-4a52-8e7c-7b1562b5f07b)
