### PR TITLE
Add various planet blocks to meteors.

### DIFF
--- a/config/BloodMagic/meteors/RainbowGlassMeteor.json
+++ b/config/BloodMagic/meteors/RainbowGlassMeteor.json
@@ -16,6 +16,8 @@
     "1",
 	"stainedGlassGray",
     "1",
+	"stainedGlassLightGray",
+    "1",
 	"stainedGlassCyan",
     "1",
 	"stainedGlassPurple",

--- a/config/BloodMagic/meteors/SuperGTStones.json
+++ b/config/BloodMagic/meteors/SuperGTStones.json
@@ -1,13 +1,9 @@
 {
   "ores": [
-    "stoneMarble",
-    "250",
-	"stoneBasalt",
-    "250",
-	"stoneGraniteRed",
-    "250",
-	"stoneGraniteBlack",
-    "250"
+	"gregtech:gt.blockstones:0:250",
+	"gregtech:gt.blockstones:8:250",
+	"gregtech:gt.blockgranites:0:250",
+	"gregtech:gt.blockgranites:8:250"
   ],
   "radius": 20,
   "cost": 775000,

--- a/config/BloodMagic/meteors/T1RocketStones.json
+++ b/config/BloodMagic/meteors/T1RocketStones.json
@@ -1,7 +1,8 @@
 {
   "ores": [
-    "rockMoon",
-    "1000"
+	"GalacticraftCore:tile.moonBlock:4:850",
+	"GalacticraftCore:tile.moonBlock:3:100",
+	"GalacticraftCore:tile.moonBlock:5:50"
   ],
   "radius": 20,
   "cost": 500000,

--- a/config/BloodMagic/meteors/T2RocketStones.json
+++ b/config/BloodMagic/meteors/T2RocketStones.json
@@ -1,11 +1,15 @@
 {
   "ores": [
-    "rockMars",
-    "334",
-	"rockPhobos",
-    "333",
-	"rockDeimos",
-    "333"
+	"GalacticraftMars:tile.mars:9:850",
+	"GalacticraftMars:tile.mars:6:100",
+	"GalacticraftMars:tile.mars:5:50",
+
+	"GalaxySpace:phobosblocks:2:850",
+	"GalaxySpace:phobosblocks:1:100",
+	"GalaxySpace:phobosblocks:0:50",
+
+	"GalaxySpace:deimosblocks:1:950",
+	"GalaxySpace:deimosblocks:0:50"
   ],
   "radius": 20,
   "cost": 750000,

--- a/config/BloodMagic/meteors/T3RocketStones.json
+++ b/config/BloodMagic/meteors/T3RocketStones.json
@@ -1,15 +1,21 @@
 {
   "ores": [
-    "rockCeres",
-    "200",
-	"rockCallisto",
-    "200",
-	"rockEuropa",
-    "200",
-	"rockGanymede",
-    "200",
-	"rockAsteroids",
-    "200"
+	"GalaxySpace:ceresblocks:1:950",
+	"GalaxySpace:ceresblocks:0:50",
+
+	"GalaxySpace:callistoblocks:1:950",
+	"GalaxySpace:callistoblocks:0:50",
+
+	"GalaxySpace:europagrunt:1:950",
+	"GalaxySpace:europagrunt:0:50",
+
+	"GalaxySpace:ganymedeblocks:1:950",
+	"GalaxySpace:ganymedeblocks:0:50",
+
+	"GalacticraftMars:tile.asteroidsBlock:0:320",
+	"GalacticraftMars:tile.asteroidsBlock:1:320",
+	"GalacticraftMars:tile.asteroidsBlock:2:320",
+	"GalacticraftMars:tile.denseIce:0:40"
   ],
   "radius": 20,
   "cost": 1000000,

--- a/config/BloodMagic/meteors/T4RocketStones.json
+++ b/config/BloodMagic/meteors/T4RocketStones.json
@@ -1,11 +1,15 @@
 {
   "ores": [
-    "rockIo",
-    "334",
-	"rockPlanetMercury",
-    "333",
-	"rockVenus",
-    "333"
+	"GalaxySpace:ioblocks:2:900",
+	"GalaxySpace:ioblocks:0:50",
+	"GalaxySpace:ioblocks:1:50",
+
+	"GalaxySpace:mercuryblocks:2:850",
+	"GalaxySpace:mercuryblocks:1:100",
+	"GalaxySpace:mercuryblocks:0:50",
+
+	"GalaxySpace:venusblocks:1:950",
+	"GalaxySpace:venusblocks:0:50"
   ],
   "radius": 20,
   "cost": 7500000,

--- a/config/BloodMagic/meteors/T5RocketStones.json
+++ b/config/BloodMagic/meteors/T5RocketStones.json
@@ -1,13 +1,21 @@
 {
   "ores": [
-	"rockTitan",
-    "250",
-	"rockEnceladus",
-    "250",
-	"rockOberon",
-    "250",
-	"rockMiranda",
-    "250"
+	"GalaxySpace:titanblocks:2:750",
+	"GalaxySpace:titanblocks:1:100",
+	"GalaxySpace:titanblocks:0:50",
+	"minecraft:packed_ice:0:100",
+
+	"GalaxySpace:enceladusblocks:1:850",
+	"GalaxySpace:enceladusblocks:3:100",
+	"GalaxySpace:enceladusblocks:0:50",
+
+	"GalaxySpace:oberonblocks:2:850",
+	"GalaxySpace:oberonblocks:1:100",
+	"GalaxySpace:oberonblocks:0:50",
+
+	"GalaxySpace:mirandablocks:2:850",
+	"GalaxySpace:mirandablocks:1:100",
+	"GalaxySpace:mirandablocks:0:50"
   ],
   "radius": 20,
   "cost": 10000000,

--- a/config/BloodMagic/meteors/T6RocketStones.json
+++ b/config/BloodMagic/meteors/T6RocketStones.json
@@ -1,9 +1,12 @@
 {
   "ores": [
-    "rockTriton",
-    "500",
-	"rockProteus",
-    "500"
+  	"GalaxySpace:tritonblocks:2:850",
+	"GalaxySpace:tritonblocks:1:100",
+	"GalaxySpace:tritonblocks:0:50",
+
+  	"GalaxySpace:proteusblocks:2:850",
+	"GalaxySpace:proteusblocks:1:100",
+	"GalaxySpace:proteusblocks:0:50"
   ],
   "radius": 20,
   "cost": 15000000,

--- a/config/BloodMagic/meteors/T7RocketStones.json
+++ b/config/BloodMagic/meteors/T7RocketStones.json
@@ -1,11 +1,16 @@
 {
   "ores": [
-    "rockPluto",
-    "334",
-	"rockMakeMake",
-    "333",
-	"rockHaumea",
-    "333"
+	"GalaxySpace:plutoblocks:5:840",
+	"GalaxySpace:plutoblocks:4:100",
+	"GalaxySpace:plutoblocks:0:15",
+	"GalaxySpace:plutoblocks:1:15",
+	"GalaxySpace:plutoblocks:2:15",
+	"GalaxySpace:plutoblocks:3:15",
+
+	"GalaxySpace:makemakegrunt:1:950",
+	"GalaxySpace:makemakegrunt:0:50",
+
+	"GalaxySpace:haumeablocks:0:1000"
   ],
   "radius": 20,
   "cost": 30000000,

--- a/config/BloodMagic/meteors/T8RocketStones.json
+++ b/config/BloodMagic/meteors/T8RocketStones.json
@@ -1,15 +1,23 @@
 {
   "ores": [
-    "rockBarnardaE",
-    "200",
-	"rockBarnardaF",
-    "200",
-	"rockVegaB",
-    "200",
-	"rockTcetiE",
-    "200",
-	"rockCentauriA",
-    "200"
+	"GalaxySpace:barnardaEsubgrunt:0:950",
+	"GalaxySpace:barnardaEgrunt:0:50",
+
+	"GalaxySpace:barnardaFsubgrunt:0:950",
+	"GalaxySpace:barnardaFgrunt:0:50",
+
+	"GalaxySpace:barnardaCdirt:0:100",
+	"GalaxySpace:barnardaCgrass:0:20",
+
+	"GalaxySpace:vegabsubgrunt:0:950",
+	"GalaxySpace:vegabgrunt:0:50",
+
+	"GalaxySpace:tcetieblocks:2:850",
+	"GalaxySpace:tcetieblocks:1:100",
+	"GalaxySpace:tcetieblocks:0:50",
+
+	"GalaxySpace:acentauribbsubgrunt:0:950",
+	"GalaxySpace:acentauribbgrunt:0:50"
   ],
   "radius": 20,
   "cost": 50000000,


### PR DESCRIPTION
The main purpose of this PR is to add all the different blocks that generate on the various planets to the respective meteors (Blood Magic Mark of the Falling Tower ritual). This closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15711. See https://github.com/GTNewHorizons/BloodMagic/pull/50 for explanation of the new format; this PR is also necessary for this change to work (older versions of BM *will crash* with this config).

Along the way I implemented two minor fixes:
* The meteor which spawns various granite blocks now always spawns the GT variants, not assorted variants from other random mods based on whichever is first in the oredict. The different variants can still be converted to each other using a chisel if one wants a different type (this is pre-existing).
* Fixed a missing color in the stained glass meteor.

The only thing that is changed is the composition of the various meteors. I have not changed the size (which controls the total number of blocks), cost, reagent items, or anything else. Some other meteors could probably benefit from being able to spawn blocks more precisely by ID as well, but I wanted to keep the number of changes to a minimum due to the feature freeze.

All changes have been tested in 2.6.0-beta-1.

<details>
<summary>In case anybody is interested in the logic behind the weights of the different blocks:</summary>

Each meteor contains blocks from several planets. First, every planet is assigned a "weight budget" of 1000, so that the different planets are equally represented in the meteor. Then this budget is then split between the different blocks that generate on the planet, roughly proportional to how many of those blocks actually generate.

A one-block-thick surface cover generally gets assigned 50 weight, a deeper subsurface layer or scattered deposits get 100. When the planet generates several different blocks in the same layer, the weight is split between them further. Finally, all the remaining weight goes to the "core" planet stone block.

This means that a majority of the meteor will consist of the basic planet "stone" equivalent, and it will then contain smaller amounts of the surface blocks. However, due to the total size of the meteors, there is still plenty enough of those blocks even from one activation to address niche needs (e.g., no rocket runs).</details>

<details>
<summary>Some space balls</summary>

![](https://i.imgur.com/mURF7gD.jpeg)
</details>