### PR TITLE
Fix the advanced metal blacklist for WG

### DIFF
--- a/config/WitchingGadgets.cfg
+++ b/config/WitchingGadgets.cfg
@@ -83,6 +83,9 @@ modules {
         Erbium
         Thulium
         Ytterbium
+        Tritanium
+        Promethium
+        Terbium
      >
 }
 


### PR DESCRIPTION
Add missing advanced materials to blacklist. Fixes https://discord.com/channels/181078474394566657/939305179524792340/1223927938320302110