### PR TITLE
Update InGameInfo.xml - Fix Slime Chunk Designation

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -105,10 +105,6 @@
                 <num>0</num>
             </icon>
             <str> Chunk X: {gold}{chunkx} {white}Z: {gold}{chunkz} {white}Off: {gold}{chunkoffsetx} {white}: {gold}{chunkoffsetz} {white}Y: {gold}{yfeeti} {white}Facing {gold}{finedirection}</str>
-            <if>
-                <var>slimechunk</var>
-                <str> {gold}SlimeChunk{white}</str>
-            </if>
         </line>
         <line>
             <icon>
@@ -309,6 +305,20 @@
                         <str>      </str>
                     </if>
                     <str>  You are at the {darkred}center {white}of the chunk.</str>
+                </concat>
+            </if>
+        </line>
+        <line>
+            <if>
+                <equal>
+                    <var>slimes</var>
+                    <str>true</str>
+                </equal>
+                <concat>
+                    <icon>
+                            <str>textures/items/slimeball.png</str>
+                    </icon>
+                    <str> You are in a {darkgreen}slime chunk{white}.</str>
                 </concat>
             </if>
         </line>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -256,6 +256,20 @@
         </line>
         <line>
             <if>
+                <equal>
+                    <var>slimes</var>
+                    <str>true</str>
+                </equal>
+                <concat>
+                    <icon>
+                            <str>textures/items/slimeball.png</str>
+                    </icon>
+                    <str> You are in a {darkgreen}slime chunk{white}.</str>
+                </concat>
+            </if>
+        </line>
+        <line>
+            <if>
                 <and>
                     <equal>
                         <var>chunkoffsetx</var>
@@ -305,20 +319,6 @@
                         <str>      </str>
                     </if>
                     <str>  You are at the {darkred}center {white}of the chunk.</str>
-                </concat>
-            </if>
-        </line>
-        <line>
-            <if>
-                <equal>
-                    <var>slimes</var>
-                    <str>true</str>
-                </equal>
-                <concat>
-                    <icon>
-                            <str>textures/items/slimeball.png</str>
-                    </icon>
-                    <str> You are in a {darkgreen}slime chunk{white}.</str>
                 </concat>
             </if>
         </line>


### PR DESCRIPTION
Noticed that the default config doesn't have a functioning slime chunk HUD even though it is included. So I replaced it with one that worked (tested personally) that fit with the "This is an ore chunk." and "This is the center of the chunk." formats.