### PR TITLE
Add Railcraft NEI handlers to height hack

### DIFF
--- a/config/NEI/heighthackhandlers.cfg
+++ b/config/NEI/heighthackhandlers.cfg
@@ -6,4 +6,5 @@ ic2.neiIntegration.core.recipehandler.*
 mariculture.plugins.nei.*
 redgear.brewcraft.plugins.nei.*
 tconstruct.plugins.nei.*
+tonius.neiintegration.mods.railcraft.*
 WayofTime.alchemicalWizardry.client.nei.*

--- a/config/NEI/heighthackhandlers.cfg
+++ b/config/NEI/heighthackhandlers.cfg
@@ -1,3 +1,7 @@
+# Each line in this file should either be a comment (line starts with '#'), or a fully-qualified class name (that
+# includes the package name) for a recipe handler. Wildcard patterns ('*') can be used to catch multiple classes with a
+# single entry.
+# If you delete this file, it will be regenerated with the default height hacked handlers list.
 buildcraft.compat.nei.*
 cofh.thermalexpansion.plugins.nei.handlers.*
 crazypants.enderio.nei.*


### PR DESCRIPTION
Fixes:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16020

I tested this and it seemed to work fine on 2.5.1