### PR TITLE
Fix quests for multiblock dehydrator downtiering

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/ToomuchIndium-AAAAAAAAAAAAAAAAAAAMSA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/ToomuchIndium-AAAAAAAAAAAAAAAAAAAMSA==.json
@@ -29,7 +29,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Milling process is an alternative way to produce Indium, designed for ZPM and UV people. It does not void Aluminium and Galena for no reason, and you can extract Indium from Sphalerite efficiently. In exchange of machine cost and infrastructure needed to process.\n\n§3This multi is LuV, but you have to use in combination with Vacuum Furnace, which is ZPM."
+      "desc:8": "Milling process is an alternative way to produce Indium, designed for ZPM and UV people, although you can start it in LuV. It does not void Aluminium and Galena for no reason, and you can extract Indium from Sphalerite efficiently. In exchange of machine cost and infrastructure needed to process."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/ToomuchIndium-AAAAAAAAAAAAAAAAAAAMSA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/ToomuchIndium-AAAAAAAAAAAAAAAAAAAMSA==.json
@@ -29,7 +29,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Milling process is an alternative way to produce Indium, designed for ZPM and UV people, although you can start it in LuV. It does not void Aluminium and Galena for no reason, and you can extract Indium from Sphalerite efficiently. In exchange of machine cost and infrastructure needed to process."
+      "desc:8": "Milling process is an alternative way to produce Indium, designed for LuV and above. It does not void Aluminium and Galena for no reason, and you can extract Indium from Sphalerite efficiently. In exchange of machine cost and infrastructure needed to process."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/WhatEvenisThis-AAAAAAAAAAAAAAAAAAAKyA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/WhatEvenisThis-AAAAAAAAAAAAAAAAAAAKyA==.json
@@ -7,7 +7,7 @@
     },
     "1:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2610
+      "questIDLow:4": 1493
     }
   },
   "questIDLow:4": 2760,
@@ -33,7 +33,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "In addition to being a dehydrator multi, it\u0027s also a Vacuum Furnace, for which no singleblock exists. It\u0027s supposed to be used with the IsaMill Grinding Machine multi and the Flotation Cell Regulator multi for the purposes of ore milling, an advanced method of ore processing that needs a lot of infrastructure, but which gives many new outputs for each ore it supports.\n\n§3This multi is ZPM."
+      "desc:8": "In addition to being a dehydrator multi, it\u0027s also a Vacuum Furnace, for which no singleblock exists. It\u0027s supposed to be used with the IsaMill Grinding Machine multi and the Flotation Cell Regulator multi for the purposes of ore milling, an advanced method of ore processing that needs a lot of infrastructure, but which gives many new outputs for each ore it supports.\n\n§3This multi is LuV now!"
     }
   },
   "tasks:9": {
@@ -69,7 +69,7 @@
         "0:10": {
           "id:8": "enhancedlootbags:lootbag",
           "Count:3": 1,
-          "Damage:2": 42,
+          "Damage:2": 41,
           "OreDict:8": ""
         }
       }


### PR DESCRIPTION
GTNewHorizons/GTPlusPlus#873 downtiered the multiblock dehydrator from ZPM to LuV. This PR updates the questbook to reflect these changes.

- Requirement is changed from ZPM hull quest to LuV hull quest
- Reward for dehydrator quest changed from ZPM loot bag to LuV loot bag
- Text updated to reflect changes.