### PR TITLE
Whitelist non-GT draconium ore dimensions to End only

### DIFF
--- a/config/DraconicEvolution.cfg
+++ b/config/DraconicEvolution.cfg
@@ -86,6 +86,11 @@ general {
 	100
     >
 
+    # Add the id's of dimensions you do want draconium ore to spawn in (if empty, uses only the blacklist)
+    I:"Ore gen dimension whitelist" <
+        1
+     >
+
     # Is Pigmen blood rage active
     B:"Pigmen Blood Rage"=true
 


### PR DESCRIPTION
Using the new DE config option, disable ore spawning outside of the end - this fixes draconium spawning in personal dimensions.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12919