### PR TITLE
Turn off NEIAddons AE2 integration

### DIFF
--- a/config/NEIAddons.cfg
+++ b/config/NEIAddons.cfg
@@ -7,7 +7,7 @@
 ##########################################################################################################
 
 addons {
-    B:"Applied Energistics 2"=true
+    B:"Applied Energistics 2"=false
     B:Botany=true
     B:"Crafting Tables"=true
     B:"Developer Tools"=false


### PR DESCRIPTION
Everything this does is already handled by NEE and currently causes https://github.com/GTNewHorizons/NotEnoughEnergistics/pull/39 not to work in base AE2 terminals.