### PR TITLE
Readd mousetweaks config and fix incorrect stack splitting

### DIFF
--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -1,0 +1,35 @@
+# Configuration file
+
+general {
+    # Scroll Scaling
+    # 0 - Multiple Wheel Clicks Move Multiple Items
+    # 1 - Always Move One Item (macOS Compatibility) [range: 0 ~ 1, default: 0]
+    I:ScrollItemScaling=0
+
+    # Wheel Scroll Direction
+    # 0 - Down to Push, Up to Pull
+    # 1 - Up to Push, Down to Pull
+    # 2 - Inventory Position Aware
+    # 3 - Inventory Position Aware, Inverted
+    #  [range: 0 ~ 3, default: 0]
+    I:WheelScrollDirection=0
+
+    # Lets you quickly pick up or move items of the same type [default: true]
+    B:LMBTweakWithItem=false
+
+    # Quickly move items into another inventory [default: true]
+    B:LMBTweakWithoutItem=true
+
+    # Scroll to quickly move items between inventories [default: true]
+    B:WheelTweak=true
+
+    # Wheel Inventory Slot Search Order
+    # 0 - First to Last
+    # 1 - Last To First [range: 0 ~ 1, default: 1]
+    I:WheelSearchOrder=1
+
+    # Very similar to the standard RMB dragging mechanic, with one difference: if you drag over a slot multiple times, an item will be put there multiple times. Replaces the standard mechanic if enabled. [default: false]
+    B:RMBTweak=false
+}
+
+

--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -21,7 +21,7 @@ general {
     B:LMBTweakWithoutItem=true
 
     # Scroll to quickly move items between inventories [default: true]
-    B:WheelTweak=true
+    B:WheelTweak=false
 
     # Wheel Inventory Slot Search Order
     # 0 - First to Last

--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -21,7 +21,7 @@ general {
     B:LMBTweakWithoutItem=true
 
     # Scroll to quickly move items between inventories [default: true]
-    B:WheelTweak=false
+    B:WheelTweak=true
 
     # Wheel Inventory Slot Search Order
     # 0 - First to Last

--- a/config/NEI/client.cfg
+++ b/config/NEI/client.cfg
@@ -8,7 +8,7 @@ inventory.bookmarksEnabled=true
 inventory.cheatmode=2
 #Creative or JEI style tabs
 inventory.creative_tab_style=false
-inventory.disableMouseScrollTransfer=false
+inventory.disableMouseScrollTransfer=true
 inventory.gamemodes=creative, creative+, adventure
 inventory.hidden=false
 inventory.invertMouseScrollTransfer=false

--- a/config/NEI/client.cfg
+++ b/config/NEI/client.cfg
@@ -8,7 +8,7 @@ inventory.bookmarksEnabled=true
 inventory.cheatmode=2
 #Creative or JEI style tabs
 inventory.creative_tab_style=false
-inventory.disableMouseScrollTransfer=true
+inventory.disableMouseScrollTransfer=false
 inventory.gamemodes=creative, creative+, adventure
 inventory.hidden=false
 inventory.invertMouseScrollTransfer=false


### PR DESCRIPTION
readds the mousetweaks config in the new format with the LMBTweakWithItem setting it had in 2.5.0. I am not gonna touch wheeltweaks here after all that is a bigger can of worms including defaultconfig mod considerations.

specifically:
- this disables LMBTweakWithItem again. which is a buggy thing we always had disabled. This fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16126