### PR TITLE
Update MouseTweaks entry to match new config format

### DIFF
--- a/config/localconfig.txt
+++ b/config/localconfig.txt
@@ -200,7 +200,7 @@ modularui.cfg/animations/*
 modularui.cfg/keyboard/*
 modularui.cfg/rendering/*
 
-MouseTweaks.cfg//* $format=simple
+MouseTweaks.cfg/*/*
 
 multipart.cfg//useSawIcons $format=simple
 

--- a/config/localconfig.txt
+++ b/config/localconfig.txt
@@ -201,6 +201,7 @@ modularui.cfg/keyboard/*
 modularui.cfg/rendering/*
 
 MouseTweaks.cfg/*/*
+!MouseTweaks.cfg/general/LMBTweakWithItem
 
 multipart.cfg//useSawIcons $format=simple
 


### PR DESCRIPTION
May or may not have been responsible for the autotransition to the new MouseTweaks config format not working in some cases.

`LMBTweakWithItem` is excluded.