### PR TITLE
Update InGameInfo.xml - Weather & Moon Phases, Improving Slime Chunk Commit

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -129,7 +129,33 @@
             <str>{white})</str>
         </line>
         <line>
-            <str>{black}</str>
+            <icon>
+                <str>witchery:mooncharm</str>
+            </icon>
+			<str> Moon phase: </str>
+			<op>
+				<str>eq</str>
+				<modi>
+					<var>day</var>
+					<num>8</num>
+				</modi>
+				<num>0</num>
+				<num>1</num>
+				<num>2</num>
+				<num>3</num>
+				<num>4</num>
+				<num>5</num>
+				<num>6</num>
+				<num>7</num>
+				<str>{gold}Full moon</str>
+				<str>{yellow}Waning gibbous (1/3)</str>
+				<str>{gray}Last quarter (2/3)</str>
+				<str>{darkgray}Waning crescent (3/3)</str>
+				<str>{black}New moon</str>
+				<str>{darkgray}Waxing crescent (1/3)</str>
+				<str>{gray}First quarter (2/3)</str>
+				<str>{yellow}Waxing gibbous (3/3)</str>
+			</op>
         </line>
         <line>
             <if>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -595,6 +595,20 @@
         <line>
             <if>
                 <equal>
+                    <var>slimes</var>
+                    <str>true</str>
+                </equal>
+                <concat>
+                    <icon>
+                            <str>textures/items/slimeball.png</str>
+                    </icon>
+                    <str> This is a {darkgreen}slime chunk{white}.</str>
+                </concat>
+            </if>
+        </line>
+        <line>
+            <if>
+                <equal>
                 <var>gtnewore</var>
                     <str>true</str>
                 </equal>
@@ -636,12 +650,8 @@
                     <concat>
                         <icon>
                             <str>textures/items/diamond_pickaxe.png</str>
-                            <num>0</num>
-                            <num>0</num>
-                            <num>16</num>
-                            <num>16</num>
                         </icon>
-                        <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+                        <str> This is an {darkgreen}{underline}ore{white} chunk.</str>
                     </concat>
                 </if>
             </if>
@@ -688,28 +698,10 @@
                     <concat>
                         <icon>
                             <str>textures/items/diamond_pickaxe.png</str>
-                            <num>0</num>
-                            <num>0</num>
-                            <num>16</num>
-                            <num>16</num>
                         </icon>
-                        <str>  This is an {darkgreen}{underline}ore{white} chunk.</str>
+                        <str> This is an {darkgreen}{underline}ore{white} chunk.</str>
                     </concat>
                 </if>
-            </if>
-        </line>
-        <line>
-            <if>
-                <equal>
-                    <var>slimes</var>
-                    <str>true</str>
-                </equal>
-                <concat>
-                    <icon>
-                            <str>textures/items/slimeball.png</str>
-                    </icon>
-                    <str> You are in a {darkgreen}slime chunk{white}.</str>
-                </concat>
             </if>
         </line>
         <line>
@@ -762,7 +754,7 @@
                         </and>
                         <str>      </str>
                     </if>
-                    <str>  You are at the {darkred}center {white}of the chunk.</str>
+                    <str>   You are at the {darkred}center {white}of the chunk.</str>
                 </concat>
             </if>
         </line>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -132,30 +132,30 @@
             <icon>
                 <str>witchery:mooncharm</str>
             </icon>
-			<str> Moon phase: </str>
-			<op>
-				<str>eq</str>
-				<modi>
-					<var>day</var>
-					<num>8</num>
-				</modi>
-				<num>0</num>
-				<num>1</num>
-				<num>2</num>
-				<num>3</num>
-				<num>4</num>
-				<num>5</num>
-				<num>6</num>
-				<num>7</num>
-				<str>{gold}Full moon</str>
-				<str>{yellow}Waning gibbous (1/3)</str>
-				<str>{gray}Last quarter (2/3)</str>
-				<str>{darkgray}Waning crescent (3/3)</str>
-				<str>{black}New moon</str>
-				<str>{darkgray}Waxing crescent (1/3)</str>
-				<str>{gray}First quarter (2/3)</str>
-				<str>{yellow}Waxing gibbous (3/3)</str>
-			</op>
+		<str> Moon phase: </str>
+		<op>
+			<str>eq</str>
+			<modi>
+				<var>day</var>
+				<num>8</num>
+			</modi>
+			<num>0</num>
+			<num>1</num>
+			<num>2</num>
+			<num>3</num>
+			<num>4</num>
+			<num>5</num>
+			<num>6</num>
+			<num>7</num>
+			<str>{gold}Full moon</str>
+			<str>{yellow}Waning gibbous (1/3)</str>
+			<str>{gray}Last quarter (2/3)</str>
+			<str>{darkgray}Waning crescent (3/3)</str>
+			<str>{black}New moon</str>
+			<str>{darkgray}Waxing crescent (1/3)</str>
+			<str>{gray}First quarter (2/3)</str>
+			<str>{yellow}Waxing gibbous (3/3)</str>
+		</op>
         </line>
         <line>
             <if>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -147,14 +147,14 @@
 			<num>5</num>
 			<num>6</num>
 			<num>7</num>
-			<str>{gold}Full moon</str>
-			<str>{yellow}Waning gibbous (1/3)</str>
-			<str>{gray}Last quarter (2/3)</str>
-			<str>{darkgray}Waning crescent (3/3)</str>
-			<str>{black}New moon</str>
-			<str>{darkgray}Waxing crescent (1/3)</str>
-			<str>{gray}First quarter (2/3)</str>
-			<str>{yellow}Waxing gibbous (3/3)</str>
+			<str>{gold}Full moon (D)</str>
+			<str>{yellow}Waning gibbous {gold}(D)</str>
+			<str>{gray}Last quarter {gold}(D)</str>
+			<str>{darkgray}Waning crescent {gold}(D)</str>
+			<str>{black}New moon {black}(N)</str>
+			<str>{darkgray}Waxing crescent {black}(N)</str>
+			<str>{gray}First quarter {black}(N)</str>
+			<str>{yellow}Waxing gibbous {black}(N)</str>
 		</op>
         </line>
         <line>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -133,16 +133,434 @@
         </line>
         <line>
             <if>
-                <var>snowing</var>
-                <str>  It is {darkgreen}{underline}Snowing{reset}</str>
+                <or>
+                    <equal>
+                        <var>raining</var>
+                        <str>true</str>
+                    </equal>
+                    <equal>
+                        <var>snowing</var>
+                        <str>true</str>
+                    </equal>
+                </or>
+                <if>
+                    <or>
+                        <greater>
+                            <var>localtemperature</var>
+                            <num>15</num>
+                        </greater>
+                        <equal>
+                            <var>localtemperature</var>
+                            <num>15</num>
+                        </equal>
+                    </or>
+                    <if>
+                        <equal>
+                            <var>thundering</var>
+                            <str>false</str>
+                        </equal>
+                        <concat>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/aqua.png</str>
+                            </icon>
+                            <str> It is {darkaqua}Raining{reset} for another {darkgreen}{nextrain}{reset}.</str>
+                        </concat>
+                    </if>
+                    <if>
+                        <var>thundering</var>
+                        <concat>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/aqua.png</str>
+                            </icon>
+                            <str> It is {darkaqua}Raining{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/tempestas.png</str>
+                            </icon>
+                        </concat>
+                    </if>
+                </if>
             </if>
             <if>
-                <var>raining</var>
-                <str>  It is {darkgreen}{underline}Raining{reset}</str>
+                <or>
+                    <equal>
+                        <var>raining</var>
+                        <str>true</str>
+                    </equal>
+                    <equal>
+                        <var>snowing</var>
+                        <str>true</str>
+                    </equal>
+                </or>
+                <if>
+                    <less>
+                        <var>localtemperature</var>
+                        <num>15</num>
+                    </less>
+                    <if>
+                        <equal>
+                            <var>thundering</var>
+                            <str>false</str>
+                        </equal>
+                        <concat>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/gelum.png</str>
+                            </icon>
+                            <str> It is {darkaqua}Snowing{reset} for another {darkgreen}{nextrain}{reset}.</str>
+                        </concat>
+                    </if>
+                    <if>
+                        <var>thundering</var>
+                        <concat>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/gelum.png</str>
+                            </icon>
+                            <str> It is {darkaqua}Snowing{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
+                            <icon>
+                                <str>thaumcraft:textures/aspects/tempestas.png</str>
+                            </icon>
+                        </concat>
+                    </if>
+                </if>
             </if>
             <if>
-                <var>thundering</var>
-                <str> and {darkgreen}{underline}Thundering{reset}.</str>
+                <or>
+                    <equal>
+                        <var>biome</var>
+                        <str>Storage Cell</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Hot Ocean</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Desert Oil Field</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Sky</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Hot Forest</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Pocket Plane</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Hot Desert</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Hot River</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Hot Plains</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Desert</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Desert M</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Savanna</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Savanna M</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Savanna Plateau</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Savanna Plateau M</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa (Bryce)</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa Plateau</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa Plateau F</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa Plateau F M</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Mesa Plateau F M</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Space</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Venus</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>moon</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>marsFlat</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>asteroids</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Io</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>IoAsh</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Titan</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Pluto</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Pluto2</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Pluto3</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>Pluto4</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>BarnardaCFlowers</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>BarnardaCHills</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>BarnardaCLowPlains</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>BarnardaCOceans</str>
+                    </equal>
+                    <equal>
+                        <var>biome</var>
+                        <str>BarnardaCShores</str>
+                    </equal>
+                </or>
+                <concat>
+                    <icon>
+                        <str>thaumcraft:textures/aspects/aer.png</str>
+                    </icon>
+                    <str> This {darkgreen}biome{reset} does not have {aqua}precipitation{reset}.</str>
+                </concat>
+            </if>
+            <if>
+                <and>
+                    <equal>
+                        <var>raining</var>
+                        <str>false</str>
+                    </equal>
+                    <equal>
+                        <var>snowing</var>
+                        <str>false</str>
+                    </equal>
+                    <equal>
+                        <var>thundering</var>
+                        <str>false</str>
+                    </equal>
+                    <not>
+                        <or>
+                            <equal>
+                                <var>biome</var>
+                                <str>Storage Cell</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Hot Ocean</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Desert Oil Field</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Sky</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Hot Forest</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Pocket Plane</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Hot Desert</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Hot River</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Hot Plains</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Desert</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Desert M</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Savanna</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Savanna M</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Savanna Plateau</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Savanna Plateau M</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa (Bryce)</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa Plateau</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa Plateau F</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa Plateau F M</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Mesa Plateau F M</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Space</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Venus</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>moon</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>marsFlat</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>asteroids</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Io</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>IoAsh</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Titan</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Pluto</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Pluto2</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Pluto3</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>Pluto4</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>BarnardaCFlowers</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>BarnardaCHills</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>BarnardaCLowPlains</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>BarnardaCOceans</str>
+                            </equal>
+                            <equal>
+                                <var>biome</var>
+                                <str>BarnardaCShores</str>
+                            </equal>
+                        </or>
+                    </not>
+                </and>
+                <concat>
+                    <icon>
+                        <str>thaumcraft:textures/aspects/tempestas.png</str>
+                    </icon>
+                    <str> {darkgreen}{nextrain}{reset} until the next {aqua}storm{reset}.</str>
+                </concat>
             </if>
         </line>
         <line>


### PR DESCRIPTION
Improves the weather information to be accurate based on localtemperature (which is how weather *actually* works, that being a .15 temperature threshold which is dynamic based on y level) instead of the previous raining/snowing/thundering variables. Also shares the remaining length of the current storm / time until the next storm.

The big series of biomes are me trying to catch every biome which does not have any precipitation, as uh, there is no easy way to add that without including every case (and there are less no precipitation biomes than there are precipitation biomes).

Examples:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/08951dcd-5c40-4437-8f27-c0371787555c)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/e4f5e3a3-5ecd-4d0e-a5d5-33272c5f2f31)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/0b510922-cb04-4fac-a078-19aac091127f)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/f8c25a8b-fd08-41e2-a13b-e4df5f35d8f8)

As for moon phases, this is a modification from what was grabbed in this page here: https://gtnh.miraheze.org/wiki/InGame_Info_XML
Instead of color coding based on Day/Night cycle on the moon, it's color coded based on the fullness of the moon (as the terms for gibbous and crescent might be unfamiliar for users). Instead, the Day/Night cycle is just added to the side separately.

Examples:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/e0aeb579-043b-44ff-b21e-60ae84929ea5)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/7fee5f48-4e84-4594-aa69-2a750b7d135c)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/e288849f-e24c-4c1e-aa13-787b5fa93847)

Lastly, after realizing there were a uh, few issues with consistency and spacing, I modified the slime chunk line (which I added in my earlier commit here: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/16016) so it's way more in line and consistent with the rest of the HUD. Same goes for ore chunks / center of the chunk.

Examples:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/fbaa1d73-fdef-4fb3-8ef2-366aaaf7f7ba)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/43c7d23b-f08d-4fa6-aa88-3531927b9315)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/3158887/dfba3a6f-7a6a-49b4-af1f-dc66027705f3)
