### PR TITLE
Update hunter backpack contents

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -12568,12 +12568,19 @@ backpacks {
     hunter {
         # Add itemStacks for the hunter's backpack here in the format 'modid:name:meta'. For wildcard metadata the format is 'modid:name'.
         S:item.stacks <
-		    BiomesOPlenty:misc:10
-		    BloodArsenal:wolf_hide
+            BiomesOPlenty:misc:10
+            BloodArsenal:wolf_hide
             Botania:gaiaHead:0
-            EnderZoo:enderFragment
+            dreamcraft:item.LichBone
+            dreamcraft:item.LichBoneChip
+            dreamcraft:item.NagaScaleChip
+            dreamcraft:item.NagaScaleFragment
+            dreamcraft:item.SnowQueenBlood
             EnderZoo:confusingDust
+            EnderZoo:enderFragment
             EnderZoo:witheringDust
+            ForbiddenMagic:GluttonyShard
+            ForbiddenMagic:NetherShard
             HardcoreEnderExpansion:enderman_head:0
             harvestcraft:anchovyrawItem:0
             harvestcraft:bassrawItem:0
@@ -12626,8 +12633,8 @@ backpacks {
             minecraft:fish:3
             minecraft:fishing_rod
             minecraft:ghast_tear
-            minecraft:gold_nugget
             minecraft:golden_horse_armor
+            minecraft:gold_nugget
             minecraft:gunpowder
             minecraft:hay_block
             minecraft:iron_horse_armor
@@ -12642,13 +12649,28 @@ backpacks {
             minecraft:speckled_melon
             minecraft:spider_eye
             minecraft:string
+            minecraft:web
             minecraft:wool
-            Natura:barleyFood:7
-            RandomThings:ingredient:3
-            witchery:wolfhead:0
-            witchery:wolfhead:1
-            witchery:ingredient:24
-			witchery:ingredient:25
+            Natura:barleyFood:6 # Imp Leather
+            Natura:barleyFood:7 # Flamestring
+            Natura:impmeat
+            OpenBlocks:trophy
+            RandomThings:ingredient:3 # Ectoplastm
+            TConstruct:heartCanister:1 # Red Heart
+            TConstruct:heartCanister:3 # Yellow Heart
+            TConstruct:materials:8 # Necrotic bone
+            TConstruct:strangeFood
+            Thaumcraft:ItemLootBag
+            Thaumcraft:ItemZombieBrain
+            ThaumicTinkerer:kamiResource:6 # Nether Shard
+            ThaumicTinkerer:kamiResource:7 # Ender Shard
+            TwilightForest:item.carminite
+            TwilightForest:item.fieryBlood
+            TwilightForest:item.nagaScale
+            TwilightForest:item.tfFeather
+            witchery:ingredient:24 # Wool of Bat
+            witchery:ingredient:25 # Tongue of Dog
+            witchery:wolfhead
          >
 
         # Add ore dictionary names for the hunter's backpack here in the format 'oreDictName'.


### PR DESCRIPTION
# Update hunter backpack contents
After having to copy my local Forestry backpack config changes when updating from 2.5.x -> 2.6.0 and once again from 2.6.0 -> 2.6.1 I've decided to open a PR to improve the Hunter's Backpack for everyone.

This PR adds to the config the items I noticed were not picked by the Hunter's Backpack.
I also included some additional boss drops the full Twilight Forest progression I have yet to obtain, so those are untested.

## Items I noticed where not picked

![photo_2024-05-25_14-20-09](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/4048877/61fcfcb9-a92d-429c-84fe-2b27a34d985a)

## Backpack picking items after changing the config

![photo_2024-05-25_14-20-11](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/4048877/ddd35fef-abc2-4d3c-9aef-bac2e9d61be5)'

