### PR TITLE
Fix Applied Greg quest requisite

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/AppliedGreg-AAAAAAAAAAAAAAAAAAALPQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/AppliedGreg-AAAAAAAAAAAAAAAAAAALPQ==.json
@@ -4,10 +4,6 @@
     "0:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 1302
-    },
-    "1:10": {
-      "questIDHigh:4": -5580929755334229399,
-      "questIDLow:4": -6652765312740277196
     }
   },
   "questIDLow:4": 2877,

--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/StockingFluids-soyN9ODlQmmjrKEyKBNENA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/StockingFluids-soyN9ODlQmmjrKEyKBNENA==.json
@@ -8,6 +8,10 @@
     "1:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 2652
+    },
+    "2:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 2877
     }
   },
   "questIDLow:4": -6652765312740277196,


### PR DESCRIPTION
Fixes the Applied Greg quest requisite from #16177.

Applied Greg should only require Interfacing with Machines and not Stocking Fluids. 
Stocking Fluids should require Applied Greg and not the other way around.

Before:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/88239847/dc0015eb-a2c5-499a-83dc-2a3083dc7511)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/88239847/35855278-f5c8-4e8a-8fb1-c5f041d48a32)
After:
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/88239847/7527a092-ff50-490c-9984-c71cc126ca6c)
![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/88239847/598eab46-2be3-41c5-b40b-3bbd71688635)
