### PR TITLE
Fix some broken hodgepodge config entries

### DIFF
--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -1,343 +1,420 @@
 # Configuration file
 
 asm {
-    # Enable Glease's ASM patch to disable unused CoFH tileentity cache
+    # Disable CoFH TileEntity cache (and patch MineFactory Reloaded and Thermal Expansion with a workaround) [default: true]
     B:cofhWorldTransformer=true
 
-    # Enable pollution rendering ASM
-    B:pollutionAsm=false
-
-    # Speedup progressbar
+    # Speedup progressbar [default: true]
     B:speedupProgressBar=true
 
-    # If using Bukkit/Thermos, the CraftServer package.
+    # If using Bukkit/Thermos, the CraftServer package. [default: org.bukkit.craftbukkit.v1_7_R4.CraftServer]
     S:thermosCraftServerClass=org.bukkit.craftbukkit.v1_7_R4.CraftServer
 }
 
 
 debug {
-    # Enable chunk save cme debugging code.
+    # Enable chunk save cme debugging code. [default: false]
     B:chunkSaveCMEDebug=false
 
-    # Prints debug log if DimensionManager got crashed
+    # Prints debug log if DimensionManager got crashed [default: true]
     B:dimensionManagerDebug=true
 
-    # Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero.
+    # Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero. [default: true]
     B:renderDebug=false
 
-    # Default GL state debug mode. 0 - off, 1 - reduced, 2 - full
+    # Default GL state debug mode. 0 - off, 1 - reduced, 2 - full [range: 0 ~ 2, default: 0]
     I:renderDebugMode=0
 }
 
 
 fixes {
-    # Maximum hp for BetterHUD to render as hearts
+    # Maximum hp for BetterHUD to render as hearts [range: 1 ~ 100000, default: 5000]
     I:betterHUDHPRenderLimit=5000
 
-    # Removes duplicate Fermenter and Squeezer recipes and flower registration
+    # Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes [default: true]
+    B:changeMaxNetworkNbtSizeLimit=true
+
+    # Removes duplicate Fermenter and Squeezer recipes and flower registration [default: true]
     B:deduplicateForestryCompatInBOP=true
 
-    # Disable Witchery potion extender for Java 12 compat
+    # Disable Witchery potion extender for Java 12 compat [default: true]
     B:disableWitcheryPotionExtender=true
 
-    # Safely enlarge the potion array before other mods
+    # Checks saved TileEntity coordinates earlier to provide a more descriptive error message [default: true]
+    B:earlyChunkTileCoordinateCheck=true
+
+    # Safely enlarge the potion array before other mods [default: true]
     B:enlargePotionArray=true
 
-    # Fix BetterHUD armor bar rendering breaking with skulls
+    # Fix BetterHUD armor bar rendering breaking with skulls [default: true]
     B:fixBetterHUDArmorDisplay=true
 
-    # Fix BetterHUD freezing the game when trying to render high amounts of hp
+    # Fix BetterHUD freezing the game when trying to render high amounts of hp [default: true]
     B:fixBetterHUDHPDisplay=true
 
-    # Fix Bibliocraft packet exploits
+    # Fix Bibliocraft packet exploits [default: true]
     B:fixBibliocraftPackets=true
 
-    # Fix Bibliocraft path sanitization
+    # Fix Bibliocraft path sanitization [default: true]
     B:fixBibliocraftPathSanitization=true
 
-    # Fix wrapped chat lines missing colors
+    # Fix bogus FMLProxyPacket NPEs on integrated server crashes. [default: true]
+    B:fixBogusIntegratedServerNPEs=true
+
+    # Fix wrapped chat lines missing colors [default: true]
     B:fixChatWrappedColors=true
 
-    # Prevents crash if server sends container with wrong itemStack size
+    # Prevents crash if server sends container with wrong itemStack size [default: true]
     B:fixContainerPutStacksInSlots=true
 
-    # Fixes the debug hitbox of the player beeing offset
+    # Fixes the debug hitbox of the player beeing offset [default: true]
     B:fixDebugBoundingBox=true
 
-    # Fix losing bonus hearts on dimension change
+    # Fix losing bonus hearts on dimension change [default: true]
     B:fixDimensionChangeHearts=true
 
-    # Fix deleting stack when eating mushroom stew
+    # Fix deleting stack when eating mushroom stew [default: true]
     B:fixEatingStackedStew=true
 
-    # Fix enchantment levels not displaying properly above a certain value
+    # Fix a class name typo in MinecraftForge's initialize method [default: true]
+    B:fixEffectRendererClassTypo=true
+
+    # Fix enchantment levels not displaying properly above a certain value [default: true]
     B:fixEnchantmentNumerals=true
 
-    # Fix Extra Utilities drums eating ic2 cells and forestry capsules
+    # Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum) [default: false]
+    B:fixExtraTiCTEConflict=false
+
+    # Fix Extra Utilities drums eating IC2 cells and Forestry capsules [default: true]
     B:fixExtraUtilitiesDrumEatingCells=true
 
-    # Fixes rendering issues with transparent items from extra utilities
+    # Fixes rendering issues with transparent items from Extra Utilities [default: true]
     B:fixExtraUtilitiesItemRendering=true
 
-    # Fix dupe bug with division sigil removing enchantment
+    # Fix dupe bug with Division Sigil removing enchantment [default: true]
     B:fixExtraUtilitiesUnEnchanting=true
 
-    # Fix fence connections with other types of fence
+    # Fix fence connections with other types of fence [default: true]
     B:fixFenceConnections=true
 
-    # Fix vanilla fire spread sometimes cause NPE on thermos
+    # Fix vanilla fire spread sometimes cause NPE on thermos [default: true]
     B:fixFireSpread=true
 
-    # Fix Forge fluid container registry key
+    # Fix Forge fluid container registry key [default: true]
     B:fixFluidContainerRegistryKey=true
 
-    # Replace recursion with iteration in FontRenderer line wrapping code
+    # Replace recursion with iteration in FontRenderer line wrapping code [default: true]
     B:fixFontRendererLinewrapRecursion=true
 
-    # Fix windowId being set on openContainer even if openGui failed
+    # Fix windowId being set on openContainer even if openGui failed [default: true]
     B:fixForgeOpenGuiHandlerWindowId=true
 
-    # Fix the forge update checker
+    # Fix the Forge update checker [default: true]
     B:fixForgeUpdateChecker=true
 
-    # Fix vanilla issue where player sounds register as animal sounds
+    # Fix vanilla issue where player sounds register as animal sounds [default: true]
     B:fixFriendlyCreatureSounds=true
 
-    # Fix vanilla light calculation sometimes cause NPE on thermos
+    # Fix vanilla light calculation sometimes cause NPE on thermos [default: true]
     B:fixGetBlockLightValue=true
 
-    # Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).
+    # Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135). [default: true]
     B:fixGlStateBugs=true
 
-    # Fix Game Over GUI buttons disabled if switching fullscreen
+    # Fix Game Over GUI buttons disabled if switching fullscreen [default: true]
     B:fixGuiGameOver=true
 
-    # Fix arm not swinging when having too much haste
+    # Fix arm not swinging when having too much haste [default: true]
     B:fixHasteArmSwing=true
 
-    # Fix vanilla hopper hit box
+    # Fix vanilla Hopper hit box [default: true]
     B:fixHopperHitBox=true
 
-    # Fix Drawer + Hopper voiding items
+    # Fix Drawer + Hopper voiding items [default: true]
     B:fixHopperVoidingItems=true
 
-    # Fix oversized chat message kicking player.
+    # Fix oversized chat message kicking player. [default: true]
     B:fixHugeChatKick=true
 
-    # Fix hunger overhaul low stat effects
+    # Fix Hunger Overhaul low stat effects [default: true]
     B:fixHungerOverhaul=true
 
-    # Fix some items restore 0 hunger
+    # Fix some items restore 0 hunger [default: true]
     B:fixHungerOverhaulRestore0Hunger=true
 
-    # Fix lag caused by IC2 armor tick
+    # Fix lag caused by IC2 armor tick [default: true]
     B:fixIc2ArmorLag=true
 
-    # Fix IC2's direct inventory access
+    # Fix IC2's direct inventory access [default: true]
     B:fixIc2DirectInventoryAccess=true
 
-    # Fix IC2 armors to avoid giving poison
+    # Fix IC2 armors to avoid giving poison [default: true]
     B:fixIc2Hazmat=true
 
-    # Fix IC2's armor hover mode
+    # Fix IC2's armor hover mode [default: true]
     B:fixIc2HoverMode=true
 
-    # Prevent IC2's nightvision from blinding you
+    # Prevent IC2's nightvision from blinding you [default: true]
     B:fixIc2Nightvision=true
 
-    # Fix IC2's reactor dupe
+    # Fix IC2's reactor dupe [default: true]
     B:fixIc2ReactorDupe=true
 
-    # Fixes various unchecked IC2 getBlock() methods
+    # Fix IC2 not loading translations from resource packs [default: true]
+    B:fixIc2ResourcePackTranslation=true
+
+    # Fixes various unchecked IC2 getBlock() methods [default: true]
     B:fixIc2UnprotectedGetBlock=true
 
-    # Fix Axis aligned Bounding Box of Ignis Fruit
+    # Fix Axis aligned Bounding Box of Ignis Fruit [default: true]
     B:fixIgnisFruitAABB=true
 
-    # Fix the bug that makes fireballs stop moving when chunk unloads
+    # Fix the bug that makes fireballs stop moving when chunk unloads [default: true]
     B:fixImmobileFireballs=true
 
-    # Prevents journeymap from using illegal character in file paths
+    # Prevents journeymap from using illegal character in file paths [default: true]
     B:fixJourneymapFilePath=true
 
-    # Fix jumpy scrolling in the waypoint manager screen
+    # Fix jumpy scrolling in the waypoint manager screen [default: true]
     B:fixJourneymapJumpyScrolling=true
 
-    # Prevent unbinded keybinds from triggering when pressing certain keys
+    # Prevent unbound keybinds from triggering when pressing certain keys [default: true]
     B:fixJourneymapKeybinds=true
 
-    # Allows the server to assign the logged in UUID to the same username when online_mode is false
+    # Fix an overflow of the dimension id when a player logins on a server [default: true]
+    B:fixLoginDimensionIDOverflow=true
+
+    # Fixes the damage of the Thick Neutron Reflectors in the MT Core recipe (Advanced Solar Panels) [default: true]
+    B:fixMTCoreRecipe=true
+
+    # Allows the server to assign the logged in UUID to the same username when online_mode is false [default: true]
     B:fixNetHandlerLoginServerOfflineMode=true
 
-    # Prevents crash if server sends itemStack with index larger than client's container
+    # Prevents crash if server sends itemStack with index larger than client's container [default: true]
     B:fixNetHandlerPlayClientHandleSetSlot=true
 
-    # If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too
+    # If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too [default: true]
     B:fixNetherLeavesFaceRendering=true
 
-    # Fix northwest bias on RandomPositionGenerator
+    # Fix NPE in Netty's Bootstrap class [default: true]
+    B:fixNettyNPE=true
+
+    # Fix northwest bias on RandomPositionGenerator [default: true]
     B:fixNorthWestBias=true
 
-    # Forces the chunk loading option from optifine to default since other values can crash the game
+    # Forces the chunk loading option from optifine to default since other values can crash the game [default: true]
     B:fixOptifineChunkLoadingCrash=true
 
-    # Prevent tall grass and such to affect the perspective camera
+    # Prevent tall grass and such to affect the perspective camera [default: true]
     B:fixPerspectiveCamera=true
 
-    # Allow some mods to properly fetch the player skin
+    # Allow some mods to properly fetch the player skin [default: true]
     B:fixPlayerSkinFetching=true
 
-    # Properly display level of potion effects in the inventory and on tooltips
+    # Fix outdated URLs used in the PortalGun mod to download the sound pack [default: true]
+    B:fixPortalGunURLs=true
+
+    # Properly display level of potion effects in the inventory and on tooltips [default: true]
     B:fixPotionEffectNumerals=true
 
-    # Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions
+    # Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions [default: true]
     B:fixPotionIterating=true
 
-    # Fix potions >= 128
+    # Fix potions >= 128 [default: true]
     B:fixPotionLimit=true
 
-    # Fix game window becoming not resizable after toggling fullscrean in any way
+    # Preserve the order of quads in terrain pass 1 [default: true]
+    B:fixPreserveQuadOrder=true
+
+    # Fix redstone torch leaking world [default: true]
+    B:fixRedstoneTorchWorldLeak=true
+
+    # Fix EffectRenderer and RenderGlobal leaking world instance when leaving world [default: true]
+    B:fixRenderersWorldLeak=true
+
+    # Fix game window becoming not resizable after toggling fullscrean in any way [default: true]
     B:fixResizableFullscreen=true
 
-    # Fix resource pack folder not opening on Windows if file path has a space
+    # Fix resource pack folder not opening on Windows if file path has a space [default: true]
     B:fixResourcePackOpening=true
 
-    # Fix Thaumcraft Aspects being sorted by tag instead of by name
+    # Fix Thaumcraft Aspects being sorted by tag instead of by name [default: true]
     B:fixThaumcraftAspectSorting=true
 
-    # Fix golem's marker loading failure when dimensionId larger than MAX_BYTE
+    # Fix golem's marker loading failure when dimensionId larger than MAX_BYTE [default: true]
     B:fixThaumcraftGolemMarkerLoading=true
 
-    # Fix time commands with GC
+    # Fix Thaumcraft leaves frequent ticking [default: true]
+    B:fixThaumcraftLeavesLag=true
+
+    # Implement a proper hashing method for WorldCoordinates [default: true]
+    B:fixThaumcraftWorldCoordinatesHashingMethod=true
+
+    # Fix time commands with GC [default: true]
     B:fixTimeCommandWithGC=true
 
-    # Fix exiting fullscreen when you tab out of the game
+    # Fix too many allocations from Chunk Coordinate Int Pair [default: true]
+    B:fixTooManyAllocationsChunkPositionIntPair=true
+
+    # Fix exiting fullscreen when you tab out of the game [default: true]
     B:fixUnfocusedFullscreen=true
 
-    # Fix URISyntaxException in forge.
+    # Fix URISyntaxException in forge. [default: true]
     B:fixUrlDetection=true
 
-    # Fixes various unchecked vanilla getBlock() methods
+    # Fixes various unchecked vanilla getBlock() methods [default: true]
     B:fixVanillaUnprotectedGetBlock=true
 
-    # Fixes village unchecked getBlock() calls
+    # Fixes village unchecked getBlock() calls [default: true]
     B:fixVillageUncheckedGetBlock=true
 
-    # Fix unprotected getBlock() in World
+    # Fix some NullPointerExceptions [default: true]
+    B:fixVoxelMapChunkNPE=true
+
+    # Fix Y coordinate being off by one [default: true]
+    B:fixVoxelMapYCoord=true
+
+    # Fixes Witchery player skins reflections with inhabited mirrors [default: true]
+    B:fixWitcheryReflections=true
+
+    # Enhanced Witchery Thunder Detection for rituals and Witch Hunters [default: true]
+    B:fixWitcheryThunderDetection=true
+
+    # Fix unprotected getBlock() in World [default: true]
     B:fixWorldGetBlock=true
 
-    # Fix WorldServer leaking entities when no players are present in a dimension
+    # Fix WorldServer leaking entities when no players are present in a dimension [default: true]
     B:fixWorldServerLeakingUnloadedEntities=true
 
-    # Fix scrolling in the world map screen
-    B:fixXaerosWorldMapScrolling=true
+    # Fix scrolling in the world map screen [default: true]
+    B:fixXaerosWorldMapScroll=true
 
-    # Fix ZTones packet exploits
+    # Fix ZTones packet exploits [default: true]
     B:fixZTonesPackets=true
 
-    # Stacks picked up per tick
+    # Increase the maximum network packet size from the default of 2MiB [default: true]
+    B:increasePacketSizeLimit=true
+
+    # Stacks picked up per tick [range: 1 ~ 64, default: 36]
     I:itemStacksPickedUpPerTick=36
 
-    # BiomesOPlenty Java 12 compatibility patches.
+    # BiomesOPlenty Java 12 compatibility patches. [default: true]
     B:java12BopCompat=true
 
-    # Immersive Engineering Java 12 compatibility patch
+    # Immersive Engineering Java 12 compatibility patch [default: true]
     B:java12ImmersiveEngineeringCompat=true
 
-    # Lotr Java 12 compatibility patch
+    # Lotr Java 12 compatibility patch [default: true]
     B:java12LotrCompat=true
 
-    # Minechem Java 12 compatibility patch
+    # Minechem Java 12 compatibility patch [default: true]
     B:java12MineChemCompat=true
 
-    # Log oversized chat message to console. WARNING: might create huge log files if this happens very often.
+    # Log oversized chat message to console. WARNING: might create huge log files if this happens very often. [default: true]
     B:logHugeChat=true
 
-    # Optimize inventory access to IC2 nuclear reactor
+    # The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB). [range: 1024 ~ 1073741824, default: 268435456]
+    I:maxNetworkNbtSizeLimit=268435456
+
+    # Optimize inventory access to IC2 nuclear reactor [default: true]
     B:optimizeIc2ReactorInventoryAccess=true
 
-    # Fix too early light initialization
+    # Fix too early light initialization [default: true]
     B:optimizeWorldUpdateLight=true
 
-    # Disable the creative search tab since it can be very laggy in large modpacks
+    # The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB). [range: 1024 ~ 1073741824, default: 268435456]
+    I:packetSizeLimit=268435456
+
+    # Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers [default: true]
+    B:preventThermalDynamicsNASE=true
+
+    # Spigot-style extended chunk format to remove the 2MB chunk size limit [default: true]
+    B:remove2MBChunkLimit=true
+
+    # Remove the BOP warning on first world generation (ignored when dreamcraft is present) [default: false]
+    B:removeBOPWarning=false
+
+    # Disable the creative search tab since it can be very laggy in large modpacks [default: true]
     B:removeCreativeSearchTab=true
 
-    # Remove old/stale/outdated update checks.
+    # Remove old/stale/outdated update checks. [default: true]
     B:removeUpdateChecks=true
 
-    # Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)
+    # Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working) [default: true]
     B:speedupAnimations=true
 
-    # Stop "You can only sleep at night" message filling the chat
+    # Stop "You can only sleep at night" message filling the chat [default: true]
     B:squashBedErrorMessage=true
 
-    # Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag
+    # Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag [default: true]
     B:throttleItemPickupEvent=true
 
-    # Triggers all conflicting key bindings on key press instead of a random one
+    # Triggers all conflicting key bindings on key press instead of a random one [default: true]
     B:triggerAllConflictingKeybindings=true
 
-    # Validate vanilla packet encodings before sending in addition to on reception
+    # Validate vanilla packet encodings before sending in addition to on reception [default: true]
     B:validatePacketEncodingBeforeSending=true
 
-    # Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)
+    # Should the extended packet validation error cause a crash (true) or just print out an error to the log (false) [default: false]
     B:validatePacketEncodingBeforeSendingShouldCrash=false
 }
 
 
-pollution {
-    # Pollution Amount for Advanced Coke Ovens
-    I:advancedCokeOvenPollution=80
-
-    # Pollution Amount for Coke Ovens
-    I:cokeOvenPollution=10
-
-    # Explosion pollution
-    D:explosionPollution=333.34
-
-    # Pollution Amount for RC Firebox
-    I:fireboxPollution=20
-
-    # Furnace pollution per second, min 1!
-    I:furnacePollution=20
-
-    # Make furnaces Pollute
-    B:furnacesPollute=true
-
-    # Pollution Amount for hobbyist steam engine
-    I:hobbyistEnginePollution=20
-
-    # Make Railcraft Pollute
-    B:railcraftPollutes=true
-
-    # Pollution Amount for Rockets
-    I:rocketPollution=10000
-
-    # Make rockets Pollute
-    B:rocketsPollute=true
-
-    # Pollution Amount for tunnel bore
-    I:tunnelBorePollution=2
+general {
 }
 
 
-##########################################################################################################
-# pollution_recolor
-#--------------------------------------------------------------------------------------------------------#
-# Blocks that should be colored by pollution. 
-# 	Grouped by the render type. 
-# 	Format: [BlockClass]:[colortype] 
-# 	Valid types: GRASS, LEAVES, FLOWER, LIQUID 
-# 	Add [-] first to blacklist.
-##########################################################################################################
+pollution {
+    # Pollution Amount for Advanced Coke Ovens [range: -2147483648 ~ 2147483647, default: 80]
+    I:advancedCokeOvenPollutionAmount=80
+
+    # Pollution Amount for Coke Ovens [range: -2147483648 ~ 2147483647, default: 3]
+    I:cokeOvenPollutionAmount=10
+
+    # Explosion pollution [range: 1.4E-45 ~ 3.4028235E38, default: 33.34]
+    S:explosionPollutionAmount=333.34
+
+    # Pollution Amount for RC Firebox [range: -2147483648 ~ 2147483647, default: 15]
+    I:fireboxPollutionAmount=20
+
+    # Furnace pollution per second, min 1! [range: -2147483648 ~ 2147483647, default: 20]
+    I:furnacePollutionAmount=20
+
+    # Make furnaces Pollute [default: true]
+    B:furnacesPollute=true
+
+    # Pollution Amount for hobbyist steam engine [range: -2147483648 ~ 2147483647, default: 20]
+    I:hobbyistEnginePollutionAmount=20
+
+    # Make Railcraft Pollute [default: true]
+    B:railcraftPollutes=true
+
+    # Pollution Amount for Rockets [range: -2147483648 ~ 2147483647, default: 1000]
+    I:rocketPollutionAmount=10000
+
+    # Make rockets Pollute [default: true]
+    B:rocketsPollute=true
+
+    # Pollution Amount for tunnel bore [range: -2147483648 ~ 2147483647, default: 2]
+    I:tunnelBorePollutionAmount=2
+}
+
 
 pollution_recolor {
+    # Changes colors of certain blocks based on pollution levels [default: true]
+    B:pollutionBlockRecolor=true
+
+    # Double Plant Blocks - Recolor Block List [default: [net.minecraft.block.BlockDoublePlant:FLOWER]]
     S:renderBlockDoublePlant <
         net.minecraft.block.BlockDoublePlant:FLOWER
      >
+
+    # Liquid Blocks - Recolor Block List [default: [net.minecraft.block.BlockLiquid:LIQUID]]
     S:renderBlockLiquid <
         net.minecraft.block.BlockLiquid:LIQUID
      >
+
+    # Crossed Squares - Recolor Block List [default: [net.minecraft.block.BlockTallGrass:FLOWER], [net.minecraft.block.BlockFlower:FLOWER], [biomesoplenty.common.blocks.BlockBOPFlower:FLOWER], [biomesoplenty.common.blocks.BlockBOPFlower2:FLOWER], [biomesoplenty.common.blocks.BlockBOPFoliage:FLOWER]]
     S:renderCrossedSquares <
         net.minecraft.block.BlockTallGrass:FLOWER
         net.minecraft.block.BlockFlower:FLOWER
@@ -345,6 +422,8 @@ pollution_recolor {
         biomesoplenty.common.blocks.BlockBOPFlower2:FLOWER
         biomesoplenty.common.blocks.BlockBOPFoliage:FLOWER
      >
+
+    # Standard Blocks - Recolor Block List [default: [net.minecraft.block.BlockGrass:GRASS], [net.minecraft.block.BlockLeavesBase:LEAVES], [biomesoplenty.common.blocks.BlockOriginGrass:GRASS], [biomesoplenty.common.blocks.BlockLongGrass:GRASS], [biomesoplenty.common.blocks.BlockNewGrass:GRASS], [tconstruct.blocks.slime.SlimeGrass:GRASS], [thaumcraft.common.blocks.BlockMagicalLeaves:LEAVES]]
     S:renderStandardBlock <
         net.minecraft.block.BlockGrass:GRASS
         net.minecraft.block.BlockLeavesBase:LEAVES
@@ -354,6 +433,8 @@ pollution_recolor {
         tconstruct.blocks.slime.SlimeGrass:GRASS
         thaumcraft.common.blocks.BlockMagicalLeaves:LEAVES
      >
+
+    # Block Vine - Recolor Block List [default: [net.minecraft.block.BlockVine:FLOWER]]
     S:renderblockVine <
         net.minecraft.block.BlockVine:FLOWER
      >
@@ -361,143 +442,179 @@ pollution_recolor {
 
 
 speedups {
-    # Optimize ASMDataTable getAnnotationsFor for faster startup
+    # Optimize ASMDataTable getAnnotationsFor for faster startup [default: true]
     B:optimizeASMDataTable=true
 
-    # Optimize texture loading
+    # Optimize texture loading [default: true]
     B:optimizeTextureLoading=true
 
-    # Optimize tileEntity removal in World.class
+    # Optimize tileEntity removal in World.class [default: true]
     B:optimizeTileentityRemoval=true
 
-    # Speedup biome fog rendering in BiomesOPlenty
+    # Replace reflection in VoxelMap to directly access the fields instead. [default: true]
+    B:replaceVoxelMapReflection=true
+
+    # Speedup biome fog rendering in BiomesOPlenty [default: true]
     B:speedupBOPFogHandling=true
 
-    # Speedup ChunkCoordinates hashCode
+    # Speedup ChunkCoordinates hashCode [default: true]
     B:speedupChunkCoordinatesHashCode=true
 
-    # Speed up grass block random ticking
+    # Speed up grass block random ticking [default: true]
     B:speedupGrassBlockRandomTicking=true
 
-    # Speedup Vanilla Furnace recipe lookup
+    # Speedup Vanilla Furnace recipe lookup [default: true]
     B:speedupVanillaFurnace=true
 
-    # Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks
+    # Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks [default: true]
     B:tcpNoDelay=true
 }
 
 
 tweaks {
-    # Compacts identical consecutive chat messages together
-    B:"Compact chat"=true
-
-    # Add CV support to Thaumcraft wand recharge pedestal
+    # Add CV support to Thaumcraft wand recharge pedestal [default: true]
     B:addCVSupportToWandPedestal=true
 
-    # Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)
+    # Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture) [default: true]
     B:addSystemInfo=true
 
-    # Add a debug message in the chat when toggling vanilla debug options
+    # Add a debug message in the chat when toggling vanilla debug options [default: true]
     B:addToggleDebugMessage=true
 
-    # Uses arabic numbers for enchantment levels and potion amplifier levels instead of roman numbers
+    # Uses arabic numbers for enchantment levels and potion amplifier levels instead of roman numbers [default: false]
     B:arabicNumbersForEnchantsPotions=false
 
-    # Minechem Atropine High (Delirium) effect ID
+    # Minechem Atropine High (Delirium) effect ID [range: 1 ~ 255, default: 255]
     I:atropineHighID=255
 
-    # Show "cannot sleep" messages above hotbar
+    # Sets the interval for auto saves in ticks (20 ticks = 1 second) [range: 1 ~ 2147483647, default: 900]
+    I:autoSaveInterval=900
+
+    # Show "cannot sleep" messages above hotbar [default: true]
     B:bedMessageAboveHotbar=true
 
-    # Moves the sprint keybind to the movement category
+    # Changes the file extension of VoxelMap's cache files from .zip to .data to stop the TechnicLauncher from deleting them when updating [default: true]
+    B:changeCacheFileExtension=true
+
+    # Moves the sprint keybind to the movement category [default: true]
     B:changeSprintCategory=true
 
-    # Amount of chat lines kept [100(Vanilla) - 32767]
+    # Amount of chat lines kept (Vanilla: 100) [range: 100 ~ 32767, default: 8191]
     I:chatLength=8191
 
-    # Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port.
+    # Compacts identical consecutive chat messages together [default: true]
+    B:compactChat=true
+
+    # Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port. [range: 0 ~ 65535, default: 25565]
     I:defaultLanPort=25565
 
-    # Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far.
+    # Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far. [default: true]
     B:disableAidSpawnByXUSpikes=true
 
-    # Display fluid localized name in IC2 fluid cell tooltip
+    # Disable terrain generation for new generated chunks (all blocks become air, biomes remain) [default: false]
+    B:disableChunkTerrainGeneration=false
+
+    # Disable all extra mod chunk population for new generated chunks (e.g. Natura's clouds) [default: false]
+    B:disableModdedChunkPopulation=false
+
+    # Disable Minecraft Realms button on main menu [default: true]
+    B:disableRealmsButton=true
+
+    # Disable world type associated chunk population for new generated chunks (e.g. vanilla structures in Overworld) [default: false]
+    B:disableWorldTypeChunkPopulation=false
+
+    # Display fluid localized name in IC2 fluid cell tooltip [default: true]
     B:displayIc2FluidLocalizedName=true
 
-    # Stop inverting colors of crosshair
+    # Stop inverting colors of crosshair [default: false]
     B:dontInvertCrosshairColor=false
 
-    # Drop picked loot on entity despawn
+    # Drop picked loot on entity despawn [default: true]
     B:dropPickedLootOnDespawn=true
 
-    # Open an integrated server on a static port.
+    # Open an integrated server on a static port. [default: true]
     B:enableDefaultLanPort=true
 
-    # Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.)
+    # Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.) [default: true]
     B:enableMacosCmdShortcuts=true
 
-    # Shows renderer's impact on FPS in vanilla lagometer
+    # Shows renderer's impact on FPS in vanilla lagometer [default: true]
     B:enableTileRendererProfiler=true
 
-    # Remove the blueish sky tint from night vision
+    # Remove the blueish sky tint from night vision [default: false]
     B:enhanceNightVision=false
 
-    # Fix Project Red components popping off on unloaded chunks
+    # Allows blocks to be placed at a faster rate (toggleable via keybind) [default: false]
+    B:fastBlockPlacing=false
+
+    # Fix Project Red components popping off on unloaded chunks [default: true]
     B:fixComponentsPoppingOff=true
 
-    # Fix hotbars being dark when Project Red is installed
+    # Fix hotbars being dark when Project Red is installed [default: true]
     B:fixHudLightingGlitch=true
 
-    # Fix vanilla potion effects rendering above the NEI tooltips in the inventory
+    # Fix vanilla potion effects rendering above the NEI tooltips in the inventory [default: true]
     B:fixPotionEffectRender=true
 
-    # Prevents the inventory from shifting when the player has active potion effects
+    # Prevents the inventory from shifting when the player has active potion effects [default: true]
     B:fixPotionRenderOffset=true
 
-    # Stops rendering the crosshair when you are playing in third person
+    # Stops rendering the crosshair when you are playing in third person [default: true]
     B:hideCrosshairInThirdPerson=true
 
-    # Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor
+    # Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor [default: true]
     B:hideIc2ReactorSlots=true
 
-    # Stops rendering potion particles from yourself
+    # Stops rendering potion particles from yourself [default: true]
     B:hidePotionParticlesFromSelf=true
 
-    # give ic2 cells containers like gregtech cells do
+    # Give IC2 cells containers like GregTech cells do [default: true]
     B:ic2CellWithContainer=true
 
-    # IC2 seed max stack size
+    # IC2 seed max stack size [range: 1 ~ 64, default: 64]
     I:ic2SeedMaxStackSize=64
 
-    # Increase particle limit
+    # Increase particle limit [default: true]
     B:increaseParticleLimit=true
 
-    # Wake up passive & personal anchors on player login
+    # Wake up passive & personal anchors on player login [default: true]
     B:installAnchorAlarm=true
 
-    # Makes the chat history longer instead of 100 lines
+    # Makes the chat history longer instead of 100 lines [default: true]
     B:longerChat=true
 
-    # Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree
+    # Allows you to send longer chat messages, up to 256 characters, instead of 100 in vanilla. [default: true]
+    B:longerSentMessages=true
+
+    # Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree [default: true]
     B:makeBigFirsPlantable=true
 
-    # Particle limit [4000-16000]
+    # Adds pick block functionality to survival mode [default: true]
+    B:modernPickBlock=true
+
+    # Particle limit (Vanilla: 4000) [range: 4000 ~ 16000, default: 8000]
     I:particleLimit=8000
 
-    # Prevent monsters from picking up loot.
+    # Prevent monsters from picking up loot. [default: true]
     B:preventPickupLoot=true
 
-    # Stop playing a sound when spawning a minecart in the world
+    # Removes the 'GL error' message that appears when using a shader in Optifine/Shadersmod [default: true]
+    B:removeOptifineGLErrors=true
+
+    # Stop playing a sound when spawning a minecart in the world [default: true]
     B:removeSpawningMinecartSound=true
 
-    # Implement container for thirsty tank
+    # Implement container for thirsty tank [default: true]
     B:thirstyTankContainer=true
 
-    # Doesn't render the black box behind messages when the chat is closed
+    # Doesn't render the black box behind messages when the chat is closed [default: true]
     B:transparentChat=true
 
-    # Unbinds keybinds of certain ARR mods to avoid keybinds conflicts
+    # Unbinds keybinds of certain ARR mods to avoid keybinds conflicts [default: true]
     B:unbindKeybindsByDefault=true
+
+    # Reduces water opacity from 3 to 1, to match modern [default: false]
+    B:useLighterWater=false
 }
 
 


### PR DESCRIPTION
Fixes several hodgepodge configs not actually working. (e.g., XaeroWorldMapScrolling, coke oven pollution)

This updates the hodgepodge config to a freshly generated one. However keeping all our configs (please check).

This was needed as a number of entry names were broken by https://github.com/GTNewHorizons/Hodgepodge/pull/313.