### PR TITLE
update and fix TF config

### DIFF
--- a/config/TwilightForest.cfg
+++ b/config/TwilightForest.cfg
@@ -73,16 +73,16 @@ performance {
     B:EnableTiConstructIntegration=false
 
     # Tinker Material ID for FieryMetal.
-    I:FieryMetal_ID=42
+    I:FieryMetal_ID=1553
 
     # Tinker Material ID for KnightMetal.
-    I:KnightMetal_ID=43
+    I:KnightMetal_ID=1626
 
     # Tinker Material ID for NagaScale.
     I:NagaScale_ID=44
 
     # Tinker Material ID for Steeleaf.
-    I:Steeleaf_ID=45
+    I:Steeleaf_ID=1625
 }
 
 

--- a/config/TwilightForest.cfg
+++ b/config/TwilightForest.cfg
@@ -68,3 +68,21 @@ performance {
 }
 
 
+"tinker integration" {
+    # Enable backport of 1.12.2 TiC integration including materials and modifiers.
+    B:EnableTiConstructIntegration=false
+
+    # Tinker Material ID for FieryMetal.
+    I:FieryMetal_ID=42
+
+    # Tinker Material ID for KnightMetal.
+    I:KnightMetal_ID=43
+
+    # Tinker Material ID for NagaScale.
+    I:NagaScale_ID=44
+
+    # Tinker Material ID for Steeleaf.
+    I:Steeleaf_ID=45
+}
+
+


### PR DESCRIPTION
- updates the TF config (while keeping our values)
- sets the EnableTiConstructIntegration to false and puts in the right ids. I talked to drparadox and that was the setting for GTNH intended by https://github.com/GTNewHorizons/twilightforest/pull/62

This fixes various issues in dev with duplicate incompatible fluids, duplicate tinker tool parts, ingot<->nugget crafting recipes, etc (again).