### PR TITLE
Quest completes for lower tier machines from higher tier machines

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/AdvancedCompress-AAAAAAAAAAAAAAAAAAAFKA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/AdvancedCompress-AAAAAAAAAAAAAAAAAAAFKA==.json
@@ -95,6 +95,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAACIA\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/AdvancedMacerato-AAAAAAAAAAAAAAAAAAAFKQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/AdvancedMacerato-AAAAAAAAAAAAAAAAAAAFKQ==.json
@@ -95,6 +95,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAAXg\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/CoolingKanthal-AAAAAAAAAAAAAAAAAAAL_w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/CoolingKanthal-AAAAAAAAAAAAAAAAAAAL_w==.json
@@ -95,6 +95,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAF2w\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/FluidSolidifier-AAAAAAAAAAAAAAAAAAADtw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/FluidSolidifier-AAAAAAAAAAAAAAAAAAADtw==.json
@@ -112,6 +112,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAEgw\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/PressAlltheThing-AAAAAAAAAAAAAAAAAAAGCw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/PressAlltheThing-AAAAAAAAAAAAAAAAAAAGCw==.json
@@ -77,6 +77,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAAZA\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/SiliconWafer-AAAAAAAAAAAAAAAAAAADGA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/SiliconWafer-AAAAAAAAAAAAAAAAAAADGA==.json
@@ -106,6 +106,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAAZg\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/HVBender-AAAAAAAAAAAAAAAAAAAFCQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/HVBender-AAAAAAAAAAAAAAAAAAAFCQ==.json
@@ -83,6 +83,16 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAAaQ\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
+    },
+    "3:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAEOQ\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 3
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/PerformingChemic-AAAAAAAAAAAAAAAAAAADrw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/PerformingChemic-AAAAAAAAAAAAAAAAAAADrw==.json
@@ -89,6 +89,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAG0A\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/PlayingWithDust-AAAAAAAAAAAAAAAAAAADAQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/PlayingWithDust-AAAAAAAAAAAAAAAAAAADAQ==.json
@@ -83,6 +83,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAADAw\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/SeparatingGemsFr-AAAAAAAAAAAAAAAAAAAF8Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/SeparatingGemsFr-AAAAAAAAAAAAAAAAAAAF8Q==.json
@@ -77,6 +77,11 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAADZQ\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
     }
   }
 }

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/SeparatingMolecu-AAAAAAAAAAAAAAAAAAAHgQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/SeparatingMolecu-AAAAAAAAAAAAAAAAAAAHgQ==.json
@@ -55,6 +55,11 @@
   },
   "rewards:9": {
     "0:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAFKg\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 0
+    },
+    "1:10": {
       "rewardID:8": "bq_standard:item",
       "index:3": 1,
       "rewards:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/UniversalMacerat-AAAAAAAAAAAAAAAAAAAEjA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/UniversalMacerat-AAAAAAAAAAAAAAAAAAAEjA==.json
@@ -83,6 +83,16 @@
           "OreDict:8": ""
         }
       }
+    },
+    "2:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAAXg\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 2
+    },
+    "3:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAFKQ\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 3
     }
   }
 }


### PR DESCRIPTION
A set of quests in the hv and mv chapters now unlock prior quests in other chapters allowing players to not have quests of machines that they have not crafted. When they have indeed crafted the other machines.

Set of machines that were changed.

autoclave
macerator
bending machine
sifting machine
chemical reactor
centrifuge
mv forming press
Fluid solidifier
compressor
chemical bath
cutting machine