### PR TITLE
Fix enchanted minecraft:book rewards

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/LooktotheEdges-AAAAAAAAAAAAAAAAAAAAGw==/Arthana-AAAAAAAAAAAAAAAAAAAJJQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/LooktotheEdges-AAAAAAAAAAAAAAAAAAAAGw==/Arthana-AAAAAAAAAAAAAAAAAAAJJQ==.json
@@ -59,10 +59,10 @@
       "index:3": 0,
       "choices:9": {
         "0:10": {
-          "id:8": "minecraft:book",
+          "id:8": "minecraft:enchanted_book",
           "Count:3": 1,
           "tag:10": {
-            "ench:9": {
+            "StoredEnchantments:9": {
               "0:10": {
                 "lvl:2": 3,
                 "id:2": 21

--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/AreYouPrepared-AAAAAAAAAAAAAAAAAAAELA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/AreYouPrepared-AAAAAAAAAAAAAAAAAAAELA==.json
@@ -104,10 +104,10 @@
       "index:3": 0,
       "choices:9": {
         "0:10": {
-          "id:8": "minecraft:book",
+          "id:8": "minecraft:enchanted_book",
           "Count:3": 1,
           "tag:10": {
-            "ench:9": {
+            "StoredEnchantments:9": {
               "0:10": {
                 "lvl:4": 2,
                 "id:4": 212


### PR DESCRIPTION
Fixes #16453

Fixes both the reported instance and another instance in Are You Prepared

Tested that both books function properly after the change