### PR TITLE
Fixing typo in a Quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/1kFluidStorageCe-AAAAAAAAAAAAAAAAAAAJsg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/1kFluidStorageCe-AAAAAAAAAAAAAAAAAAAJsg==.json
@@ -30,7 +30,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Unlike the item version, these can only hold 1 type of liquid each. It can hold over 2 ML.There is also another variant that can hold 5. You\u0027ll want to make the fluid terminal to see what you have."
+      "desc:8": "Unlike the item version, these can only hold 1 type of liquid each. It can hold over 2 ML. There is also another variant that can hold 5. You\u0027ll want to make the fluid terminal to see what you have."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
This commit is about a missing space. You can find this quest in `Applied Energestics > 1k Fluid Storage Cell`

It adds the missing space after the second sentence.