### PR TITLE
Update InGameInfo.xml - Fix Server/Local Discrepency

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -160,8 +160,8 @@
         <line>
             <if>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 <if>
                     <or>
@@ -218,8 +218,8 @@
             <if>
                 <not>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 </not>
                 <if>
@@ -276,8 +276,8 @@
             </if>
             <if>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 <if>
                     <or>
@@ -328,8 +328,8 @@
             <if>
                 <not>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 </not>
                 <if>
@@ -542,8 +542,8 @@
             </if>
             <if>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 <if>
                     <and>
@@ -727,8 +727,8 @@
             <if>
                 <not>
                 <equal>
-                    <var>server</var>
-                    <str>localhost</str>
+                    <var>serverport</var>
+                    <str>-1</str>
                 </equal>
                 </not>
                 <if>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -159,92 +159,222 @@
         </line>
         <line>
             <if>
-                <or>
-                    <equal>
-                        <var>raining</var>
-                        <str>true</str>
-                    </equal>
-                    <equal>
-                        <var>snowing</var>
-                        <str>true</str>
-                    </equal>
-                </or>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
                 <if>
                     <or>
-                        <greater>
-                            <var>localtemperature</var>
-                            <num>15</num>
-                        </greater>
                         <equal>
-                            <var>localtemperature</var>
-                            <num>15</num>
+                            <var>raining</var>
+                            <str>true</str>
+                        </equal>
+                        <equal>
+                            <var>snowing</var>
+                            <str>true</str>
                         </equal>
                     </or>
                     <if>
-                        <equal>
-                            <var>thundering</var>
-                            <str>false</str>
-                        </equal>
-                        <concat>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/aqua.png</str>
-                            </icon>
-                            <str> It is {darkaqua}Raining{reset} for another {darkgreen}{nextrain}{reset}.</str>
-                        </concat>
-                    </if>
-                    <if>
-                        <var>thundering</var>
-                        <concat>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/aqua.png</str>
-                            </icon>
-                            <str> It is {darkaqua}Raining{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/tempestas.png</str>
-                            </icon>
-                        </concat>
+                        <or>
+                            <greater>
+                                <var>localtemperature</var>
+                                <num>15</num>
+                            </greater>
+                            <equal>
+                                <var>localtemperature</var>
+                                <num>15</num>
+                            </equal>
+                        </or>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>false</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/aqua.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Raining{reset} for another {darkgreen}{nextrain}{reset}.</str>
+                            </concat>
+                        </if>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>true</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/aqua.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Raining{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/tempestas.png</str>
+                                </icon>
+                            </concat>
+                        </if>
                     </if>
                 </if>
             </if>
             <if>
-                <or>
-                    <equal>
-                        <var>raining</var>
-                        <str>true</str>
-                    </equal>
-                    <equal>
-                        <var>snowing</var>
-                        <str>true</str>
-                    </equal>
-                </or>
+                <not>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
+                </not>
                 <if>
-                    <less>
-                        <var>localtemperature</var>
-                        <num>15</num>
-                    </less>
-                    <if>
+                    <or>
                         <equal>
-                            <var>thundering</var>
-                            <str>false</str>
+                            <var>raining</var>
+                            <str>true</str>
                         </equal>
-                        <concat>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/gelum.png</str>
-                            </icon>
-                            <str> It is {darkaqua}Snowing{reset} for another {darkgreen}{nextrain}{reset}.</str>
-                        </concat>
-                    </if>
+                        <equal>
+                            <var>snowing</var>
+                            <str>true</str>
+                        </equal>
+                    </or>
                     <if>
-                        <var>thundering</var>
-                        <concat>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/gelum.png</str>
-                            </icon>
-                            <str> It is {darkaqua}Snowing{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
-                            <icon>
-                                <str>thaumcraft:textures/aspects/tempestas.png</str>
-                            </icon>
-                        </concat>
+                        <or>
+                            <greater>
+                                <var>localtemperature</var>
+                                <num>15</num>
+                            </greater>
+                            <equal>
+                                <var>localtemperature</var>
+                                <num>15</num>
+                            </equal>
+                        </or>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>false</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/aqua.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Raining{reset}.</str>
+                            </concat>
+                        </if>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>true</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/aqua.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Raining{reset} and {gold}Thundering{reset}. </str>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/tempestas.png</str>
+                                </icon>
+                            </concat>
+                        </if>
+                    </if>
+                </if>
+            </if>
+            <if>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
+                <if>
+                    <or>
+                        <equal>
+                            <var>raining</var>
+                            <str>true</str>
+                        </equal>
+                        <equal>
+                            <var>snowing</var>
+                            <str>true</str>
+                        </equal>
+                    </or>
+                    <if>
+                        <less>
+                            <var>localtemperature</var>
+                            <num>15</num>
+                        </less>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>false</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/gelum.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Snowing{reset} for another {darkgreen}{nextrain}{reset}.</str>
+                            </concat>
+                        </if>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>true</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/gelum.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Snowing{reset} and {gold}Thundering{reset} for another {darkgreen}{nextrain}{reset}. </str>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/tempestas.png</str>
+                                </icon>
+                            </concat>
+                        </if>
+                    </if>
+                </if>
+            </if>
+            <if>
+                <not>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
+                </not>
+                <if>
+                    <or>
+                        <equal>
+                            <var>raining</var>
+                            <str>true</str>
+                        </equal>
+                        <equal>
+                            <var>snowing</var>
+                            <str>true</str>
+                        </equal>
+                    </or>
+                    <if>
+                        <less>
+                            <var>localtemperature</var>
+                            <num>15</num>
+                        </less>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>false</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/gelum.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Snowing{reset}.</str>
+                            </concat>
+                        </if>
+                        <if>
+                            <equal>
+                                <var>thundering</var>
+                                <str>true</str>
+                            </equal>
+                            <concat>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/gelum.png</str>
+                                </icon>
+                                <str> It is {darkaqua}Snowing{reset} and {gold}Thundering{reset}. </str>
+                                <icon>
+                                    <str>thaumcraft:textures/aspects/tempestas.png</str>
+                                </icon>
+                            </concat>
+                        </if>
                     </if>
                 </if>
             </if>
@@ -411,182 +541,374 @@
                 </concat>
             </if>
             <if>
-                <and>
-                    <equal>
-                        <var>raining</var>
-                        <str>false</str>
-                    </equal>
-                    <equal>
-                        <var>snowing</var>
-                        <str>false</str>
-                    </equal>
-                    <equal>
-                        <var>thundering</var>
-                        <str>false</str>
-                    </equal>
-                    <not>
-                        <or>
-                            <equal>
-                                <var>biome</var>
-                                <str>Storage Cell</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Hot Ocean</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Desert Oil Field</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Sky</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Hot Forest</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Pocket Plane</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Hot Desert</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Hot River</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Hot Plains</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Desert</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Desert M</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Savanna</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Savanna M</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Savanna Plateau</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Savanna Plateau M</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa (Bryce)</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa Plateau</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa Plateau F</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa Plateau F M</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Mesa Plateau F M</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Space</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Venus</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>moon</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>marsFlat</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>asteroids</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Io</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>IoAsh</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Titan</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Pluto</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Pluto2</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Pluto3</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>Pluto4</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>BarnardaCFlowers</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>BarnardaCHills</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>BarnardaCLowPlains</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>BarnardaCOceans</str>
-                            </equal>
-                            <equal>
-                                <var>biome</var>
-                                <str>BarnardaCShores</str>
-                            </equal>
-                        </or>
-                    </not>
-                </and>
-                <concat>
-                    <icon>
-                        <str>thaumcraft:textures/aspects/tempestas.png</str>
-                    </icon>
-                    <str> {darkgreen}{nextrain}{reset} until the next {aqua}storm{reset}.</str>
-                </concat>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
+                <if>
+                    <and>
+                        <equal>
+                            <var>raining</var>
+                            <str>false</str>
+                        </equal>
+                        <equal>
+                            <var>snowing</var>
+                            <str>false</str>
+                        </equal>
+                        <equal>
+                            <var>thundering</var>
+                            <str>false</str>
+                        </equal>
+                        <not>
+                            <or>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Storage Cell</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Ocean</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert Oil Field</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Sky</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Forest</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pocket Plane</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Desert</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot River</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Plains</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna Plateau</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna Plateau M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa (Bryce)</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Space</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Venus</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>moon</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>marsFlat</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>asteroids</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Io</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>IoAsh</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Titan</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto2</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto3</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto4</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCFlowers</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCHills</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCLowPlains</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCOceans</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCShores</str>
+                                </equal>
+                            </or>
+                        </not>
+                    </and>
+                    <concat>
+                        <icon>
+                            <str>thaumcraft:textures/aspects/tempestas.png</str>
+                        </icon>
+                        <str> {darkgreen}{nextrain}{reset} until the next {aqua}storm{reset}.</str>
+                    </concat>
+                </if>
+            </if>
+            <if>
+                <not>
+                <equal>
+                    <var>server</var>
+                    <str>localhost</str>
+                </equal>
+                </not>
+                <if>
+                    <and>
+                        <equal>
+                            <var>raining</var>
+                            <str>false</str>
+                        </equal>
+                        <equal>
+                            <var>snowing</var>
+                            <str>false</str>
+                        </equal>
+                        <equal>
+                            <var>thundering</var>
+                            <str>false</str>
+                        </equal>
+                        <not>
+                            <or>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Storage Cell</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Ocean</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert Oil Field</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Sky</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Forest</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pocket Plane</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Desert</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot River</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Hot Plains</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Desert M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna Plateau</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Savanna Plateau M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa (Bryce)</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Mesa Plateau F M</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Space</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Venus</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>moon</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>marsFlat</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>asteroids</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Io</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>IoAsh</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Titan</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto2</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto3</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>Pluto4</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCFlowers</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCHills</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCLowPlains</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCOceans</str>
+                                </equal>
+                                <equal>
+                                    <var>biome</var>
+                                    <str>BarnardaCShores</str>
+                                </equal>
+                            </or>
+                        </not>
+                    </and>
+                    <concat>
+                        <icon>
+                            <str>thaumcraft:textures/aspects/tempestas.png</str>
+                        </icon>
+                        <str> There is currently no {aqua}precipitation{reset}.</str>
+                    </concat>
+                </if>
             </if>
         </line>
         <line>


### PR DESCRIPTION
Fixes the issue of the broken {raintime} tag for users on multiplayer by giving a non-raintime variant on serverport check for -1.

Tested whether it would detect as the serverport -1 or not on a local singleplayer world (inverting behavior to see if the lines functioned correctly), and I had AnrDaemon help on the discord with finding a better tag for detection. I didn't test it on a personal server file host (as I only play through singleplayer). Might need someone to double check in case connecting to a server hosted on the same machine will still list it as -1 or not. This should work fine though for at minimum external server hostings not on the same pc/ip, so for that it'll be a lot better for users.

Compared to 2.6.1's lines (which would stay persistent for singleplayer users), new lines are as follows:
It is {darkaqua}Raining{reset}. (While Raining) 
It is {darkaqua}Raining{reset} and {gold}Thundering{reset}. (While Raining and Thundering) 
It is {darkaqua}Snowing{reset}. (While Snowing)
It is {darkaqua}Snowing{reset} and {gold}Thundering{reset}. (While Snowing and Thundering)
There is currently no {aqua}precipitation{reset}. (When in a biome that has precipitation but no precipitation is occurring)
This {darkgreen}biome{reset} does not have {aqua}precipitation{reset}. (When in a biome that does not have precipitation, unchanged)

If you do want to test it yourself, copy lines 160 through 913 and paste that in your own IGI config (or just copy the file itself and replace it).