### PR TITLE
Fixed QFT Quest showing incorrect amount of Manipulatiors

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ChemicalPseudoAl-AAAAAAAAAAAAAAAAAAAM1w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ChemicalPseudoAl-AAAAAAAAAAAAAAAAAAAM1w==.json
@@ -71,7 +71,7 @@
         },
         "3:10": {
           "id:8": "miscutils:gtplusplus.blockcasings.5",
-          "Count:3": 233,
+          "Count:3": 236,
           "Damage:2": 7,
           "OreDict:8": ""
         },


### PR DESCRIPTION
QFT structure change fixed the symmetry by adding 3 Manipulators, but quest was never updated.