### PR TITLE
Trigger Quests inconsistency fix

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNaqlineSk-AAAAAAAAAAAAAAAAAAAL3A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNaqlineSk-AAAAAAAAAAAAAAAAAAAL3A==.json
@@ -1,6 +1,11 @@
 {
   "questIDHigh:4": 0,
-  "preRequisites:9": {},
+  "preRequisites:9": {
+    "0:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 1493
+    }
+  },
   "questIDLow:4": 3036,
   "properties:10": {
     "betterquesting:10": {

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPTFESkip-AAAAAAAAAAAAAAAAAAAL2Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPTFESkip-AAAAAAAAAAAAAAAAAAAL2Q==.json
@@ -1,6 +1,11 @@
 {
   "questIDHigh:4": 0,
-  "preRequisites:9": {},
+  "preRequisites:9": {
+    "0:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 943
+    }
+  },
   "questIDLow:4": 3033,
   "properties:10": {
     "betterquesting:10": {

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolystyre-AAAAAAAAAAAAAAAAAAAL2g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolystyre-AAAAAAAAAAAAAAAAAAAL2g==.json
@@ -1,6 +1,11 @@
 {
   "questIDHigh:4": 0,
-  "preRequisites:9": {},
+  "preRequisites:9": {
+    "0:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 943
+    }
+  },
   "questIDLow:4": 3034,
   "properties:10": {
     "betterquesting:10": {

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSiliconeR-AAAAAAAAAAAAAAAAAAAL2A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSiliconeR-AAAAAAAAAAAAAAAAAAAL2A==.json
@@ -1,6 +1,11 @@
 {
   "questIDHigh:4": 0,
-  "preRequisites:9": {},
+  "preRequisites:9": {
+    "0:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 943
+    }
+  },
   "questIDLow:4": 3032,
   "properties:10": {
     "betterquesting:10": {


### PR DESCRIPTION
Epoxid and Styrene-Butadiene work fine, but these 4 quests don't check for Tier Unlock.
- 3 other HV plastics
- Naquadah dust

Naq dust will check for LuV Tier unlock and HV plastics will check for HV chem react (like how Styrene works).