### PR TITLE
Fixed "Bound by" items not detecting by QB

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/AdvancedRituals-AAAAAAAAAAAAAAAAAAACyA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/AdvancedRituals-AAAAAAAAAAAAAAAAAAACyA==.json
@@ -39,7 +39,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/ApprenticeOrb-AAAAAAAAAAAAAAAAAAABpw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/ApprenticeOrb-AAAAAAAAAAAAAAAAAAABpw==.json
@@ -43,7 +43,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/ArchmageOrbLetTh-AAAAAAAAAAAAAAAAAAACww==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/ArchmageOrbLetTh-AAAAAAAAAAAAAAAAAAACww==.json
@@ -51,7 +51,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/Ascended-AAAAAAAAAAAAAAAAAAACvQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/Ascended-AAAAAAAAAAAAAAAAAAACvQ==.json
@@ -43,7 +43,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/Convocationofthe-AAAAAAAAAAAAAAAAAAACyg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/Convocationofthe-AAAAAAAAAAAAAAAAAAACyg==.json
@@ -200,7 +200,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 2,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/HighendRituals-AAAAAAAAAAAAAAAAAAACyQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/HighendRituals-AAAAAAAAAAAAAAAAAAACyQ==.json
@@ -39,7 +39,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/HowDarkCanYouGo-AAAAAAAAAAAAAAAAAAACvA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/HowDarkCanYouGo-AAAAAAAAAAAAAAAAAAACvA==.json
@@ -39,7 +39,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/MagicansOrb-AAAAAAAAAAAAAAAAAAABqA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/MagicansOrb-AAAAAAAAAAAAAAAAAAABqA==.json
@@ -43,7 +43,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/PortableBattery-AAAAAAAAAAAAAAAAAAAApA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/PortableBattery-AAAAAAAAAAAAAAAAAAAApA==.json
@@ -43,7 +43,7 @@
       "partialMatch:1": 1,
       "autoConsume:1": 0,
       "groupDetect:1": 0,
-      "ignoreNBT:1": 0,
+      "ignoreNBT:1": 1,
       "index:3": 0,
       "consume:1": 0,
       "requiredItems:9": {

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/StarterKey-AAAAAAAAAAAAAAAAAAAJmQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/StarterKey-AAAAAAAAAAAAAAAAAAAJmQ==.json
@@ -30,7 +30,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "You need this to start Rituals. More complex rituals need the Activated version. To use it, bind it to yourself and right click on the center of the ritual."
+      "desc:8": "You need this to start Rituals. More complex rituals need the Activated version. To use it, bind it to yourself and right click on the center of the ritual.\n\n[note]The Energy Crystal needs to be fully charged.[/note]"
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Some items can be bound to the player in Blood Magic (Blood Orbs, Activation Crystals and Ritual Diviners) those don't count for the quest when they are bound. Also clarified that Energy Crystal has to be fully charged (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15373#issuecomment-1998022306). 