### PR TITLE
Fixed and cleaned Magic Absorber Quests

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALBg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALBg==.json
@@ -3,7 +3,7 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2823
+      "questIDLow:4": 2820
     },
     "1:10": {
       "questIDHigh:4": 0,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALBw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALBw==.json
@@ -3,11 +3,7 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 1232
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 2824
+      "questIDLow:4": 2820
     }
   },
   "questIDLow:4": 2823,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALCA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALCA==.json
@@ -4,10 +4,6 @@
     "0:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 2819
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 1477
     }
   },
   "questIDLow:4": 2824,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALCQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AbsorbingMagicEn-AAAAAAAAAAAAAAAAAAALCQ==.json
@@ -3,7 +3,7 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2823
+      "questIDLow:4": 2821
     },
     "1:10": {
       "questIDHigh:4": 0,


### PR DESCRIPTION
- Changed the order of the quest prerequisite, now each Absorber only needs prerequisite Convertor
- Removed doubled quest prerequisite

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/154506304/8406acfc-c2ee-437e-8dc0-d8c4354f1d87)
The old quest flow made no sense since the Convertor -> Absorber lines are seperated from each other by default.
Thanks to Mr_Vovikpro on discord for pointing it out.
