### PR TITLE
Fixed Stainless Steel quest requirement

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/StainlessSteelEB-AAAAAAAAAAAAAAAAAAAC8Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/StainlessSteelEB-AAAAAAAAAAAAAAAAAAAC8Q==.json
@@ -28,7 +28,7 @@
       "snd_update:8": "random.levelup",
       "repeatTime:3": -1,
       "globalShare:1": 1,
-      "questLogic:8": "OR",
+      "questLogic:8": "AND",
       "repeat_relative:1": 1,
       "name:8": "§6§lStainless Steel EBF processing",
       "isGlobal:1": 0,


### PR DESCRIPTION
- Fixed Stainless steel quest requiring either the dust OR the mv energy hatch instead of both.

Fixes (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16658#issuecomment-2203965646)