### PR TITLE
Rename Dark Iron Bars

### DIFF
--- a/config/txloader/load/enderio/lang/en_US.lang
+++ b/config/txloader/load/enderio/lang/en_US.lang
@@ -1,0 +1,1 @@
+tile.blockDarkIronBars.name=Dark Steel Bars


### PR DESCRIPTION
to Dark Steel Bars

In order to make it consistent with the used material.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7776