### PR TITLE
Fixed Solar Quest pre-reqs

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatE-AAAAAAAAAAAAAAAAAAAGiA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatE-AAAAAAAAAAAAAAAAAAAGiA==.json
@@ -7,9 +7,13 @@
     },
     "1:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 1671
+      "questIDLow:4": 1409
     },
     "2:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 1671
+    },
+    "3:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 1006
     }

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatI-AAAAAAAAAAAAAAAAAAAGuA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatI-AAAAAAAAAAAAAAAAAAAGuA==.json
@@ -3,9 +3,13 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 1672
+      "questIDLow:4": 2944
     },
     "1:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 1672
+    },
+    "2:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 1722
     }

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatL-AAAAAAAAAAAAAAAAAAAK1g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatL-AAAAAAAAAAAAAAAAAAAK1g==.json
@@ -3,9 +3,17 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 1720
+      "questIDLow:4": 2630
     },
     "1:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 1720
+    },
+    "2:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 2619
+    },
+    "3:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 1710
     }

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatM-AAAAAAAAAAAAAAAAAAAD6w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatM-AAAAAAAAAAAAAAAAAAAD6w==.json
@@ -7,7 +7,15 @@
     },
     "1:10": {
       "questIDHigh:4": 0,
+      "questIDLow:4": 1014
+    },
+    "2:10": {
+      "questIDHigh:4": 0,
       "questIDLow:4": 936
+    },
+    "3:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 1224
     }
   },
   "questIDLow:4": 1003,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatU-AAAAAAAAAAAAAAAAAAAK2Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatU-AAAAAAAAAAAAAAAAAAAK2Q==.json
@@ -8,6 +8,14 @@
     "1:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 2776
+    },
+    "2:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 2665
+    },
+    "3:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 2621
     }
   },
   "questIDLow:4": 2777,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatZ-AAAAAAAAAAAAAAAAAAAK2A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatZ-AAAAAAAAAAAAAAAAAAAK2A==.json
@@ -3,11 +3,15 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2774
+      "questIDLow:4": 2656
     },
     "1:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2665
+      "questIDLow:4": 2774
+    },
+    "2:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 2633
     }
   },
   "questIDLow:4": 2776,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UVSolar-AAAAAAAAAAAAAAAAAAAKGw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UVSolar-AAAAAAAAAAAAAAAAAAAKGw==.json
@@ -4,10 +4,6 @@
     "0:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 2777
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 2665
     }
   },
   "questIDLow:4": 2587,


### PR DESCRIPTION
Solar panel quests had some wrong/outdated requirements, such as wetware mainframe being required for LuV tier.
- Fixed certain tiers not having correct prerequisites.
- Added some missing prerequisites to some tiers.