### PR TITLE
Update redstone quest in stone age

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
@@ -62,7 +62,7 @@
           "OreDict:8": ""
         }
       },
-      "taskID:8": "bq_standard:retrieval"
+      "taskID:8": "bq_standard:optional_retrieval"
     },
     "1:10": {
       "partialMatch:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RedstoneEarlyGam-AAAAAAAAAAAAAAAAAAACFw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RedstoneEarlyGam-AAAAAAAAAAAAAAAAAAACFw==.json
@@ -35,7 +35,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Are you wondering how to process redstone without a macerator? \n\nPlace the ore you got back down, mine it with a gregtech hammer, and get the crushed ore. \nUse the hammer in the crafting table to get some impure redstone dust. \nFill a cauldron with water and drop the whole stack of dust into it either manually or by pressing Ctrl+Q, which the cauldron can handle for the same amount of water. You will get pure redstone dust for your redstone needs."
+      "desc:8": "Are you wondering how to process raw redstone ore without a macerator?\n\nUse the hammer in the crafting table to get some crushed redstone ore from your raw redstone ore. After that, use the hammer in the crafting table again to get some impure redstone dust.\n\nLastly, fill a cauldron with water and drop the whole stack of dust into it, either manually or by pressing Ctrl+Q. The cauldron can handle the entire stack with the same amount of water. You will get pure redstone dust for your redstone needs."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Cant progress on my new run since you dont get redstone ore anymore. To still make it clear what ore has to be found and mined it will still be in the quest but be optional. This way they can be blicked to see the ore information in NEI.

The second commit updates the quest explaining how to process it since you no longer place the block but rather put it in the crafting table with a hammer 2 times now.

![image](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/assets/174252612/ac023ab8-8a61-4260-9b17-3279d182dbac)


This change has to be made for the other ore quests aswell unless having to get amber tools for silk touch is the intended way of finishing these quests, which i highly doubt. Will do them the coming days if this way of changing the quest is accepted