### PR TITLE
Modified IGI config to fall back to less informative rain changes

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -159,10 +159,12 @@
         </line>
         <line>
             <if>
+                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
+                </not>
                 <if>
                     <or>
                         <equal>
@@ -216,12 +218,10 @@
                 </if>
             </if>
             <if>
-                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
-                </not>
                 <if>
                     <or>
                         <equal>
@@ -275,10 +275,12 @@
                 </if>
             </if>
             <if>
+                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
+                </not>
                 <if>
                     <or>
                         <equal>
@@ -326,12 +328,10 @@
                 </if>
             </if>
             <if>
-                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
-                </not>
                 <if>
                     <or>
                         <equal>
@@ -541,10 +541,12 @@
                 </concat>
             </if>
             <if>
+                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
+                </not>
                 <if>
                     <and>
                         <equal>
@@ -725,12 +727,10 @@
                 </if>
             </if>
             <if>
-                <not>
                 <equal>
-                    <var>serverport</var>
-                    <str>-1</str>
+                    <var>nextrain</var>
+                    <str>?</str>
                 </equal>
-                </not>
                 <if>
                     <and>
                         <equal>


### PR DESCRIPTION
…from https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/16572 if IGI is not installed on the server, not based on a server port check.

This should be paired with https://github.com/GTNewHorizons/InGame-Info-XML/pull/21, and IGI should be included in the server files zip after that PR is merged.  If IGI is not included in the server though, it is still fine, as it will just fall back to the changes @PlayfulPiano made in the previous PR.