### PR TITLE
Enable AFK time tracking by default, including singleplayer

### DIFF
--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -2,10 +2,10 @@
 
 afk {
     # Enables afk timer.
-    B:enabled=false
+    B:enabled=true
 
     # Enables afk timer in singleplayer.
-    B:enabled_singleplayer=false
+    B:enabled_singleplayer=true
 
     # Will print in console when someone goes/comes back from AFK.
     B:log_afk=false


### PR DESCRIPTION
This will enable tracking of time players spend AFK, which shows up in game statistics and chat.