### PR TITLE
Misc Quest Changes

### DIFF
--- a/config/betterquesting/DefaultQuests/QuestLines/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/MakingPatternsQu-AAAAAAAAAAAAAAAAAAAJ2Q==.json
+++ b/config/betterquesting/DefaultQuests/QuestLines/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/MakingPatternsQu-AAAAAAAAAAAAAAAAAAAJ2Q==.json
@@ -1,7 +1,7 @@
 {
   "questIDHigh:4": 0,
   "sizeX:3": 24,
-  "x:3": 216,
+  "x:3": 180,
   "y:3": 0,
   "questIDLow:4": 2521,
   "sizeY:3": 24

--- a/config/betterquesting/DefaultQuests/QuestLines/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/RecipePatterns-AAAAAAAAAAAAAAAAAAAFLw==.json
+++ b/config/betterquesting/DefaultQuests/QuestLines/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/RecipePatterns-AAAAAAAAAAAAAAAAAAAFLw==.json
@@ -1,7 +1,7 @@
 {
   "questIDHigh:4": 0,
   "sizeX:3": 24,
-  "x:3": 180,
+  "x:3": 216,
   "y:3": 0,
   "questIDLow:4": 1327,
   "sizeY:3": 24

--- a/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/Nearlythere-AAAAAAAAAAAAAAAAAAAMpQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/Nearlythere-AAAAAAAAAAAAAAAAAAAMpQ==.json
@@ -4,10 +4,6 @@
     "0:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 3239
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 3242
     }
   },
   "questIDLow:4": 3237,

--- a/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/UMVCircuits-AAAAAAAAAAAAAAAAAAAMqg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/UMVCircuits-AAAAAAAAAAAAAAAAAAAMqg==.json
@@ -34,7 +34,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Circuits required for UMV tier."
+      "desc:8": "Pico circuits, a direct upgrade from Optical Mainframes, these UMV circuits will be required for a lot of future crafts. \n\n\n[note]You will need an UMV powered Assembling Line to get started.[/note]"
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/UXVCircuits-AAAAAAAAAAAAAAAAAAAMrA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/UXVCircuits-AAAAAAAAAAAAAAAAAAAMrA==.json
@@ -34,7 +34,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Circuits required for UXV."
+      "desc:8": "The final circuit in the game: Quantum Circuit, these will be required for lots of UMV/UXV crafts."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Solves (#16811)
- Fixes a dependency loop in UIV components and Pico circuits
- Added a bit of info to clarify that you still need *some* UIV components
- Swapped 2 Pattern related quests in AE2 tab to not have quest lines going through quests:
Before 
![image](https://github.com/user-attachments/assets/92fd46f4-6f29-467d-a0fc-1e6e0f4fcd7c)
After
![image](https://github.com/user-attachments/assets/43e5df48-1ab0-40c3-8158-6ba5bf56543d)
