### PR TITLE
Fix water pump requirements

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/DiggingDeepforWa-jreOZVXRQa2sGXViV7-3Gg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/DiggingDeepforWa-jreOZVXRQa2sGXViV7-3Gg==.json
@@ -3,11 +3,11 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 890
+      "questIDLow:4": 75
     },
     "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 75
+      "questIDHigh:4": -3965147138498412514,
+      "questIDLow:4": -8911182845288729667
     }
   },
   "questIDLow:4": -6045671959528753382,


### PR DESCRIPTION
This small fix just locks the water pump quest behind the right quest now that everything regarding to the steam multis is merged.
![image](https://github.com/user-attachments/assets/a6069a4f-c58e-491c-8785-f04bb5521f7b)
