### PR TITLE
fix tinker tools in NEI

### DIFF
--- a/config/INpureProjects/custom_nei_filters/Tcon.js
+++ b/config/INpureProjects/custom_nei_filters/Tcon.js
@@ -1,75 +1,10 @@
 if (FML.isModLoaded("TConstruct") && Tcon_enabled) {
-    NEI.override("TConstruct:tool*", [0]);
-    NEI.override("TConstruct:binding", [0]);
-    NEI.override("TConstruct:scytheBlade", [0]);
     NEI.override("TConstruct:ToolForgeBlock", [0])
     NEI.override("TConstruct:buckets", [0])
 
     NEI.override("TConstruct:GlassPaneClearStained", [0])
     NEI.override("TConstruct:GlassBlock.Stained*", [0])
     NEI.hide("TConstruct:fluid.molten.*"  )
-
-    // Tools
-    NEI.override_with_nbt("TConstruct", "pickaxe");
-    NEI.override_with_nbt("TConstruct", "battleaxe");
-    NEI.override_with_nbt("TConstruct", "shovel");
-    NEI.override_with_nbt("TConstruct", "hatchet");
-    NEI.override_with_nbt("TConstruct", "broadsword");
-    NEI.override_with_nbt("TConstruct", "longsword");
-    NEI.override_with_nbt("TConstruct", "rapier");
-    NEI.override_with_nbt("TConstruct", "dagger");
-    NEI.override_with_nbt("TConstruct", "cutlass");
-    NEI.override_with_nbt("TConstruct", "frypan");
-    NEI.override_with_nbt("TConstruct", "battlesign");
-    NEI.override_with_nbt("TConstruct", "mattock");
-    NEI.override_with_nbt("TConstruct", "chisel");
-    NEI.override_with_nbt("TConstruct", "lumberaxe");
-    NEI.override_with_nbt("TConstruct", "cleaver");
-    NEI.override_with_nbt("TConstruct", "scythe");
-    NEI.override_with_nbt("TConstruct", "excavator");
-    NEI.override_with_nbt("TConstruct", "hammer");
-    NEI.override_with_nbt("TConstruct", "Shuriken");
-    NEI.override_with_nbt("TConstruct", "ThrowingKnife");
-    NEI.override_with_nbt("TConstruct", "Javelin");
-    NEI.override_with_nbt("TConstruct", "ShortBow");
-    NEI.override_with_nbt("TConstruct", "arrow");
-    NEI.override_with_nbt("TConstruct", "LongBow");
-    NEI.override_with_nbt("TConstruct", "Crossbow");
-    NEI.override_with_nbt("TConstruct", "ArrowAmmo");
-    NEI.override_with_nbt("TConstruct", "BoltAmmo");
-
-    // Tool Parts
-    NEI.override_with_nbt("TConstruct", "toolRod");
-    NEI.override_with_nbt("TConstruct", "toolShard");
-    NEI.override_with_nbt("TConstruct", "pickaxeHead");
-    NEI.override_with_nbt("TConstruct", "shovelHead");
-    NEI.override_with_nbt("TConstruct", "hatchetHead");
-    NEI.override_with_nbt("TConstruct", "binding");
-    NEI.override_with_nbt("TConstruct", "toughBinding");
-    NEI.override_with_nbt("TConstruct", "toughRod");
-    NEI.override_with_nbt("TConstruct", "heavyPlate");
-    NEI.override_with_nbt("TConstruct", "swordBlade");
-    NEI.override_with_nbt("TConstruct", "wideGuard");
-    NEI.override_with_nbt("TConstruct", "handGuard");
-    NEI.override_with_nbt("TConstruct", "crossbar");
-    NEI.override_with_nbt("TConstruct", "knifeBlade");
-    NEI.override_with_nbt("TConstruct", "frypanHead");
-    NEI.override_with_nbt("TConstruct", "signHead");
-    NEI.override_with_nbt("TConstruct", "chiselHead");
-    NEI.override_with_nbt("TConstruct", "scytheBlade");
-    NEI.override_with_nbt("TConstruct", "broadAxeHead");
-    NEI.override_with_nbt("TConstruct", "excavatorHead");
-    NEI.override_with_nbt("TConstruct", "largeSwordBlade");
-    NEI.override_with_nbt("TConstruct", "hammerHead");
-    NEI.override_with_nbt("TConstruct", "bowstring");
-    NEI.override_with_nbt("TConstruct", "fletching");
-    NEI.override_with_nbt("TConstruct", "arrowhead");
-    NEI.override_with_nbt("TConstruct", "ShurikenPart");
-    NEI.override_with_nbt("TConstruct", "CrossbowLimbPart");
-    NEI.override_with_nbt("TConstruct", "BowLimbPart");
-    NEI.override_with_nbt("TConstruct", "CrossbowBodyPart");
-    NEI.override_with_nbt("TConstruct", "BoltPart");
-    NEI.override_with_nbt("TConstruct", "creativeModifier");
     // This part apparently only uses meta... why? who the hell knows.
     NEI.override("TConstruct:fullGuard", [0]);
 


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9920

longer explanation:
if you search for "iron pickaxe head" (normal and important in early game) the game gives you 9 options (new nei grouping disabled it just makes this worse to see but doesnt really change anything):
![image](https://github.com/user-attachments/assets/2c2f9e23-7844-4174-8c8d-0e4bfbefbaf4)
however: none of them is the iron pickaxe head!!
the most important tinker tools have not been searchable in nei for many years now and there wasnt even any upside, nei was still full of tinker tools. This PR rectifies that:
you now get 12 options instead of 9, sure. but the first one is the one you want
![image](https://github.com/user-attachments/assets/4e490b5a-5f5e-4267-bc8d-747b5632a036)

Maybe even more clearly, with "thaumium binding" the comparison becomes 0 results to 1 result (the right one).
![image](https://github.com/user-attachments/assets/a1c220d2-e0a1-425d-b01a-dc2b793c6d06)
