### PR TITLE
Quick fix  for HV semifluid gen quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PuttingtheSemiBa-AAAAAAAAAAAAAAAAAAAK5g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PuttingtheSemiBa-AAAAAAAAAAAAAAAAAAAK5g==.json
@@ -3,10 +3,6 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 81
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
       "questIDLow:4": 1231
     }
   },


### PR DESCRIPTION
fixes (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16658#issuecomment-2268973383) by simply removing the need for the vac freezer quest.
Chrome does not need to be cooled down after EBFing. So the Vac freezer is not needed. The recipe for reference:
![image](https://github.com/user-attachments/assets/b77e928b-b7a2-4ed4-b209-d1b62990c3b7)
After the fix it has the same reqs as the other HV singleblock gens:
![image](https://github.com/user-attachments/assets/7e81c441-08ba-4797-86dc-415858a8d727)

