### PR TITLE
Update quests related to Fluid Heater changes

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FluidHeater-55XTBx8LRN2Ol_42LS6Mwg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FluidHeater-55XTBx8LRN2Ol_42LS6Mwg==.json
@@ -29,7 +29,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "You will need a Fluid Heater for some chemical processes, for the best fries, but also right now to make NaK coolant. To proceed you will need either an MV or an HV Fluid Heater. Make one of them."
+      "desc:8": "You will need a Fluid Heater for some chemical processes, for the best fries, but also right now to make NaK coolant. To proceed you will need either an MV or an HV Fluid Heater. Make one of them.\n\nThe HV one can be used later to better process bauxite after you have been to the moon."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/HotSlurry-AAAAAAAAAAAAAAAAAAALoQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/HotSlurry-AAAAAAAAAAAAAAAAAAALoQ==.json
@@ -6,8 +6,9 @@
       "questIDLow:4": 2978
     },
     "1:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 766
+      "questIDHigh:4": -1759268051879246627,
+      "questIDLow:4": -8171783490200761150,
+      "type:1": 1
     }
   },
   "questIDLow:4": 2977,
@@ -35,7 +36,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Then heat up the slurry with steam."
+      "desc:8": "Then heat up the slurry you made with a Fluid Heater."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Some recipes got changed to now use the fluid heater instead of the oil cracker (thank god). To keep the quests updated this PR changes some things:
-Updates the description for the bauxite slurry quest to state its made using a fluid heater
-Change the req for the bauxite slurry quest from the oil cracker quest to the fluid heater quest in the HV tab
-Mention that the HV fluid heater can be used to better process bauxite once the player has been to the moon in the fluid heater quest
See pictures below for better reference (the line is set to only show when hovered):
![image](https://github.com/user-attachments/assets/03d73b79-c266-48a0-9c3d-347a1000c4a3)
![image](https://github.com/user-attachments/assets/59bc9097-d321-4a1a-9b0e-e7baa2a82b13)
