### PR TITLE
Make the Universium quest more clearer

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/Tier13UXV-7wI7VuLKRe6lqAJpuYKKJg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/EndgameGoals-AAAAAAAAAAAAAAAAAAAAHQ==/Tier13UXV-7wI7VuLKRe6lqAJpuYKKJg==.json
@@ -33,7 +33,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Welcome to the final tier of NH (for now).\n\nWe hope you enjoy your stay, though be prepared for a lot of waiting.\n\nHave fun crafting 2 Stargates!\n\n[warn]This tier is far from complete. Expect changes.[/warn]\n"
+      "desc:8": "Welcome to the final tier of NH (for now).\n\nWe hope you enjoy your stay, though be prepared for a lot of waiting.\n\nNow that you have a reliable way to make MHDCSM, it would be wise to upgrade your EOHs to T9 for the Universium boost.\n\nHave fun crafting 2 Stargates!\n\n[warn]This tier is far from complete. Expect changes.[/warn]\n"
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier12UMV-l37V2WvbSHGZQ5oMgAfBuw==/FinallyUniversiu-21tDEYptRuOgSJym30Watg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier12UMV-l37V2WvbSHGZQ5oMgAfBuw==/FinallyUniversiu-21tDEYptRuOgSJym30Watg==.json
@@ -29,7 +29,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "You’ve finally solved it. Who knew that leaving dead stars long enough would cause your artificial solar system to implode and lead to a Big Bang?\n\nIf only you could tap into that much mass right before it started expanding again, you could literally hold the entire universe in the palm of your hand.\n\n[note]This is your third and final material from the EOH.\n\nUse your first few to upgrade your EOH to Tier 9 so you can produce more Universium.\n\nIt might be time to create multiple Eyes now.\n\nCongrats! You can now move on to the UXV tier.[/note]"
+      "desc:8": "You’ve finally solved it. Who knew that leaving dead stars long enough would cause your artificial solar system to implode and lead to a Big Bang?\n\nIf only you could tap into that much mass right before it started expanding again, you could literally hold the entire universe in the palm of your hand.\n\n[note]This is your third and final material from the EOH.\n\nIt\u0027s mainly used for UXV crafts, but your first few should go in the §dEternity§r loop. The quest for it is located in the Endgame Goals tab.\n\nCongrats! You can now move on to the UXV tier.[/note]"
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Changes the description of the Universium quest to instead mention that the first few should go towards the Eternity loop.
Due to this, the T9 EOH mention has been moved to the UXV Hull quest.

![image](https://github.com/user-attachments/assets/2da52076-165d-4fd2-acdb-8e621921d41f)
