### PR TITLE
Disable Blinding Enderman spawns

### DIFF
--- a/config/SpecialMobs.cfg
+++ b/config/SpecialMobs.cfg
@@ -209,7 +209,7 @@ enderman_rates {
     # Set this to false to disable all special endermen.
     B:_special_endermen=true
     I:_vanilla=3
-    I:blinding=1
+    I:blinding=0
     I:cursed=1
     I:icy=1
     I:lightning=1


### PR DESCRIPTION
Blinding Endermen sometimes cause your screen to rapidly flash due to Blindness. This may be an interaction between my night vision, baubles, or similar.
Whatever the cause, this is a potential risk for people suffering from epilepsy, as well as just being generally unpleasant on the eyes

https://github.com/user-attachments/assets/fd79d77d-d65e-4775-b83e-98199e722d12


Edit: It seems to be caused by Night Vision being overwritten by Blindness, and Blindness being overwritten by Night Vision.
I don't know of this is vanilla behavior or if it's exclusive to Q-Goggles of Revealing, but taking them off completely fixes the flashing
According to Cloud this may be a vanilla thing and potentially involves touching Hodgepodge, which is beyond me