### PR TITLE
Update the quest for electric GT Tools

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/BlackandDecker-AAAAAAAAAAAAAAAAAAAGAQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/BlackandDecker-AAAAAAAAAAAAAAAAAAAGAQ==.json
@@ -14,7 +14,7 @@
   "properties:10": {
     "betterquesting:10": {
       "snd_complete:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "partySingleReward:1": 0,
       "visibility:8": "NORMAL",
       "isMain:1": 0,
@@ -42,7 +42,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Tired of having to replace tools all the time? Now that steel is available, it\u0027s time to make some electric versions of the screwdriver and wrench! Charge them up like a battery, and they\u0027ll last much longer than normal versions of the tools.\n\nYou can use lithium batteries, or if you\u0027re on a budget, cadmium or sodium batteries instead. Later on, Vibrant Alloy will make excellent tools with great durability.\n\nIf you look in NEI, you can also see MV and HV versions, but you need Aluminium or Stainless Steel for those."
+      "desc:8": "Tired of having to replace tools all the time because they constantly break? Now that Steel is available, it\u0027s time to make some electric versions of the Screwdriver and Wrench! Charge them up like Batteries, and they\u0027ll last much longer than the non-electric versions of these tools.\n\nYou can use Lithium Batteries, or if you\u0027re on a budget, Cadmium or Sodium Batteries instead. This does reduce their energy capacity though. Later on, Vibrant Alloy will make excellent tools with great durability. There are, however, a multitude of other great materials that you may have access to, so take a look around in NEI and decide for yourself.\n\nThere are also MV and HV versions, though they require that you can process Aluminium or Stainless Steel, respectively."
     }
   },
   "tasks:9": {
@@ -59,6 +59,12 @@
           "Count:3": 1,
           "Damage:2": 120,
           "OreDict:8": ""
+        },
+        "1:10": {
+          "id:8": "gregtech:gt.metatool.01",
+          "Count:3": 1,
+          "Damage:2": 150,
+          "OreDict:8": ""
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -74,7 +80,36 @@
         "0:10": {
           "id:8": "gregtech:gt.metatool.01",
           "Count:3": 1,
-          "Damage:2": 150,
+          "Damage:2": 122,
+          "OreDict:8": ""
+        },
+        "1:10": {
+          "id:8": "gregtech:gt.metatool.01",
+          "Count:3": 1,
+          "Damage:2": 152,
+          "OreDict:8": ""
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "2:10": {
+      "partialMatch:1": 1,
+      "autoConsume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 2,
+      "consume:1": 0,
+      "requiredItems:9": {
+        "0:10": {
+          "id:8": "gregtech:gt.metatool.01",
+          "Count:3": 1,
+          "Damage:2": 124,
+          "OreDict:8": ""
+        },
+        "1:10": {
+          "id:8": "gregtech:gt.metatool.01",
+          "Count:3": 1,
+          "Damage:2": 154,
           "OreDict:8": ""
         }
       },


### PR DESCRIPTION
This PR updates the quest explaining the electric version of the GT Wrench and Screwdriver. Additionally to changing the quest description to incentivize the player to have a look for himself regarding the material he wants to use it also detects if you craft GT Tools of a higher tier. The old version only detected LV tools despite the quest explicitly mentioning the MV and HV ones. See below for more details:
![image](https://github.com/user-attachments/assets/78c74e5c-dbed-4544-a696-18ae0457ab12)
