### PR TITLE
remove unused concreteVelocity from chisel.cfg

### DIFF
--- a/config/chisel.cfg
+++ b/config/chisel.cfg
@@ -197,7 +197,6 @@ general {
 
     # Chisel stone to cobblestone and bricks by left clicking.
     B:chiselStoneToCobbleBricks=true
-    D:concreteVelocity=0.45
 
     # The factor that concrete increases your velocity. Default is 1.35, set to 1 for no change.
     D:concreteVelocityMult=1.35


### PR DESCRIPTION
This config option has been unused since Sep 16, 2015 where it was replaced by `concreteVelocityMult`
https://github.com/GTNewHorizons/Chisel/commit/45b1cfdb9eb694c468a0a449ea5f3336bf65b680

It should have been removed on Sep 30, 2016 in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/commit/d131018d95aeabc05e7b8b9d6eb33f88e20c4231
where its comment was removed and the new `concreteVelocityMult` which replaces it was added, but the line wasn't actually removed.