### PR TITLE
Some adjustments for quest rewards, quest logic and mostly formatting

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/GTMultiblocks-w5O5rPL_Q_GDp8lxWMd0DQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/GTMultiblocks-w5O5rPL_Q_GDp8lxWMd0DQ==.json
@@ -27,7 +27,7 @@
       "snd_update:8": "random.levelup",
       "repeatTime:3": -1,
       "globalShare:1": 0,
-      "questLogic:8": "OR",
+      "questLogic:8": "AND",
       "repeat_relative:1": 1,
       "name:8": "GT++ Multiblocks",
       "lockedProgress:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/STEAMPOWEREDBREA-quLxATDCQFWsrZRuh_gspA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/GT-AAAAAAAAAAAAAAAAAAAAEQ==/STEAMPOWEREDBREA-quLxATDCQFWsrZRuh_gspA==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "§2§lSTEAM-POWERED BREAKTHROUGH",
+      "name:8": "STEAM-POWERED BREAKTHROUGH",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DarksteelChest-t6xRGFm_S2SG6_-xNh8mwQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DarksteelChest-t6xRGFm_S2SG6_-xNh8mwQ==.json
@@ -29,7 +29,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "§8§lDark steel Chest",
+      "name:8": "§5§6§lDark Steel Chest",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/SteelChest-V4jinTYRSueIrEqn90dRzQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/SteelChest-V4jinTYRSueIrEqn90dRzQ==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "§7§lSteel Chest?",
+      "name:8": "§3§lSteel Chest?",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/FlamingIdiots-AAAAAAAAAAAAAAAAAAAHNQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/FlamingIdiots-AAAAAAAAAAAAAAAAAAAHNQ==.json
@@ -26,7 +26,7 @@
       "globalShare:1": 1,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "§1§lFlaming Idiots",
+      "name:8": "§3§lFlaming idiots",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/NewSourceofGlows-AAAAAAAAAAAAAAAAAAAERA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/NewSourceofGlows-AAAAAAAAAAAAAAAAAAAERA==.json
@@ -78,7 +78,7 @@
         "0:10": {
           "id:8": "enhancedlootbags:lootbag",
           "Count:3": 1,
-          "Damage:2": 4,
+          "Damage:2": 2,
           "OreDict:8": ""
         },
         "1:10": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/EXTREMEMIXING-kQL8JceoSMSLDU_2AFjoqw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/EXTREMEMIXING-kQL8JceoSMSLDU_2AFjoqw==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "§4§lEXTREME MIXING",
+      "name:8": "§a§lEXTREME MIXING",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/Fourfluidsintheo-JkWQZxq_TECWjHhjywrZZA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/Fourfluidsintheo-JkWQZxq_TECWjHhjywrZZA==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Four fluids in the one Hatch!",
+      "name:8": "§a§lFour fluids in the one Hatch!",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Intradimensional-VCXYSn_PTZ6kY3d6kFTFwg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Intradimensional-VCXYSn_PTZ6kY3d6kFTFwg==.json
@@ -30,7 +30,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Intradimensional Input buses",
+      "name:8": "§b§lIntradimensional Input buses",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/SupersizedBuses-Mt25IP2aShSSUBhZ1GGItg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/SupersizedBuses-Mt25IP2aShSSUBhZ1GGItg==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Supersized Buses",
+      "name:8": "§b§lSupersized Buses",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Thesaneoption-SIqmtgRmTj-EsZlXpCdyWQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Thesaneoption-SIqmtgRmTj-EsZlXpCdyWQ==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "The sane option",
+      "name:8": "§b§lThe sane option",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Thorium232-nNTmwkdsQgyE6QAfmIwcvg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Thorium232-nNTmwkdsQgyE6QAfmIwcvg==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Thorium 232?",
+      "name:8": "§b§lThorium 232?",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Universalpickaxe-VoQ7oLYhTjuomLCz_ddOhA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Universalpickaxe-VoQ7oLYhTjuomLCz_ddOhA==.json
@@ -33,7 +33,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Universal pickaxe, Vajra",
+      "name:8": "§b§lUniversal pickaxe, Vajra",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Waitareyousure-fvz-5lJaRAqfsM1hcAYOng==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/Waitareyousure-fvz-5lJaRAqfsM1hcAYOng==.json
@@ -25,7 +25,7 @@
       "globalShare:1": 0,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Wait are you sure?",
+      "name:8": "§b§lWait are you sure?",
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,


### PR DESCRIPTION
This PR contains small fixes for some quests. Most of them fix quest names that were not in line with other quests of its tab. Examples can be seen below:
![image](https://github.com/user-attachments/assets/2c1e7126-70dc-4e54-875b-21171cd88fb0)
![image](https://github.com/user-attachments/assets/ba31b886-9866-4382-9cde-ba078acb238c)

Additionally this fixes a steam age quest that was giving an LV lootbag and the requirements unlocking the EV multis in the GT++ Tab.
![image](https://github.com/user-attachments/assets/a4256ee6-7fc9-41ed-9f8b-ce491723cc28)
![image](https://github.com/user-attachments/assets/b21247cd-73a0-4e28-899c-ba44ae36dac3)
