### PR TITLE
More small quest fixes

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Evenmorechalleng-AAAAAAAAAAAAAAAAAAABjQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Evenmorechalleng-AAAAAAAAAAAAAAAAAAABjQ==.json
@@ -26,7 +26,7 @@
       "globalShare:1": 1,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Even more challenge needed?",
+      "name:8": "§1§lEven more challenges needed?",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Goals-AAAAAAAAAAAAAAAAAAABjA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Goals-AAAAAAAAAAAAAAAAAAABjA==.json
@@ -26,7 +26,7 @@
       "globalShare:1": 1,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Goals",
+      "name:8": "§1§lGoals",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatZ-AAAAAAAAAAAAAAAAAAAK2A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/PoweroftheSunatZ-AAAAAAAAAAAAAAAAAAAK2A==.json
@@ -3,11 +3,11 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2774
+      "questIDLow:4": 2656
     },
     "1:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2665
+      "questIDLow:4": 2774
     }
   },
   "questIDLow:4": 2776,

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/MVBending-AAAAAAAAAAAAAAAAAAAEOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/MVBending-AAAAAAAAAAAAAAAAAAAEOQ==.json
@@ -59,9 +59,9 @@
       "index:3": 0,
       "rewards:9": {
         "0:10": {
-          "id:8": "IC2:itemDensePlates",
+          "id:8": "gregtech:gt.metaitem.01",
           "Count:3": 8,
-          "Damage:2": 5,
+          "Damage:2": 22305,
           "OreDict:8": ""
         },
         "1:10": {


### PR DESCRIPTION
This PR does the following:

**Fixes (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16658#issuecomment-2295240196) by changing the req to first UHV circuit quest (wetware mainframe)** 
![image](https://github.com/user-attachments/assets/d75cb057-8014-4259-940f-8507a3e69bde)
**Change MV bender to give GT dense steel plates instead of IC2 ones**
![image](https://github.com/user-attachments/assets/d8815615-abf5-4eba-b197-1d87169b5be6)
**Adjust names of two quests to match the formatting of the whole beginning tab and fix a typo**
![image](https://github.com/user-attachments/assets/eb82f0a9-a6fd-4a35-91e0-023c31823ea6)


