### PR TITLE
Add storage drawers pack configuration

### DIFF
--- a/config/StorageDrawers.cfg
+++ b/config/StorageDrawers.cfg
@@ -109,11 +109,13 @@ integration {
 
 
 packs {
-    B:enableBiomesOPlenty=true
+    # If enabled, all explicit pack options will be ignored. Packs will be enabled if their corresponding mod is present (Not including misc pack)
+    B:autoEnablePacks=true
+    B:enableBiomesOPlenty=false
     B:enableErebus=false
-    B:enableForestry=true
+    B:enableForestry=false
     B:enableMisc=true
-    B:enableNatura=true
+    B:enableNatura=false
 }
 
 

--- a/config/StorageDrawers.cfg
+++ b/config/StorageDrawers.cfg
@@ -108,6 +108,15 @@ integration {
 }
 
 
+packs {
+    B:enableBiomesOPlenty=true
+    B:enableErebus=false
+    B:enableForestry=true
+    B:enableMisc=true
+    B:enableNatura=true
+}
+
+
 upgrades {
     I:level2Mult=2
     I:level3Mult=4


### PR DESCRIPTION
This adds configuration that is being added with https://github.com/GTNewHorizons/StorageDrawers/pull/33. This controls which add-on packs are enabled in the pack.

I've disabled the Erebus add-on as that hasn't been shipped with GTNH previously. 