### PR TITLE
Adjust fuel value of Naphtha in its dedicated quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Naphtha-AAAAAAAAAAAAAAAAAAACgQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Naphtha-AAAAAAAAAAAAAAAAAAACgQ==.json
@@ -40,7 +40,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "You can process Sulfuric Naphtha to fluid Naphtha which has a burn value of 320,000 EU in the Gas Turbine. Naphtha can be used to get Ethylene for Polyethylene, but it shares this use with Refinery Gas and Light Fuel, so decide for yourself which one you want to use. \n\nIf you choose to make High-Octane Gasoline in EV and onwards, it will need a lot of Naphtha. You can also make Polycaprolactam (Nylon), which doesn\u0027t have any useful purpose yet, but it might get some in the near future."
+      "desc:8": "You can process Sulfuric Naphtha to fluid Naphtha which has a burn value of 220,000 EU in the Gas Turbine. Naphtha can be used to get Ethylene for Polyethylene, but it shares this use with Refinery Gas and Light Fuel, so decide for yourself which one you want to use. \n\nIf you choose to make High-Octane Gasoline in EV and onwards, it will need a lot of Naphtha. You can also make Polycaprolactam (Nylon), which doesn\u0027t have any useful purpose yet, but it might get some in the near future."
     }
   },
   "tasks:9": {


### PR DESCRIPTION
It was nerfed from 320 to 220. This PR fixes the quest side of it.