### PR TITLE
Fix tgregworks id conflicts

### DIFF
--- a/config/TGregworks.cfg
+++ b/config/TGregworks.cfg
@@ -46,6 +46,7 @@ enable {
     B:ConductiveIron=true
     B:ConstructionFoam=false
     B:CosmicNeutronium=false
+    B:Creon=false
     B:CrudeSteel=true
     B:CrystallineAlloy=true
     B:CrystallinePinkSlime=true
@@ -77,6 +78,7 @@ enable {
     B:EnrichedNaquadahAlloy=true
     B:Epoxid=true
     B:EpoxidFiberReinforced=true
+    B:Eternity=false
     B:Eximite=true
     B:ExtremelyUnstableNaquadah=true
     B:Fayalite=true
@@ -130,6 +132,7 @@ enable {
     B:Jasper=true
     B:Kanthal=true
     B:Knightmetal=true
+    B:LanthanumHexaboride=false
     B:Lead=true
     B:Ledox=true
     B:LithiumChloride=true
@@ -138,6 +141,7 @@ enable {
     B:Lumiium=true
     B:MAR-Ce-M200Steel=true
     B:MAR-M200Steel=true
+    B:Magmatter=false
     B:Magnalium=true
     B:MagnetoResonatic=true
     B:MagnetohydrodynamicallyConstrainedStarMatter=true
@@ -145,6 +149,7 @@ enable {
     B:Manganese=true
     B:Manyullyn=false
     B:Marble=true
+    B:Mellion=false
     B:MelodicAlloy=true
     B:MetastableOganesson=true
     B:MeteoricIron=true
@@ -152,6 +157,7 @@ enable {
     B:Midasium=true
     B:Mithril=false
     B:Molybdenum=true
+    B:Mu-metal=false
     B:MysteriousCrystal=true
     B:Mytryl=true
     B:Naquadah=true
@@ -176,6 +182,7 @@ enable {
     B:Osmium=true
     B:Oureclase=true
     B:Palladium=true
+    B:Permalloy=false
     B:PigIron=true
     B:Plastic=true
     B:Platinum=true
@@ -214,6 +221,7 @@ enable {
     B:Signalium=true
     B:Silicone=true
     B:Silver=true
+    B:SixPhasedCopper=false
     B:Soularium=true
     B:SpaceTime=true
     B:StainlessSteel=true
@@ -229,6 +237,8 @@ enable {
     B:Tairitsu=true
     B:TanmolyiumBeta-C=true
     B:Tanzanite=true
+    B:TengamAttuned=false
+    B:TengamPurified=false
     B:Terrasteel=true
     B:Thaumium=false
     B:Thorium=true
@@ -263,6 +273,10 @@ enable {
     B:Zircaloy-2=true
     B:Zircaloy-4=true
     B:Zn-ThAlloy=true
+    B:exohalkonite=false
+    B:hotexohalkonite=false
+    B:hotprotohalkonite=false
+    B:protohalkonite=false
 
     recipe {
         # Allow repairing TGregworks tools with ingots [default: false]

--- a/config/TGregworks.cfg
+++ b/config/TGregworks.cfg
@@ -521,6 +521,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=1.33
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -543,6 +544,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -567,6 +569,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=5.73
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=2.0
         D:Platinum=1.0
@@ -791,6 +794,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=1.625
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -813,6 +817,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -837,6 +842,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=2.25
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=1.0
         D:Platinum=1.0
@@ -1061,6 +1067,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=2.333
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -1083,6 +1090,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -1107,6 +1115,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=8.0
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=1.0
         D:Platinum=1.0
@@ -1331,6 +1340,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=1.0
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -1353,6 +1363,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -1377,6 +1388,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=1.0
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=1.0
         D:Platinum=1.0
@@ -1602,6 +1614,7 @@ materials {
         I:Jasper=0
         I:Kanthal=0
         I:Knightmetal=0
+        I:LanthanumHexaboride=0
         I:Lead=0
         I:Ledox=0
         I:LithiumChloride=0
@@ -1624,6 +1637,7 @@ materials {
         I:Midasium=0
         I:Mithril=0
         I:Molybdenum=0
+        I:Mu-metal=0
         I:MysteriousCrystal=0
         I:Mytryl=0
         I:Naquadah=0
@@ -1648,6 +1662,7 @@ materials {
         I:Osmium=0
         I:Oureclase=0
         I:Palladium=0
+        I:Permalloy=0
         I:PigIron=0
         I:Plastic=0
         I:Platinum=0
@@ -1873,6 +1888,7 @@ materials {
         I:Jasper=0
         I:Kanthal=0
         I:Knightmetal=0
+        I:LanthanumHexaboride=0
         I:Lead=0
         I:Ledox=0
         I:LithiumChloride=0
@@ -1895,6 +1911,7 @@ materials {
         I:Midasium=0
         I:Mithril=0
         I:Molybdenum=0
+        I:Mu-metal=0
         I:MysteriousCrystal=0
         I:Mytryl=0
         I:Naquadah=0
@@ -1919,6 +1936,7 @@ materials {
         I:Osmium=2
         I:Oureclase=0
         I:Palladium=0
+        I:Permalloy=0
         I:PigIron=0
         I:Plastic=0
         I:Platinum=0
@@ -2143,6 +2161,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=1.0
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -2165,6 +2184,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -2189,6 +2209,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=1.0
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=0.5
         D:Platinum=1.0
@@ -2413,6 +2434,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=1.0
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -2435,6 +2457,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -2459,6 +2482,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=1.0
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=5.6
         D:Platinum=1.0
@@ -2683,6 +2707,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=0.21408
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -2705,6 +2730,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -2729,6 +2755,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=0.188679
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=1.0
         D:Platinum=1.0
@@ -2953,6 +2980,7 @@ materials {
         D:Jasper=1.0
         D:Kanthal=1.0
         D:Knightmetal=0.01
+        D:LanthanumHexaboride=1.0
         D:Lead=1.0
         D:Ledox=1.0
         D:LithiumChloride=1.0
@@ -2975,6 +3003,7 @@ materials {
         D:Midasium=1.0
         D:Mithril=1.0
         D:Molybdenum=1.0
+        D:Mu-metal=1.0
         D:MysteriousCrystal=1.0
         D:Mytryl=1.0
         D:Naquadah=1.0
@@ -2999,6 +3028,7 @@ materials {
         D:Osmium=1.0
         D:Oureclase=1.0
         D:Palladium=0.01
+        D:Permalloy=1.0
         D:PigIron=1.0
         D:Plastic=1.0
         D:Platinum=1.0
@@ -3219,6 +3249,7 @@ materials {
         I:Jasper=1571
         I:Kanthal=1601
         I:Knightmetal=1626
+        I:LanthanumHexaboride=1542
         I:Lead=1507
         I:Ledox=1654
         I:LithiumChloride=1724
@@ -3238,6 +3269,7 @@ materials {
         I:MeteoricIron=1572
         I:MeteoricSteel=1573
         I:Molybdenum=1509
+        I:Mu-metal=1540
         I:MysteriousCrystal=1676
         I:Mytryl=1656
         I:Naquadah=1574
@@ -3262,6 +3294,7 @@ materials {
         I:Osmium=1513
         I:Oureclase=1580
         I:Palladium=1514
+        I:Permalloy=1539
         I:PigIron=1605
         I:Plastic=1606
         I:Platinum=1515


### PR DESCRIPTION
I turned off tinker mats for the new materials as they were not actually desired.
The bw ones still decided they need id/properties when loading it ingame.