### PR TITLE
Re-enable mutatron for indium bee

### DIFF
--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,6 +182,7 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
+    "gregtech.bee.speciesIndium" = REQUIREMENTS
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinitycatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED

--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -185,7 +185,6 @@ cfg Genetics {
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinitycatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED
-	"gregtech.bee.speciesIndium" = DISABLED
 	"gregtech.bee.speciesAmericium" = DISABLED
 	"gregtech.bee.speciesEuropium" = DISABLED
 	"gregtech.bee.speciesKevlar" = REQUIREMENTS

--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -182,7 +182,6 @@ cfg Genetics {
     "forestry.speciesTipsy" = REQUIREMENTS
     "forestry.speciesTricky" = REQUIREMENTS
     "extrabees.species.chad" = REQUIREMENTS
-    "gregtech.bee.speciesIndium" = REQUIREMENTS
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinitycatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED


### PR DESCRIPTION
After https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/967, the indium bee is not as overpowered as it was before, so the mutatron blacklist is not necessary anymore.