### PR TITLE
Create Trigger Quest: Nether Skip

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
@@ -1,0 +1,61 @@
+{
+  "questIDHigh:4": -6316535045498188988,
+  "preRequisites:9": {
+    "0:10": {
+      "questIDHigh:4": 0,
+      "questIDLow:4": 65
+    }
+  },
+  "questIDLow:4": -5649038508759348891,
+  "properties:10": {
+    "betterquesting:10": {
+      "snd_complete:8": "random.levelup",
+      "taskLogic:8": "AND",
+      "visibility:8": "NORMAL",
+      "isMain:1": 0,
+      "simultaneous:1": 0,
+      "icon:10": {
+        "id:8": "gregtech:gt.metaitem.01",
+        "Count:3": 1,
+        "Damage:2": 11880,
+        "OreDict:8": ""
+      },
+      "snd_update:8": "random.levelup",
+      "repeatTime:3": -1,
+      "globalShare:1": 0,
+      "questLogic:8": "AND",
+      "repeat_relative:1": 1,
+      "name:8": "Trigger:Nether Skip",
+      "lockedProgress:1": 0,
+      "autoClaim:1": 1,
+      "isSilent:1": 0,
+      "desc:8": "No Description"
+    }
+  },
+  "tasks:9": {
+    "0:10": {
+      "partialMatch:1": 1,
+      "autoConsume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 0,
+      "consume:1": 0,
+      "requiredItems:9": {
+        "0:10": {
+          "id:8": "gregtech:gt.metaitem.01",
+          "Count:3": 128,
+          "Damage:2": 11880,
+          "OreDict:8": ""
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    }
+  },
+  "rewards:9": {
+    "0:10": {
+      "questID:8": "AAAAAAAAAAAAAAAAAAAARQ\u003d\u003d",
+      "rewardID:8": "bq_standard:questcompletion",
+      "index:3": 0
+    }
+  }
+}

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
@@ -11,7 +11,7 @@
     "betterquesting:10": {
       "snd_complete:8": "random.levelup",
       "taskLogic:8": "AND",
-      "visibility:8": "NORMAL",
+      "visibility:8": "HIDDEN",
       "isMain:1": 0,
       "simultaneous:1": 0,
       "icon:10": {


### PR DESCRIPTION
Note: This was written in 2.6.1's questbook, and I have not written a quest before. I tried to match how other quests were made in the discord, so there might need to be edits to fix this.


This adds a Trigger Quest to skip "THE NETHER" & "How To Make Rubber" by obtaining 128 Rubber Bars in your inventory. Doing so will unlock "Wire-Wrap".

This is so players who decided to progress through the steam age without going to the nether (fear of nether mobs, wanting to build renewable methods early through XP Buckets, etc.) can still progress through the questbook.