### PR TITLE
Disable PostNeidWorldsSupport by default in NotEnoughIDs

### DIFF
--- a/config/NEID.cfg
+++ b/config/NEID.cfg
@@ -1,0 +1,15 @@
+# Configuration file
+
+neid {
+    # Causes a crash when a block has not been registered(e.g. has an id of -1) [default: false]
+    B:CatchUnregisteredBlocks=false
+
+    # Extend DataWatch IDs. Vanilla limit is 31, new limit is 127. [default: false]
+    B:ExtendDataWatcher=false
+
+    # If true, only blocks with IDs > 4095 will disappear after removing NEID. Metadatas outside of the range 0-15 will be set to 0. [default: true]
+    B:PostNeidWorldsSupport=false
+
+    # Remove invalid (corrupted) blocks from the game. [default: false]
+    B:RemoveInvalidBlocks=false
+}


### PR DESCRIPTION
NotEnoughIDs has an option called `PostNeidWorldsSupport` which enables additionally saving the blocks and metadata which can be, in the vanilla format(blocks which cannot be saved in that manner are simply replaced with air if over the block ID limit, or meta value 0 if over the meta limit). This enables worlds saved with NEID to be able to be opened(albeit likely broken, but in a way that won't crash) without NEID being present.

The important thing to note about this change, is that GTNH worlds will no longer be able to be opened at all without NEID present, as the `Blocks` and `Data` tags in the NBT are no longer present in the save file at all, and are replaced by NEID's `Blocks16` and `Data16`.

This option is on by default in NotEnoughIDs, but that doesn't really make much sense for GTNH and adds extra memory and world saving overhead. Especially with hard dependencies in GTNH on the metadata now it really doesn't make sense to use.