### PR TITLE
remove duplicate items from railcraft

### DIFF
--- a/config/railcraft/items.cfg
+++ b/config/railcraft/items.cfg
@@ -38,7 +38,7 @@ items {
     B:cart.track.relayer=true
     B:cart.undercutter=true
     B:cart.work=true
-    B:dust=true
+    B:dust=false
     B:emblem=true
     B:firestone.cracked=true
     B:firestone.cut=true
@@ -53,11 +53,11 @@ items {
     B:fluid.steam.bottle=true
     B:fuel.coke=true
     B:ic2.upgrade.lapotron=true
-    B:ingot=true
-    B:nugget=true
+    B:ingot=false
+    B:nugget=false
     B:part.circuit=true
     B:part.gear=true
-    B:part.plate=true
+    B:part.plate=false
     B:part.rail=true
     B:part.railbed=true
     B:part.rebar=true


### PR DESCRIPTION
removes railcraft items for:
- obsidian, sulfur, saltpeter, charcoal dust
- iron, steel, tin, copper, lead plate
- steel, copper, tin, lead ingot
- iron, steel, tin, copper, lead nugget

those all exist in gt.

this also removes a bunch of colliding recipes.