### PR TITLE
Add T9 planet meteor

### DIFF
--- a/config/BloodMagic/meteors/T9Ores.json
+++ b/config/BloodMagic/meteors/T9Ores.json
@@ -1,0 +1,15 @@
+{
+  "ores": [
+    "oreAwakenedDraconium", "1000",
+    "oreNeodymium", "500",
+    "oreSamarium", "300",
+    "oreNetherStar", "250",
+    "oreTartarite", "60",
+    "oreTengamRaw", "1"
+  ],
+  "radius": 16,
+  "cost": 1000000001,
+  "focusModId": "gregtech",
+  "focusName": "gt.blockmachines",
+  "focusMeta": 14009
+}


### PR DESCRIPTION
The main purpose of this meteor is providing an expensive no-rocket source of tartarite. Tartarite is required for progressing into UIV, and my PR adding Proto-Halkonite to UIV components accidentally killed off all no space runs, making them end at UIV. Now, I am very well aware no-space and challenge runs are unsupported, however

- My intention with Proto-Halkonite was never to kill no-space.
- Just because it is not officially supported doesn't mean no devs care about adding in some support for the content they provided.
- This meteor is quite expensive, coming in at a full Mk3 Space Mining Module (late UEV, pricy), making it not really worth using for anyone except out of necessity.
- In similar fashion, after a very long debate, a Tengam meteor was added a while ago. If that meteor can exist, then this one has just as much right to. I'd like to avoid the long debate here if possible, though I know additions like this are somewhat controversial.

![image](https://github.com/user-attachments/assets/6cd257fe-d0ad-4de1-8283-31be0dbf1186)
