### PR TITLE
Nerf steam multi quests to prevent skipping proper steel production early

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Asteampoweredwhi-0rUmaWIPQPaL93q-_pgKXw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Asteampoweredwhi-0rUmaWIPQPaL93q-_pgKXw==.json
@@ -123,7 +123,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Moresteammorepre-Plg8vg0gS9Ks2Ddc5sIVOg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Moresteammorepre-Plg8vg0gS9Ks2Ddc5sIVOg==.json
@@ -99,7 +99,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Pressurewashing-zorY0c3BQuqLJp7ThOLG-g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Pressurewashing-zorY0c3BQuqLJp7ThOLG-g==.json
@@ -123,7 +123,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/SteamBlender-WEwrzX4ZRkSxJ3M6cBesfA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/SteamBlender-WEwrzX4ZRkSxJ3M6cBesfA==.json
@@ -111,7 +111,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Steamstomping-s6AEHSKiQe2XveT_oDZbZg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Steamstomping-s6AEHSKiQe2XveT_oDZbZg==.json
@@ -111,7 +111,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 1,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/SteamyMincer-AAAAAAAAAAAAAAAAAAAKzA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/SteamyMincer-AAAAAAAAAAAAAAAAAAAKzA==.json
@@ -99,7 +99,7 @@
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 11305,
           "OreDict:8": ""
         },


### PR DESCRIPTION
8 steel -> 4 steel. Fixes one quest that i set to 1 steel too.
For more details on why: https://discord.com/channels/181078474394566657/949447391587733504/1287721952970276956