### PR TITLE
Use SU for backups

### DIFF
--- a/config/aroma1997/Aroma1997Core.cfg
+++ b/config/aroma1997/Aroma1997Core.cfg
@@ -1,6 +1,0 @@
-# Configuration file
-
-general {
-    # If Aroma1997Core should run a VersionCheck.
-    B:checkVersion=false
-}

--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -50,7 +50,7 @@ backups {
     B:display_file_size=true
 
     # Enables backups.
-    B:enable_backups=false
+    B:enable_backups=true
 
     # Backups won't run if no players are online.
     B:need_online_players=true
@@ -71,7 +71,7 @@ chat {
 
 commands {
     B:back=false
-    B:backup=false
+    B:backup=true
     B:chunks=false
     B:dump_chunkloaders=false
     B:dump_permissions=true


### PR DESCRIPTION
We now want to use server utilities for backups and remove aroma backup+aroma core.

it's requested by boubou and also dream approved: https://discord.com/channels/181078474394566657/603348502637969419/1290679475461423154

_note_ that this includes servers where aroma was never on. But if someone doesnt want it they can turn it off easily enough.