### PR TITLE
Buff Hydroponics Unit.

### DIFF
--- a/config/GalacticraftAmunRa.cfg
+++ b/config/GalacticraftAmunRa.cfg
@@ -18,7 +18,7 @@ general {
     B:generateOres=false
 
     # Multiplier for the oxygen production of the hydroponics unit [range: 1.4E-45 ~ 3.4028235E38, default: 1.0]
-    S:hydroponicsFactor=1.0
+    S:hydroponicsFactor=5.0
 }
 
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17549.

Some numbers for context:

Oxygen Collector produces 0.75 units of oxygen per 10 ticks per leaf block, at a cost of 6 RF/t.
Hydroponics Unit produces 3 units of oxygen per 10 ticks, at a cost of 3 RF/t.

This PR buffs the Hydroponics Unit by a factor of 5, for a total of 15 oxygen units per 10 ticks. Energy cost is unchanged. (It is not configurable, would require a PR to Amun-Ra, and since it is so absurdly trivial I don't see a point.)

Number of oxygen generators needed to keep up with various oxygen consumers:

| Consumer  | Oxygen required per second | Collector (num. of leaves) | Hydroponics (old) | Hydroponics (new) |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Oxygen Compressor | 20(*) | 27 | 7 | 2 |
| Oxygen Bubble Distributor | 80 | 107 | 27 | 6 |
| Oxygen Sealer (sealed) | 40 | 54 | 14 | 3 |
| Oxygen Sealer (unsealed) | 120 | 160 | 40 | 8 |

(\*) Can run with less, it will just fill tanks slower.

Hydroponics Unit is gated behind Naquadah wafers and T4 rocket (needs Mithril, which is not available from meteors and must be mined from T4 planets). At the point in the game when you actually unlock it it is also very cheap to make. Thus all this buff does is reduces the number of units you need to spam to keep up with oxygen consumption for your base or station. You will still need more than one (realistically how much oxygen does one wheat plant produce), but it will be a meaningful upgrade over just dumping a pile of leaves in a corner somewhere.