### PR TITLE
Oc transistor achievement fix

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/SFMandComputers-AAAAAAAAAAAAAAAAAAAAHw==/Tier1-AAAAAAAAAAAAAAAAAAAG3w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SFMandComputers-AAAAAAAAAAAAAAAAAAAAHw==/Tier1-AAAAAAAAAAAAAAAAAAAG3w==.json
@@ -51,7 +51,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Congratulations, we have the parts to start making a computer!\n\nLet\u0027s start with the basics here."
+      "desc:8": "Congratulations, we have the parts to start making a computer!\n\nLet\u0027s start with the basics here.\n\n[note]Since you can\u0027t craft OC Transistors anymore here is a spare one for your achievemt hunting.[/note]"
     }
   },
   "tasks:9": {
@@ -69,6 +69,12 @@
           "id:8": "enhancedlootbags:lootbag",
           "Count:3": 1,
           "Damage:2": 46,
+          "OreDict:8": ""
+        },
+        "1:10": {
+          "id:8": "OpenComputers:item",
+          "Count:3": 1,
+          "Damage:2": 23,
           "OreDict:8": ""
         }
       }

--- a/config/betterquesting/DefaultQuests/Quests/SFMandComputers-AAAAAAAAAAAAAAAAAAAAHw==/Tier1-AAAAAAAAAAAAAAAAAAAG3w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SFMandComputers-AAAAAAAAAAAAAAAAAAAAHw==/Tier1-AAAAAAAAAAAAAAAAAAAG3w==.json
@@ -51,7 +51,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Congratulations, we have the parts to start making a computer!\n\nLet\u0027s start with the basics here.\n\n[note]Since you can\u0027t craft OC Transistors anymore here is a spare one for your achievemt hunting.[/note]"
+      "desc:8": "Congratulations, we have the parts to start making a computer!\n\nLet\u0027s start with the basics here."
     }
   },
   "tasks:9": {

--- a/config/opencomputers/gtnh.recipes
+++ b/config/opencomputers/gtnh.recipes
@@ -228,7 +228,7 @@ arrowKeys = false
 
 numPad = false
 
-transistor = false
+transistor = true
 
 chip1 = true
 

--- a/config/opencomputers/gtnh.recipes
+++ b/config/opencomputers/gtnh.recipes
@@ -228,7 +228,10 @@ arrowKeys = false
 
 numPad = false
 
-transistor = true
+transistor = {
+	type: shapeless
+	input: [{item="gt.metaitem.01", subID=32717}]
+}
 
 chip1 = true
 


### PR DESCRIPTION
I am not sure how many players out there want to get any achievement possible but at last I am one of them.
Now I found out that the OC Transistor is fully disabled since we have the GT Transistor which all makes sense.

Sadly the linked OC Achievement wasn't altered or maybe it got forgotten about it so I thought over this and have had the following ideas (every idea foreces to re-enable the OC Transistor which I am not going to mention twice):

1. _Add in `gtnh.recipes` a simple shapeless recipe to transform GT Transistor into OC Transistor:_
**Pro**: Simply implemented
**Contra**: Whever cares about loosing at last one GT Transistor wouldn't be able to do a shapeless backcrafting since this would require a shapless recipie with RA2 in the corresponding mod. So it would be one way ticket.

2. _Change within OC directly the tracking of GT Transistor instead of OC Transistor:_
**Pro**: Wouldn't require to re-enable the OC Transistor
**Contra**: I'm not aware of how todo this within scala which would require one of the Dev's with the knowledge here. Since this is then handled as a realy minor thing compared to other bugs and stuff it would take ages to be done.

3. _Alter one of all these OC Questline and give it as reward instead:_
**Pro**: It does not even need to alter `gtnh.recipes` file with an recipe instead of a simple `false -> true` switch. Also editing a quest and add it as a reward seem to be ledgit too.
**Contra**: I do not see any real contra here besides that one quest has to be edited.

I decided to go with option 3 as it make from my side more sense and looks also much cleaner. You aren't wasting a poor GT Transistor here - well, who would care anyways - and you also don't have to add recipes.

The quest I edited here was `SFM and Computers -> Tier 1` so you've had todo some initial stuff before getting the OC Transistor to complete the achievement for it. It feels comfortable for me because at last I've done some initial stuff instead of getting it just right know trough the quest `Welcome to OpenComputers!` - at last this is my personal meaning here.

I also added a note to this within the quests text.

It would be nice to get this merged officialy. I tested the affected quest and it worked. Images below.
If there are any questions or concernce about this PR still left, feel free to comment, thanks :)

Broken Achievement:

![image](https://github.com/user-attachments/assets/cba9b47d-7e48-44ca-915d-5ce641320df1)

Quest which was edited for this (SFM and Computers -> Tier 1):

![image](https://github.com/user-attachments/assets/405d4d28-aa33-405b-aa8e-df2b9be21efa)
![image](https://github.com/user-attachments/assets/898e7706-8054-48a3-a176-31896d47c8bf)
