### PR TITLE
Update InGameInfo.xml - Adding center chunk icon & removing unecessaey chunk checks

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -1039,10 +1039,10 @@
                     </equal>
                 </and>
                 <concat>
-					<icon>
-                        <str>tinker:textures/items/parts/obsidian_toughbind.png</str>
-                    </icon>
-                    <str> You are at the {darkred}center {white}of the chunk.</str>
+                        <icon>
+                                <str>tinker:textures/items/parts/obsidian_toughbind.png</str>
+                        </icon>
+                <str> You are at the {darkred}center {white}of the chunk.</str>
                 </concat>
             </if>
         </line>

--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -1039,44 +1039,10 @@
                     </equal>
                 </and>
                 <concat>
-                    <if>
-                        <and>
-                            <or>
-                                <equal>
-                                    <modi>
-                                        <var>chunkx</var>
-                                        <num>3</num>
-                                    </modi>
-                                    <num>-1</num>
-                                </equal>
-                                <equal>
-                                    <modi>
-                                        <var>chunkx</var>
-                                        <num>3</num>
-                                    </modi>
-                                    <num>1</num>
-                                </equal>
-                            </or>
-                            <or>
-                                <equal>
-                                    <modi>
-                                        <var>chunkz</var>
-                                        <num>3</num>
-                                    </modi>
-                                    <num>-1</num>
-                                </equal>
-                                <equal>
-                                    <modi>
-                                        <var>chunkz</var>
-                                        <num>3</num>
-                                    </modi>
-                                    <num>1</num>
-                                </equal>
-                            </or>
-                        </and>
-                        <str>      </str>
-                    </if>
-                    <str>   You are at the {darkred}center {white}of the chunk.</str>
+					<icon>
+                        <str>tinker:textures/items/parts/obsidian_toughbind.png</str>
+                    </icon>
+                    <str> You are at the {darkred}center {white}of the chunk.</str>
                 </concat>
             </if>
         </line>


### PR DESCRIPTION
Noticed that the current .xml file has an unnecessary chunk coordinate check (chunk coordinates, not relative coordinates within a chunk) for the "center of the chunk" line. I removed that part and added in the obsidian tough binding icon to be placed next to this line.

I would've added some sort of red tough binding icon but I could not figure out the proper file path for like an ignis tough binding. So obsidian it is.

Also uhhh ignore that second commit. I tried to fix one of the lines using a different tab size but it literally did nothing and could still be saved as a commit so /shrug