### PR TITLE
Enable a few SU options

### DIFF
--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -85,10 +85,10 @@ commands {
     B:backup=true
 
     #  [default: true]
-    B:chunks=false
+    B:chunks=true
 
     #  [default: true]
-    B:dump_chunkloaders=false
+    B:dump_chunkloaders=true
 
     #  [default: true]
     B:dump_permissions=true
@@ -109,28 +109,28 @@ commands {
     B:home=false
 
     #  [default: true]
-    B:inv=false
+    B:inv=true
 
     #  [default: true]
     B:kickme=false
 
     #  [default: true]
-    B:killall=false
+    B:killall=true
 
     #  [default: true]
-    B:leaderboard=false
+    B:leaderboard=true
 
     #  [default: true]
     B:mute=false
 
     #  [default: true]
-    B:nbtedit=false
+    B:nbtedit=true
 
     #  [default: true]
     B:nick=false
 
     #  [default: true]
-    B:ranks=false
+    B:ranks=true
 
     #  [default: true]
     B:rec=false
@@ -148,7 +148,7 @@ commands {
     B:tpa=false
 
     #  [default: true]
-    B:tpl=false
+    B:tpl=true
 
     #  [default: true]
     B:trash_can=true
@@ -291,7 +291,7 @@ world {
     B:chunk_claiming=false
 
     # Enables chunk loading. If chunk_claiming is set to false, changing this won't do anything. [default: true]
-    B:chunk_loading=false
+    B:chunk_loading=true
 
     # Disables player damage when they are stuck in walls. [default: false]
     B:disable_player_suffocation_damage=false

--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -1,30 +1,27 @@
 # Configuration file
 
 afk {
-    # Enables afk timer.
+    # Enables afk timer. [default: true]
     B:enabled=true
 
-    # Enables afk timer in singleplayer.
+    # Enables afk timer in singleplayer. [default: true]
     B:enabled_singleplayer=true
 
-    # Will print in console when someone goes/comes back from AFK.
-    B:log_afk=false
-
-    # After how much time it will display notification to all players.
-    S:notificationTimer=5m
+    # After how much time it will display notification to all players. [default: 5m]
+    S:notification_timer=5m
 }
 
 
 auto_shutdown {
-    # Enables auto-shutdown.
+    # Enables auto-shutdown. [default: false]
     B:enabled=false
 
-    # Enables auto-shutdown in singleplayer worlds.
+    # Enables auto-shutdown in singleplayer worlds. [default: false]
     B:enabled_singleplayer=false
 
     # Server will automatically shut down after X hours.
     # Time Format: HH:MM. If the system time matches a value, server will shut down.
-    # It will look for closest value available that is not equal to current time.
+    # It will look for closest value available that is not equal to current time. [default: [04:00], [16:00]]
     S:times <
         04:00
         16:00
@@ -33,262 +30,362 @@ auto_shutdown {
 
 
 backups {
-    # Path to backups folder.
+    # Path to backups folder. [default: ./backups/]
     S:backup_folder_path=./backups/
 
     # Time between backups in hours. 
-    # 1.0 - backups every hour 6.0 - backups every 6 hours 0.5 - backups every 30 minutes.
+    # 1.0 - backups every hour 6.0 - backups every 6 hours 0.5 - backups every 30 minutes. [range: 4.9E-324 ~ 1.7976931348623157E308, default: 0.5]
     S:backup_timer=0.5
 
-    # Number of backup files to keep before deleting old ones.
+    # Number of backup files to keep before deleting old ones. [range: -2147483648 ~ 2147483647, default: 12]
     I:backups_to_keep=12
 
-    # How much the backup file will be compressed. 1 - best speed 9 - smallest file size.
+    # How much the backup file will be compressed. 1 - best speed 9 - smallest file size. [range: -2147483648 ~ 2147483647, default: 1]
     I:compression_level=1
 
-    # Prints (current size | total size) when backup is done
+    # Delete backups that have a custom name set through /backup start <name> [default: true]
+    B:delete_custom_name_backups=true
+
+    # Prints (current size | total size) when backup is done [default: true]
     B:display_file_size=true
 
-    # Enables backups.
+    # Enables backups. [default: true]
     B:enable_backups=true
 
-    # Backups won't run if no players are online.
+    # Max size of backup folder in GB. If total folder size exceeds this value it will delete old backups until the size is under.
+    # 0 = Disabled and backups_to_keep will be used instead. [range: -2147483648 ~ 2147483647, default: 0]
+    I:max_folder_size=0
+
+    # Backups won't run if no players are online. [default: true]
     B:need_online_players=true
 
-    # Silence backup notifications.
+    # Only include claimed chunks in backup.
+    # Backups will be much faster and smaller, but any unclaimed chunk will be unrecoverable. [default: false]
+    B:only_backup_claimed_chunks=false
+
+    # Silence backup notifications. [default: false]
     B:silent_backup=false
 
-    # Run backup in a separated thread (recommended)
+    # Run backup in a separated thread (recommended) [default: true]
     B:use_separate_thread=true
 }
 
 
 chat {
-    # Adds ~ to player names that have changed nickname to prevent trolling.
+    # Adds ~ to player names that have changed nickname to prevent trolling. [default: false]
     B:add_nickname_tilde=false
 }
 
 
 commands {
+    #  [default: true]
     B:back=false
+
+    #  [default: true]
     B:backup=true
+
+    #  [default: true]
     B:chunks=false
+
+    #  [default: true]
     B:dump_chunkloaders=false
+
+    #  [default: true]
     B:dump_permissions=true
+
+    #  [default: true]
+    B:dump_stats=true
+
+    #  [default: true]
     B:fly=false
+
+    #  [default: true]
     B:god=false
+
+    #  [default: true]
     B:heal=false
+
+    #  [default: true]
     B:home=false
+
+    #  [default: true]
     B:inv=false
+
+    #  [default: true]
     B:kickme=false
+
+    #  [default: true]
     B:killall=false
+
+    #  [default: true]
     B:leaderboard=false
+
+    #  [default: true]
     B:mute=false
+
+    #  [default: true]
     B:nbtedit=false
+
+    #  [default: true]
     B:nick=false
+
+    #  [default: true]
     B:ranks=false
+
+    #  [default: true]
     B:rec=false
+
+    #  [default: true]
+    B:reload=true
+
+    #  [default: true]
     B:rtp=false
+
+    #  [default: true]
     B:spawn=false
+
+    #  [default: true]
     B:tpa=false
+
+    #  [default: true]
     B:tpl=false
+
+    #  [default: true]
     B:trash_can=true
+
+    #  [default: true]
     B:warp=false
 }
 
 
-##########################################################################################################
-# debugging
-#--------------------------------------------------------------------------------------------------------#
-# Don't set any values to true, unless you are debugging the mod.
-##########################################################################################################
-
 debugging {
-    # See dev-only sidebar buttons. They probably don't do anything.
+    # See dev-only sidebar buttons. They probably don't do anything. [default: false]
     B:dev_sidebar_buttons=false
 
-    # See GUI widget bounds when you hold B.
+    # See GUI widget bounds when you hold B. [default: false]
     B:gui_widget_bounds=false
 
-    # Print a message in console every time a chunk is forced or unforced. Recommended to be off, because spam.
+    # Print a message in console every time a chunk is forced or unforced. Recommended to be off, because spam. [default: false]
     B:log_chunkloading=false
 
-    # Log config editing.
+    # Log config editing. [default: false]
     B:log_config_editing=false
 
-    # Log all events that extend EventBase.
+    # Log all events that extend EventBase. [default: false]
     B:log_events=false
 
-    # Log incoming and outgoing network messages.
+    # Log incoming and outgoing network messages. [default: false]
     B:log_network=false
 
-    # Log player teleporting.
+    # Log player teleporting. [default: false]
     B:log_teleport=false
 
-    # Print more errors.
+    # Print more errors. [default: false]
     B:print_more_errors=false
 
-    # Print more info.
+    # Print more info. [default: false]
     B:print_more_info=false
 
-    # Enables special debug commands.
+    # Enables special debug commands. [default: false]
     B:special_commands=false
 }
 
 
 general {
     # Merges player profiles, in case player logged in without internet connection/in offline mode server. If set to DEFAULT, it will only merge on singleplayer worlds.
-    S:merge_offline_mode_players=true
-
-    # This will replace /reload with ServerUtilities version of it.
-    B:replace_reload_command=true
+    # Possible values: [TRUE, FALSE, DEFAULT]
+    #  [default: TRUE]
+    S:merge_offline_mode_players=TRUE
 }
 
 
 login {
-    # Enables message of the day.
+    # Enables message of the day. [default: false]
     B:enable_motd=false
 
-    # Enables starting items.
+    # Enables starting items. [default: false]
     B:enable_starting_items=false
 
-    # Message of the day. This will be displayed when player joins the server.
+    # Message of the day. This will be displayed when player joins the server. [default: ["Hello player!"]]
     S:motd <
         "Hello player!"
      >
 
     # Items to give player when they first join the server.
-    # Format: '{id:"ID",Count:X,Damage:X,tag:{}}', Use /print_item to get NBT of item in your hand.
+    # Format: '{id:"ID",Count:X,Damage:X,tag:{}}', Use /print_item to get NBT of item in your hand. [default: [{id:"minecraft:stone_sword",Count:1,Damage:1,tag:{display:{Name:"Epic Stone Sword"}}}]]
     S:starting_items <
      >
 }
 
 
 ranks {
-    # Enables ranks and adds command.x permissions and allows ranks to control them.
+    # Add permissions for commands and allow them to be controlled by ranks. [default: true]
+    B:command_permissions=true
+
+    # Enables Ranks. [default: true]
     B:enabled=false
 
-    # Adds chat colors/rank-specific syntax.
+    # Adds chat colors/rank-specific syntax. [default: true]
     B:override_chat=true
-
-    # Allow to configure commands with ranks. Disable this if you want to use other permission mod for that.
-    B:override_commands=true
 }
 
 
-team {
-    # Automatically creates a team for player on multiplayer, based on their username and with a random color.
+tasks {
+
+    cleanup {
+        # Enables periodic removal of entities [default: false]
+        B:enabled=false
+
+        # Include experience orbs in cleanup [default: true]
+        B:experience=true
+
+        # Include hostile mobs in cleanup [default: true]
+        B:hostiles=true
+
+        # How often the cleanup should run in hours [range: 4.9E-324 ~ 1.7976931348623157E308, default: 2.0]
+        D:interval=2.0
+
+        # Include items on the ground in cleanup [default: true]
+        B:items=true
+
+        # Include passive mobs in cleanup [default: false]
+        B:passives=false
+
+        # Silence cleanup warning that are sent prior to starting [default: false]
+        B:silent=false
+    }
+
+}
+
+
+teams {
+    # Automatically creates a team for player on multiplayer, based on their username and with a random color. [default: false]
     B:autocreate_mp=false
 
-    # Automatically creates (or joins) a team on singleplayer/LAN with ID 'singleplayer'.
+    # Automatically creates (or joins) a team on singleplayer/LAN with ID 'singleplayer'. [default: true]
     B:autocreate_sp=true
+
+    # Disable teams entirely [default: false]
     B:disable_teams=false
 
-    # Disable no team notification entirely.
+    # Forces player chat messages to be prefixed with their team name. Example: [Team] <Player> Message [default: false]
+    B:force_team_prefix=false
+
+    # Don't allow other players to break blocks in claimed chunks [default: true]
+    B:grief_protection=true
+
+    # Disable no team notification entirely. [default: false]
     B:hide_team_notification=false
+
+    # Don't allow other players to interact with blocks in claimed chunks [default: true]
+    B:interaction_protection=true
 }
 
 
 world {
-    # Dimensions where chunk claiming isn't allowed.
+    # Dimensions where chunk claiming isn't allowed. [default: []]
     I:blocked_claiming_dimensions <
      >
 
-    # Enables chunk claiming.
+    # Enables chunk claiming. [default: true]
     B:chunk_claiming=false
 
-    # Enables chunk loading. If chunk_claiming is set to false, changing this won't do anything.
+    # Enables chunk loading. If chunk_claiming is set to false, changing this won't do anything. [default: true]
     B:chunk_loading=false
 
-    # Disables player damage when they are stuck in walls.
+    # Disables player damage when they are stuck in walls. [default: false]
     B:disable_player_suffocation_damage=false
 
     # List of items that will have right-click function disabled on both sides.
     # You can use '/inv disable_right_click' command to do with from in-game.
-    # Syntax: modid:item:metadata. Set metadata to * to ignore it.
+    # Syntax: modid:item:metadata. Set metadata to * to ignore it. [default: []]
     S:disabled_right_click_items <
      >
 
-    # If set to DEFAULT, then teams can decide their Explosion setting.
-    S:enable_explosions=true
+    # Allowed values:
+    # DEFAULT = Teams can decide their explosion setting
+    # TRUE = Explosions on for everyone.
+    # FALSE = Explosions disabled for everyone.
+    # Possible values: [TRUE, FALSE, DEFAULT]
+    #  [default: DEFAULT]
+    S:enable_explosions=TRUE
 
-    # If set to DEFAULT, then players can decide their PVP status.
-    S:enable_pvp=true
+    # Allowed values:
+    # DEFAULT = Players can choose their own PVP status.
+    # TRUE = PVP on for everyone.
+    # FALSE = PVP disabled for everyone.
+    # Possible values: [TRUE, FALSE, DEFAULT]
+    #  [default: DEFAULT]
+    S:enable_pvp=TRUE
 
     # Locked time in ticks in spawn dimension.
     # -1 - Disabled
     # 0 - Morning
     # 6000 - Noon
     # 12000 - Evening
-    # 18000 - Midnight
+    # 18000 - Midnight [range: -1 ~ 23999, default: -1]
     I:forced_spawn_dimension_time=-1
 
     # Locked weather type in spawn dimension.
     # -1 - Disabled
     # 0 - Clear
     # 1 - Raining
-    # 2 - Thunderstorm
+    # 2 - Thunderstorm [range: -1 ~ 2, default: -1]
     I:forced_spawn_dimension_weather=-1
 
-    # Max /rtp distance
+    # Max /rtp distance [range: 4.9E-324 ~ 1.7976931348623157E308, default: 100000.0]
     D:rtp_max_distance=100000.0
 
-    # Max tries /rtp does before failure.
+    # Max tries /rtp does before failure. [range: -2147483648 ~ 2147483647, default: 200]
     I:rtp_max_tries=200
 
-    # Min /rtp distance
+    # Min /rtp distance [range: 4.9E-324 ~ 1.7976931348623157E308, default: 1000.0]
     D:rtp_min_distance=1000.0
 
-    # If set to true, explosions and hostile mobs in spawn area will be disabled, players won't be able to attack each other in spawn area.
+    # If set to true, explosions and hostile mobs in spawn area will be disabled, players won't be able to attack each other in spawn area. [default: false]
     B:safe_spawn=false
 
-    # Show play time in corner.
+    # Show play time in corner. [default: false]
     B:show_playtime=false
 
-    # Enable spawn area in singleplayer.
+    # Enable spawn area in singleplayer. [default: false]
     B:spawn_area_in_sp=false
 
-    # Spawn dimension. Overworld by default.
+    # Spawn dimension. Overworld by default. [range: -2147483648 ~ 2147483647, default: 0]
     I:spawn_dimension=0
 
-    # Spawn radius. You must set spawn-protection in server.properties file to 0!
+    # Spawn radius. You must set spawn-protection in server.properties file to 0! [range: -2147483648 ~ 2147483647, default: 0]
     I:spawn_radius=0
 
-    # Unloads erroring chunks if dimension isn't loaded or some other problem occurs.
+    # Unloads erroring chunks if dimension isn't loaded or some other problem occurs. [default: false]
     B:unload_erroring_chunks=false
 
-    ##########################################################################################################
-    # logging
-    #--------------------------------------------------------------------------------------------------------#
-    # Logs different events in logs/world.log file.
-    ##########################################################################################################
-
     logging {
-        # Logs block breaking.
+        # Logs block breaking. [default: true]
         B:block_broken=false
 
-        # Logs block placement.
+        # Logs block placement. [default: true]
         B:block_placed=false
 
-        # Enables chat logging.
+        # Enables chat logging. [default: false]
         B:chat_enable=false
 
-        # Enables world logging.
+        # Enables world logging. [default: false]
         B:enabled=false
 
-        # Logs player attacks on other players/entites.
+        # Logs player attacks on other players/entites. [default: true]
         B:entity_attacked=false
 
-        # Exclude mobs from entity attack logging.
+        # Exclude mobs from entity attack logging. [default: true]
         B:exclude_mob_entity=false
 
-        # Includes creative players in world logging.
+        # Includes creative players in world logging. [default: false]
         B:include_creative_players=false
 
-        # Includes fake players in world logging.
+        # Includes fake players in world logging. [default: false]
         B:include_fake_players=false
 
-        # Logs item clicking in air.
+        # Logs item clicking in air. [default: true]
         B:item_clicked_in_air=false
     }
 


### PR DESCRIPTION
This aims to lessen the amount of things players need to turn on in config if they want to use SU features.

The newly enabled values are

/ranks - Does nothing if ranks are turned off (which they are by default)
/chunks - Does nothing if chunk claiming is turned off (it is by default)
/dump_chunkloaders - Useful for debugging and is an admin command anyways
/killall - Admin command
/leaderboard - Why was this turned off?
/nbtedit - very useful for debugging and is still only usable by OPs
/tpl - admin command
/inv - admin command
and finally it enables chunk loading, this does nothing if claims are turned off as it says in the comment above the setting but leaves one less option that the players need to manually enable.

Most of the useful stuff that people use is still disabled but hopefully this will help alleviate some confusion, which is most often caused by /ranks or /chunks being disabled after they have already enabled chunk claiming/ranks.