### PR TITLE
Rename Volcanus quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/HephaestusEBF-AAAAAAAAAAAAAAAAAAAH9A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/HephaestusEBF-AAAAAAAAAAAAAAAAAAAH9A==.json
@@ -30,7 +30,7 @@
       "globalShare:1": 1,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Hephaestus' EBF",
+      "name:8": "Hephaestus\u0027 EBF",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/HephaestusEBF-AAAAAAAAAAAAAAAAAAAH9A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/HephaestusEBF-AAAAAAAAAAAAAAAAAAAH9A==.json
@@ -30,7 +30,7 @@
       "globalShare:1": 1,
       "questLogic:8": "AND",
       "repeat_relative:1": 1,
-      "name:8": "Forge of the Gods",
+      "name:8": "Hephaestus' EBF",
       "isGlobal:1": 0,
       "lockedProgress:1": 0,
       "autoClaim:1": 0,


### PR DESCRIPTION
Renames the Volcanus quest since its original name ("Forge of the Gods") may not be very applicable anymore