### PR TITLE
Prevent Fake Creepers from becoming Infernal

### DIFF
--- a/config/InfernalMobs.cfg
+++ b/config/InfernalMobs.cfg
@@ -919,6 +919,7 @@ permittedentities {
     B:EntityEvolvedSpider=true
     B:EntityEvolvedZombie=true
     B:EntityFaintGhast=true
+    B:EntityFakeCreeper=false
     B:EntityFallenKnight=true
     B:EntityFallenMount=true
     B:EntityFireAnt=true


### PR DESCRIPTION
WarpTheory spawns two types of creepers: "passive creepers", and "fake creepers". The former don't do anything, but the latter explode similar to normal creepers, with difference that their explosion doesn't do any world and player damage. Since fake creepers behave like normal creepers for the most part, if they spawn infernal, they can trigger normal infernal behavior and cause unintentional griefing. Passive creepers are already exempt from infernal status and I think the same should apply for fake creepers. See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17873 for some info.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17873