### PR TITLE
Use mouse scrolling transfer from NEI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Version 2.7.0-beta-3 is out 2024-10-21
 ## What is GT New Horizons?
 
 <p align="justify">
-    You are looking at a big progressive kitchensink pack for Minecraft 1.7.10 balanced around the mod GregTech.<BR><BR>
+    You are looking at a big progressive questing modpack for Minecraft 1.7.10 balanced around the mod GregTech.<BR><BR>
     Over 9 years of development (and still going) have formed a balance and refinement that only a handful of packs can keep up with. We are talking about thousands of recipe tweaks, a massive questbook with over 3000 quests, unique world generation, custom mods coded for the pack, custom Thaumonomicon pages, and many more.
     The main intentions of the pack are a long-lasting experience and tying mods together in a progressive fashion, making it feel more like a single game than a compilation of mods thrown together.<BR><BR>
     To reach this goal, GT New Horizons is using the tiers (basically ages of technology) from GregTech and allocates content of other mods to a fitting point within the progression.<BR><BR>

--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -21,7 +21,7 @@ general {
     B:LMBTweakWithoutItem=true
 
     # Scroll to quickly move items between inventories [default: true]
-    B:WheelTweak=true
+    B:WheelTweak=false
 
     # Wheel Inventory Slot Search Order
     # 0 - First to Last

--- a/config/NEI/client.cfg
+++ b/config/NEI/client.cfg
@@ -4,7 +4,7 @@
 
 checkUpdates=false
 inventory.cheatmode=2
-inventory.disableMouseScrollTransfer=true
+inventory.disableMouseScrollTransfer=false
 inventory.gamemodes=creative, creative+, adventure
 inventory.hidden=false
 inventory.invertMouseScrollTransfer=false


### PR DESCRIPTION
We have two mods adding the same feature : when you hover on an item and scroll your mouse, it will transfer items to the other inventory

Both NEI and MouseTweaks add it

I made NEI enabled and mouse tweaks disabled

The one from mouse tweaks will send items in the crafting grid of your inventory instead of the hotbar when you use that feature in the player inventory

Also since almost every player opens the NEI settings menu at some point and the setting is there I thought it would be better to use the feature from NEI than mousetwkeas.