### PR TITLE
disable NEI collapsible Items by default

### DIFF
--- a/config/NEI/client.cfg
+++ b/config/NEI/client.cfg
@@ -15,6 +15,7 @@ inventory.itemsort=nei.itemsort.minecraft,nei.itemsort.mod,nei.itemsort.id,nei.i
 inventory.lockmode=-1
 inventory.utilities=delete, magnet
 inventory.widgetsenabled=true
+inventory.collapsibleItems.enabled=false
 itemLoadingTimeout=500
 keys.gui.back=14
 keys.gui.bookmark=30


### PR DESCRIPTION
While it is true that this feature makes the NEI panel look less clutered, in practice it isn't of any use since you always use the search bar to find what you want and the search will reduce the amount of items displayed by a good enough amount.

When having this feature ON, every time you search something you have to do a extra ALT+click to expand the items and see a recipe. This feature makes the use of NEI heavier and less satisfying

Moreover the less experienced and non-devs might not be used to press the ALT key all the time so it's less natural and also they are not used to browse the NEI configs and might search some time before finding how to turn it off

For all these reasons I think it should be turned off by default

I'd like to see what the other devs or anyone think so I'll leave it as draft