### PR TITLE
Added Tartarite to TC Dupe Blacklist

### DIFF
--- a/config/WitchingGadgets.cfg
+++ b/config/WitchingGadgets.cfg
@@ -86,6 +86,7 @@ modules {
         Tritanium
         Promethium
         Terbium
+        Tartarite
      >
 }
 


### PR DESCRIPTION
Removal agreed on with @GDCloudstrike and @serenibyss 

Tartarite now has real use in the pack and an intended method to obtain, therefore it shouldn't have a dupe.