### PR TITLE
Move Mojang copyright notice to new line in main menu

### DIFF
--- a/config/CustomMainMenu/mainmenu.json
+++ b/config/CustomMainMenu/mainmenu.json
@@ -202,16 +202,22 @@
 			"posY": 0,
 			"alignment": "column_bottom"
 		},
+		"forge": {
+			"text": "menu.gtnh.forge",
+			"posX": 155,
+			"posY": -10,
+			"alignment": "column_bottom"
+		},
 		"version": {
 			"text": "file:mainmenu:version.txt",
 			"posX": 155,
-			"posY": -10,
+			"posY": -20,
 			"alignment": "column_bottom"
 		},
 		"aviators": {
 			"text": "menu.gtnh.aviators",
 			"posX": 150,
-			"posY": -20,
+			"posY": -30,
 			"fontSize": 0.5,
 			"alignment": "column_bottom"
 		}

--- a/config/CustomMainMenu/mainmenu_auto.json
+++ b/config/CustomMainMenu/mainmenu_auto.json
@@ -202,16 +202,22 @@
 			"posY": 0,
 			"alignment": "column_bottom"
 		},
+		"forge": {
+			"text": "menu.gtnh.forge",
+			"posX": 155,
+			"posY": -10,
+			"alignment": "column_bottom"
+		},
 		"version": {
 			"text": "file:mainmenu:version.txt",
 			"posX": 155,
-			"posY": -10,
+			"posY": -20,
 			"alignment": "column_bottom"
 		},
 		"aviators": {
 			"text": "menu.gtnh.aviators",
 			"posX": 155,
-			"posY": -20,
+			"posY": -30,
 			"fontSize": 0.5,
 			"alignment": "column_bottom"
 		}

--- a/config/CustomMainMenu/mainmenu_large.json
+++ b/config/CustomMainMenu/mainmenu_large.json
@@ -202,16 +202,22 @@
 			"posY": 0,
 			"alignment": "column_bottom"
 		},
+		"forge": {
+			"text": "menu.gtnh.forge",
+			"posX": 155,
+			"posY": -10,
+			"alignment": "column_bottom"
+		},
 		"version": {
 			"text": "file:mainmenu:version.txt",
 			"posX": 155,
-			"posY": -10,
+			"posY": -20,
 			"alignment": "column_bottom"
 		},
 		"aviators": {
 			"text": "menu.gtnh.aviators",
 			"posX": 155,
-			"posY": -20,
+			"posY": -30,
 			"fontSize": 0.5,
 			"alignment": "column_bottom"
 		}

--- a/config/CustomMainMenu/mainmenu_normal.json
+++ b/config/CustomMainMenu/mainmenu_normal.json
@@ -202,16 +202,22 @@
 			"posY": 0,
 			"alignment": "column_bottom"
 		},
+		"forge": {
+			"text": "menu.gtnh.forge",
+			"posX": 155,
+			"posY": -10,
+			"alignment": "column_bottom"
+		},
 		"version": {
 			"text": "file:mainmenu:version.txt",
 			"posX": 155,
-			"posY": -10,
+			"posY": -20,
 			"alignment": "column_bottom"
 		},
 		"aviators": {
 			"text": "menu.gtnh.aviators",
 			"posX": 155,
-			"posY": -20,
+			"posY": -30,
 			"fontSize": 0.5,
 			"alignment": "column_bottom"
 		}

--- a/config/CustomMainMenu/mainmenu_small.json
+++ b/config/CustomMainMenu/mainmenu_small.json
@@ -202,16 +202,22 @@
 			"posY": 0,
 			"alignment": "column_bottom"
 		},
+		"forge": {
+			"text": "menu.gtnh.forge",
+			"posX": 305,
+			"posY": -10,
+			"alignment": "column_bottom"
+		},
 		"version": {
 			"text": "file:mainmenu:version.txt",
 			"posX": 305,
-			"posY": -10,
+			"posY": -20,
 			"alignment": "column_bottom"
 		},
 		"aviators": {
 			"text": "menu.gtnh.aviators",
 			"posX": 305,
-			"posY": -20,
+			"posY": -30,
 			"fontSize": 0.5,
 			"alignment": "column_bottom"
 		}

--- a/config/txloader/load/custommainmenu/lang/en_US.lang
+++ b/config/txloader/load/custommainmenu/lang/en_US.lang
@@ -7,5 +7,6 @@ menu.gtnh.language=Language
 menu.gtnh.mods=Mods (#modsloaded#/#modsactive#)
 menu.gtnh.quit=Quit
 menu.gtnh.quit.hover=No! Don't leave!
-menu.gtnh.mojang=Forge #forgeversion# for Minecraft #mcversion# - Copyright Mojang AB. Do not distribute!
+menu.gtnh.forge=Forge #forgeversion# for Minecraft #mcversion#
+menu.gtnh.mojang=Copyright Mojang AB. Do not distribute!
 menu.gtnh.aviators=Opening Music Copyright by the Aviators


### PR DESCRIPTION
The copyright notice line got a bit too long on auto/large gui scale.

Before:
![2024-11-21_11 09 28](https://github.com/user-attachments/assets/027f1735-7b35-406f-a6fc-aca452b80c8f)

After:
![2024-11-21_11 00 46](https://github.com/user-attachments/assets/5a16157d-e805-4c58-b37d-1339bc14ce94)

Closes #16569