### PR TITLE
Fix mismatching config values and indicated default value in server utilities

### DIFF
--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -78,7 +78,7 @@ chat {
 
 
 commands {
-    #  [default: true]
+    #  [default: false]
     B:back=false
 
     #  [default: true]
@@ -96,22 +96,22 @@ commands {
     #  [default: true]
     B:dump_stats=true
 
-    #  [default: true]
+    #  [default: false]
     B:fly=false
 
-    #  [default: true]
+    #  [default: false]
     B:god=false
 
-    #  [default: true]
+    #  [default: false]
     B:heal=false
 
-    #  [default: true]
+    #  [default: false]
     B:home=false
 
     #  [default: true]
     B:inv=true
 
-    #  [default: true]
+    #  [default: false]
     B:kickme=false
 
     #  [default: true]
@@ -120,31 +120,31 @@ commands {
     #  [default: true]
     B:leaderboard=true
 
-    #  [default: true]
+    #  [default: false]
     B:mute=false
 
     #  [default: true]
     B:nbtedit=true
 
-    #  [default: true]
+    #  [default: false]
     B:nick=false
 
     #  [default: true]
     B:ranks=true
 
-    #  [default: true]
+    #  [default: false]
     B:rec=false
 
     #  [default: true]
     B:reload=true
 
-    #  [default: true]
+    #  [default: false]
     B:rtp=false
 
-    #  [default: true]
+    #  [default: false]
     B:spawn=false
 
-    #  [default: true]
+    #  [default: false]
     B:tpa=false
 
     #  [default: true]
@@ -153,7 +153,7 @@ commands {
     #  [default: true]
     B:trash_can=true
 
-    #  [default: true]
+    #  [default: false]
     B:warp=false
 }
 
@@ -212,7 +212,7 @@ login {
      >
 
     # Items to give player when they first join the server.
-    # Format: '{id:"ID",Count:X,Damage:X,tag:{}}', Use /print_item to get NBT of item in your hand. [default: [{id:"minecraft:stone_sword",Count:1,Damage:1,tag:{display:{Name:"Epic Stone Sword"}}}]]
+    # Format: '{id:"ID",Count:X,Damage:X,tag:{}}', Use /print_item to get NBT of item in your hand. [default: []]
     S:starting_items <
      >
 }
@@ -222,7 +222,7 @@ ranks {
     # Add permissions for commands and allow them to be controlled by ranks. [default: true]
     B:command_permissions=true
 
-    # Enables Ranks. [default: true]
+    # Enables Ranks. [default: false]
     B:enabled=false
 
     # Adds chat colors/rank-specific syntax. [default: true]
@@ -287,7 +287,7 @@ world {
     I:blocked_claiming_dimensions <
      >
 
-    # Enables chunk claiming. [default: true]
+    # Enables chunk claiming. [default: false]
     B:chunk_claiming=false
 
     # Enables chunk loading. If chunk_claiming is set to false, changing this won't do anything. [default: true]
@@ -307,7 +307,7 @@ world {
     # TRUE = Explosions on for everyone.
     # FALSE = Explosions disabled for everyone.
     # Possible values: [TRUE, FALSE, DEFAULT]
-    #  [default: DEFAULT]
+    #  [default: TRUE]
     S:enable_explosions=TRUE
 
     # Allowed values:
@@ -315,7 +315,7 @@ world {
     # TRUE = PVP on for everyone.
     # FALSE = PVP disabled for everyone.
     # Possible values: [TRUE, FALSE, DEFAULT]
-    #  [default: DEFAULT]
+    #  [default: TRUE]
     S:enable_pvp=TRUE
 
     # Locked time in ticks in spawn dimension.
@@ -361,10 +361,10 @@ world {
     B:unload_erroring_chunks=false
 
     logging {
-        # Logs block breaking. [default: true]
+        # Logs block breaking. [default: false]
         B:block_broken=false
 
-        # Logs block placement. [default: true]
+        # Logs block placement. [default: false]
         B:block_placed=false
 
         # Enables chat logging. [default: false]
@@ -376,7 +376,7 @@ world {
         # Logs player attacks on other players/entites. [default: true]
         B:entity_attacked=false
 
-        # Exclude mobs from entity attack logging. [default: true]
+        # Exclude mobs from entity attack logging. [default: false]
         B:exclude_mob_entity=false
 
         # Includes creative players in world logging. [default: false]
@@ -385,7 +385,7 @@ world {
         # Includes fake players in world logging. [default: false]
         B:include_fake_players=false
 
-        # Logs item clicking in air. [default: true]
+        # Logs item clicking in air. [default: false]
         B:item_clicked_in_air=false
     }
 


### PR DESCRIPTION
The server utilities's config have several properties which their actual default value is not the one indicated by the comment above them within `serverutilities/serverutilities.cfg`.

This PR fix that changing the indicated default value to match the actual value,