### PR TITLE
One more Tengam meteor fix.

### DIFF
--- a/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
+++ b/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
@@ -3,7 +3,7 @@
     "OREDICT:oreMarbleSalt:69"
   ],
   "filler": [
-    "OREDICT:oreMarbleSalt:72",
+    "gregtech:gt.blockores:817:72",
     "OREDICT:oreTengamRaw:1"
   ],
   "radius": 16,


### PR DESCRIPTION
ping @koolkrafter5 

The previous fix (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/18064) uses salt ore for both yield and filler parts of the meteor. This confuses the NEI diagram, which shows the same tooltip for both salt blocks:

<img src="https://i.imgur.com/v7LsIlM.png" width="400" /> <img src="https://i.imgur.com/dDzloOv.png" width="400" />

This PR replaces the filler block with stone salt ore (instead of marble ore), which displays the tooltip correctly without affecting the amount of ore one gets.

<img src="https://i.imgur.com/26IUiNS.png" width="400" /> <img src="https://i.imgur.com/DJ3AWHW.png" width="400" />

Picture of the full meteor (find the tengam!):

<img src="https://i.imgur.com/D7GduE3.png" width="600" />

Ore yield (whether salt or tengam) is not changed from #18064.