### PR TITLE
EBF Coil quest description: Unify kelvin symbol to K

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/AwakenedDraconiu-AAAAAAAAAAAAAAAAAAAHKQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/AwakenedDraconiu-AAAAAAAAAAAAAAAAAAAHKQ==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To process the most advanced materials like Infinity Catalyst or Infinity you need more than 9900K. Upgrade your EBF to 10800k.\n\n[note]With the heat adjustment included, you can get up to 11601K if you OC with UHV hatches. Not that you need it or anything.[/note]"
+      "desc:8": "To process the most advanced materials like Infinity Catalyst or Infinity you need more than 9900K. Upgrade your EBF to 10800K.\n\n[note]With the heat adjustment included, you can get up to 11601K if you OC with UHV hatches. Not that you need it or anything.[/note]"
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/ElectrumFluxCoil-AAAAAAAAAAAAAAAAAAAHGQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/ElectrumFluxCoil-AAAAAAAAAAAAAAAAAAAHGQ==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To process more advanced materials like Cosmic Neutronium, Tritanium and Awakened Draconium you need more than 9000K. Upgrade your EBF to 9900k."
+      "desc:8": "To process more advanced materials like Cosmic Neutronium, Tritanium and Awakened Draconium you need more than 9000K. Upgrade your EBF to 9900K."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/HSSGCoilUpgrade-AAAAAAAAAAAAAAAAAAAB2w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/HSSGCoilUpgrade-AAAAAAAAAAAAAAAAAAAB2w==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To process more advanced materials like HSS-E, HSS-S and naquadah you need more than 4500K. Time to upgrade your EBF to 5400k."
+      "desc:8": "To process more advanced materials like HSS-E, HSS-S and naquadah you need more than 4500K. Time to upgrade your EBF to 5400K."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/HSSSCoilUpgrade-AAAAAAAAAAAAAAAAAAALTA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/HSSSCoilUpgrade-AAAAAAAAAAAAAAAAAAALTA==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Technically this coil tier can be skipped. But you need LuV to get the next one, so you should really get these coils for now.\n\n\nTo process more advanced materials like LuV Superconductor Base you need more than 5400K. Time to upgrade your EBF to 6300k."
+      "desc:8": "Technically this coil tier can be skipped. But you need LuV to get the next one, so you should really get these coils for now.\n\n\nTo process more advanced materials like LuV Superconductor Base you need more than 5400K. Time to upgrade your EBF to 6300K."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/InfinityCoilUpgr-AAAAAAAAAAAAAAAAAAAMkQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/InfinityCoilUpgr-AAAAAAAAAAAAAAAAAAAMkQ==.json
@@ -33,7 +33,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Smelting with the ferocity of the universe itself.\n\nThis unbelievable material seemed impossible to manipulate into a coil block form, even though its properties made this desirable. It is incredibly stable even at extreme temperatures, but this also made it unable to pack together for coils.\n\nHowever, the situation changed when you thought about using something more intelligent. By integrating a Wetware or better UHV circuit, the Infinity Coil became a reality, controlled by the ever-watching eyes of the circuitry you\u0027ve spent months to create. From now on, these eyes will watch over your multiblocks.\n\nProvides 11701 heat. You could upgrade your EBF, though at this point it\u0027s more likely to be for your MEBFs or your DTPF."
+      "desc:8": "Smelting with the ferocity of the universe itself.\n\nThis unbelievable material seemed impossible to manipulate into a coil block form, even though its properties made this desirable. It is incredibly stable even at extreme temperatures, but this also made it unable to pack together for coils.\n\nHowever, the situation changed when you thought about using something more intelligent. By integrating a Wetware or better UHV circuit, the Infinity Coil became a reality, controlled by the ever-watching eyes of the circuitry you\u0027ve spent months to create. From now on, these eyes will watch over your multiblocks.\n\nProvides 11701K heat. You could upgrade your EBF, though at this point it\u0027s more likely to be for your MEBFs or your DTPF."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/NaquadahCoilUpgr-AAAAAAAAAAAAAAAAAAAB3A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/NaquadahCoilUpgr-AAAAAAAAAAAAAAAAAAAB3A==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To process more advanced materials like naquadah alloy you need more than 6300K. Upgrade your EBF to 7200k to increase the heat."
+      "desc:8": "To process more advanced materials like naquadah alloy you need more than 6300K. Upgrade your EBF to 7200K to increase the heat."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/NichromeCoilUpgr-AAAAAAAAAAAAAAAAAAAATw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/NichromeCoilUpgr-AAAAAAAAAAAAAAAAAAAATw==.json
@@ -35,7 +35,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To reach 3600k so you can process higher tier materials like tungsten, you need nichrome heating coils."
+      "desc:8": "To reach 3600K so you can process higher tier materials like tungsten, you need nichrome heating coils."
     }
   },
   "tasks:9": {

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/TriniumCoilUpgra-AAAAAAAAAAAAAAAAAAALTQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/TriniumCoilUpgra-AAAAAAAAAAAAAAAAAAALTQ==.json
@@ -31,7 +31,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "To process more advanced materials like neutronium or fluxed electrum you need more than 8100K. Upgrade your EBF to 9001k. (OVER 9000!!!)"
+      "desc:8": "To process more advanced materials like neutronium or fluxed electrum you need more than 8100K. Upgrade your EBF to 9001K. (OVER 9000!!!)"
     }
   },
   "tasks:9": {


### PR DESCRIPTION
In EBF Coil quests, the symbol of temperature unit kelvin is not unified (`K`, `k` or no symbol at all).
Every symbol of kelvin will be unified to `K` after this PR.