### PR TITLE
Fix Zirconium Ingots quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/ZirconiumIngots-AAAAAAAAAAAAAAAAAAAL6g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/ZirconiumIngots-AAAAAAAAAAAAAAAAAAAL6g==.json
@@ -67,8 +67,8 @@
         "0:10": {
           "id:8": "bartworks:gt.bwMetaGeneratedingot",
           "Count:3": 1,
-          "Damage:2": 11007,
-          "OreDict:8": ""
+          "Damage:2": 3,
+          "OreDict:8": "ingotZirconium"
         },
         "1:10": {
           "id:8": "gregtech:gt.metaitem.01",
@@ -94,7 +94,7 @@
         "1:10": {
           "id:8": "bartworks:gt.bwMetaGeneratedingot",
           "Count:3": 32,
-          "Damage:2": 11007,
+          "Damage:2": 3,
           "OreDict:8": ""
         }
       }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18112

Zirconium has 2 materials, but currently it seems to favor the metadata 3 one. I made the quest take oredict `ingotZirconium`, and choice reward gives the metadata 3 Zirconium, and if this ends up flipping again, the unificator should fix it.
New materials system soon :tm: