### PR TITLE
Prevent hiding of serum items

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -30,8 +30,6 @@ ExtraUtilities:drum !tag.Fluid=
 ExtraUtilities:microblocks !tag.mat="minecraft:stone"
 ForgeMicroblock:microblock !tag.mat="minecraft:stone"
 
-Genetics:serum
-Genetics:serumArray
 GraviSuite:itemPlasmaCell
 TConstruct:fluid.molten.
 tectech:item.em.debugContainer


### PR DESCRIPTION
Binnie mods use NEI lookup for these items to construct recipes.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18229