### PR TITLE
Enable `RMBTweak` in MouseTweaks config

### DIFF
--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -29,7 +29,7 @@ general {
     I:WheelSearchOrder=1
 
     # Very similar to the standard RMB dragging mechanic, with one difference: if you drag over a slot multiple times, an item will be put there multiple times. Replaces the standard mechanic if enabled. [default: false]
-    B:RMBTweak=false
+    B:RMBTweak=true
 }
 
 


### PR DESCRIPTION
This accidentally got changed after https://github.com/GTNewHorizons/MouseTweaks/pull/5 set the default value to false.

Fixes #16806