### PR TITLE
Prevent WarpTheory Passive Creeper from getting infernal

### DIFF
--- a/config/InfernalMobs.cfg
+++ b/config/InfernalMobs.cfg
@@ -1013,7 +1013,7 @@ permittedentities {
     B:EntityNinjaSkeleton=true
     B:EntityPaleSpider=true
     B:EntityParasyticLouse=true
-    B:EntityPassiveCreeper=true
+    B:EntityPassiveCreeper=false
     B:EntityPech=true
     B:EntityPhantom=true
     B:EntityPigZombie=true


### PR DESCRIPTION
Leftover from #17881. Passive Creepers were, in fact, not exempt from Infernal status.