### PR TITLE
Drop EULA-breaking servers for good

### DIFF
--- a/config/defaultserverlist.json
+++ b/config/defaultserverlist.json
@@ -7,10 +7,8 @@
     "Official GTNH Server 2 EU": "epsilon.gtnewhorizons.com",
     "Official GTNH Server 3 EU": "eta.gtnewhorizons.com",
     "Test Server GTNH 4 EU": "zeta.gtnewhorizons.com",
-    "APOC Gaming GTNH [US/EU]": "gtnh.apocgaming.org",
     "Prospercraft GTNH Server US": "newhorizonsold.prospercraft.com",
     "StoneLegion.com GTNH (Canada)": "mc.stonelegion.com",
-    "MyFTB GTNH German Server": "newhorizons.myftb.de",
     "StoneHuts GTNH EU whitelisted": "gtnh.stonehuts.net",
     "Zvezdolet GTNH Server 1": "gtnh.114-7.com",
     "Zvezdolet GTNH Server 2": "gtnh2.114-7.com",
@@ -19,11 +17,10 @@
     "Modded Minecraft Club  (Eu-Asia)": "gtnh.moddedminecraft.club",
     "MMC No TP (Eu+Asia2)": "gtnh-im.moddedminecraft.club",
     "Earthquake GTNH (US West)": "flancat.ddns.net",
-    "MineYourMind GTNH (EU)": "horizons.mineyourmind.net",
     "ValhallaMC (EU)": "gtnh.valhallamc.io",
-	"Truth of Horizons (EU Paris)": "truthofhorizons.us.to",
-	"Iron Fox Nexus (US)" : "23.139.82.94",
-	"The Hive Challenge Run Public SMP (US)" : "publichivesmp.paradiseisland.gg"
+    "Truth of Horizons (EU Paris)": "truthofhorizons.us.to",
+    "Iron Fox Nexus (US)" : "23.139.82.94",
+    "The Hive Challenge Run Public SMP (US)" : "publichivesmp.paradiseisland.gg"
   },
   "DO_NOT_EDIT_prevDefaultServers": []
 }

--- a/servers.json
+++ b/servers.json
@@ -13,7 +13,7 @@
     "Earthquake GTNH (US West)": "flancat.ddns.net",
     "Arcturus Network GTNH (EU)": "play.arcturus-official.eu",
     "ValhallaMC (EU)": "gtnh.valhallamc.io",
-	"Truth of Horizons (EU Paris)": "truthofhorizons.us.to",
-	"Iron Fox Nexus (US)" : "23.139.82.94",
-	"The Hive Challenge Run Public SMP (US)" : "publichivesmp.paradiseisland.gg"
+    "Truth of Horizons (EU Paris)": "truthofhorizons.us.to",
+    "Iron Fox Nexus (US)" : "23.139.82.94",
+    "The Hive Challenge Run Public SMP (US)" : "publichivesmp.paradiseisland.gg"
 }


### PR DESCRIPTION
The necessary changes to `defaultserverlist.json` were missed in #16821. This *needs* to go into 2.7.1.

The way we use DefaultServerList, we can only *add* servers by URL in the [`servers.json`](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/519e25268846c294a3b1ae6ab266165d2a4c79bb/servers.json). If we want to remove them, we also have to edit `defaultserverlist.json`.

Closes #18281.