### PR TITLE
Set Ender Quarry energy storage size in hodgepodge config

### DIFF
--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -459,6 +459,9 @@ tweaks {
     # Remove the blueish sky tint from night vision [default: false]
     B:enhanceNightVision=false
 
+    # Ender Quarry RF Storage Override (ExU default value: 10000000) (0 to use default value) [range: 0 ~ 2147483647, default: 0]
+    I:extraUtilitiesEnderQuarryOverride=200000000
+
     # Allows blocks to be placed at a faster rate (toggleable via keybind) [default: false]
     B:fastBlockPlacing=false
 


### PR DESCRIPTION
Enabled by https://github.com/GTNewHorizons/Hodgepodge/pull/446

See #18316