### PR TITLE
Update Coolant-AAAAAAAAAAAAAAAAAAAMAQ==.json

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/Coolant-AAAAAAAAAAAAAAAAAAAMAQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/Coolant-AAAAAAAAAAAAAAAAAAAMAQ==.json
@@ -36,7 +36,7 @@
       "lockedProgress:1": 0,
       "autoClaim:1": 0,
       "isSilent:1": 0,
-      "desc:8": "Make your first coolant out of water or distilled water and lapis dust in an mv mixer.\n\nUsing distilled water lets you save on lapis while also speeding up the process by a lot.\n\n[note]If you don\u0027t use distilled water, you will need a lot more than 64 lapis dust.[/note]"
+      "desc:8": "Make your first coolant out of water or distilled water and lapis dust in an mv mixer.\n\nUsing distilled water lets you save on lapis while also speeding up the process by a lot.\n\n[note]If you don\u0027t use distilled water, you will need a lot more than 8 lapis dust.[/note]"
     }
   },
   "tasks:9": {


### PR DESCRIPTION
Fixed Quest text.

With Distilled Water you need 8 Lapis dust, and with normal water you need 64. This fixes the quest text to reflect that properly.