### PR TITLE
Enable thaumic fire spread again as it was fixed and made non world bricking

### DIFF
--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -381,14 +381,6 @@
 	<ToolTip ItemName="thaumicboots:item.ItemQuantumComet:1" ToolTip="Recharge in a §8EV-tier §7Machine" NBT=""/>
 	<ToolTip ItemName="thaumicboots:item.ItemQuantumComet:325" ToolTip="Recharge in a §8EV-tier §7Machine" NBT=""/>
 	
-//Thaumic Tinkers
-	<ToolTip ItemName="ThaumicTinkerer:fireFire" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>
-	<ToolTip ItemName="ThaumicTinkerer:fireOrder" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>        
-	<ToolTip ItemName="ThaumicTinkerer:fireEarth" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>	
-	<ToolTip ItemName="ThaumicTinkerer:fireWater" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>		
-	<ToolTip ItemName="ThaumicTinkerer:fireChaos" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>
-	<ToolTip ItemName="ThaumicTinkerer:fireAir" ToolTip="§4ELEMENTAL firespread disabled" NBT=""/>
-	
 //Tinkers Construct
 	<ToolTip ItemName="TConstruct:Smeltery" ToolTip="§3Some metals processed in smeltery don't meet the purity requirement for GregTech processing." NBT=""/>
 	<ToolTip ItemName="TConstruct:LavaTank" ToolTip="§3Some metals processed in smeltery don't meet the purity requirement for GregTech processing." NBT=""/>

--- a/config/ThaumicTinkerer.cfg
+++ b/config/ThaumicTinkerer.cfg
@@ -72,7 +72,7 @@ general {
     B:imbuedFire.enabled=true
 
     # Set to false to disable imbued fire spreading/acting mechanism. [default: true]
-    B:imbuedFireSpread.enabled=false
+    B:imbuedFireSpread.enabled=true
 
     # Set to true to enable all KAMI stuff [default: true]
     B:kami.forceenabled=true


### PR DESCRIPTION
Allows for botania cake reactors :sunglasses: 

Forgot we never enabled this again after it was fixed in https://github.com/GTNewHorizons/ThaumicTinkerer/pull/31  