### PR TITLE
Red alloy fix/cleanup

### DIFF
--- a/config/ProjectRed.cfg
+++ b/config/ProjectRed.cfg
@@ -20,7 +20,7 @@ Compatibility {
     B:"Thermal Expansion: Machine Recipes"=true
 
     # This adds recipes to the smeltery.
-    B:"Tinkers Construct: Smeltery"=true
+    B:"Tinkers Construct: Smeltery"=false
 
     # This allows gem axes to work with treecapitator.
     B:"Treecapitator: Gem Axe"=true


### PR DESCRIPTION
removes a duplicate redstone fluid and a duplicate red alloy fluid and fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18458. We have that all covered in gt.

see https://github.com/GTNewHorizons/ProjectRed/blob/master/src/main/scala/mrtjp/projectred/compatibility/tconstruct/PluginTConstruct.scala for what the config does. 