### PR TITLE
Removed unnecessary NBT tag from Quantum Star quest radium reward

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/QuantumStar-AAAAAAAAAAAAAAAAAAAGAw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/QuantumStar-AAAAAAAAAAAAAAAAAAAGAw==.json
@@ -90,14 +90,6 @@
         "1:10": {
           "id:8": "miscutils:dustRadium226",
           "Count:3": 8,
-          "tag:10": {
-            "TickableItem:10": {
-              "maxTick:4": 90000,
-              "CreationDate:4": 422439,
-              "Tick:4": 0,
-              "isActive:4": 1
-            }
-          },
           "Damage:2": 0,
           "OreDict:8": ""
         },


### PR DESCRIPTION
Radium obtained from Quantum Star quest has an additional NBT tag that makes it different from radium you would obtain from processing (eg sifting uranium ores), which makes it not stackable in barrel-like containers.

Normally it wouldn't matter, as the player who claimed the reward would get it into their inventory where the item would start ticking and immediately become non-stackable via new NBT data. But I though I was smart and claimed it with full inventory over an item collector, only to realize that it doesn't stack anyways due to reward already having NBT data in it. Repeating this trick with edited quest reward made the reward barrel-stackable.