### PR TITLE
Restore wooden hoe recipe

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -166,7 +166,7 @@ food {
     B:modifyHoeUse=true
 
     # Whether wood and stone hoe recipes are removed [vanilla: false] [default: true]
-    B:removeHoeRecipes=true
+    B:removeHoeRecipes=false
 
     # Removes seed drops when breaking tall grass [vanilla: false] [default: true]
     B:removeTallGrassSeeds=true


### PR DESCRIPTION
This config removed both Wooden and Stone Hoe recipes. However coremod also removes the Stone Hoe recipe, so this only restores the Wooden one.