### PR TITLE
Mitigate stair climbing bug

### DIFF
--- a/config/etfuturum/mixins.cfg
+++ b/config/etfuturum/mixins.cfg
@@ -162,7 +162,7 @@ fixes {
 
     # Makes the player able to step up even if a block would be above their head at the destination.
     # Modified classes: net.minecraft.entity.Entity [default: true]
-    B:stepHeightFix=true
+    B:stepHeightFix=false
 }
 
 


### PR DESCRIPTION
Mitigates the issue with climbing stairs reported in https://github.com/Roadhog360/Et-Futurum-Requiem/issues/210

Based on the conversation in that issue, it seems the problem is still there and turning off the mixin is the most expedient solution.