### PR TITLE
Allow crafting a TiCo Flint Sword Blade & Bone Wide Guard

### DIFF
--- a/config/IguanaTinkerTweaks/restrictions.cfg
+++ b/config/IguanaTinkerTweaks/restrictions.cfg
@@ -24,12 +24,14 @@ toolparts {
         Flint:pickaxe
         Flint:shovel
         Flint:axe
+        Flint:swordblade
         Flint:knifeblade
         Flint:arrowhead
         Flint:shuriken
         Bone:rod
         Bone:shovel
         Bone:axe
+        Bone:largeguard
         Bone:crossbar
         Bone:knifeblade
         Bone:arrowhead


### PR DESCRIPTION
With the removal of the Gregtech Flint Sword there's a capability gap between the Wooden Sword & the Bronze Broadsword.

![image](https://github.com/user-attachments/assets/497490cd-6334-4611-a55a-b3e353e308e9)
![image](https://github.com/user-attachments/assets/1cede425-0004-4d93-ac5b-50d4a3e99bb5)
![image](https://github.com/user-attachments/assets/a5f4a393-cde1-4eb0-a2b7-b89868fc4f38)


There is already a Flint Dagger which can be crafted, but it lacks a block ability (you throw it instead) and has lower damage than the Wooden Sword so I don't think it fits the needs of new players.

![image](https://github.com/user-attachments/assets/7d2a89ef-481c-4baf-bc62-b2823ffa10af)

As a possible short-term fix, we could re-enable the Flint Sword Blade & Bone Wide Guard to allow crafting a Flint Broadsword. Incidentally this also allows crafting a Flint Rapier.

![image](https://github.com/user-attachments/assets/a0bdd571-fbbd-4195-bb5f-02c11dcd7fc9)
![image](https://github.com/user-attachments/assets/40c6f21f-7825-4139-a0b2-21c1bbf055c9)

