### PR TITLE
Mouse Tweaks Config

### DIFF
--- a/config/MouseTweaks.cfg
+++ b/config/MouseTweaks.cfg
@@ -1,35 +1,32 @@
 # Configuration file
 
 general {
-    # Scroll Scaling
-    # 0 - Multiple Wheel Clicks Move Multiple Items
-    # 1 - Always Move One Item (macOS Compatibility) [range: 0 ~ 1, default: 0]
-    I:ScrollItemScaling=0
+    # Left click and drag with an item to "left click" items of the same type. [default: true]
+    B:"LMB tweak with item"=false
 
-    # Wheel Scroll Direction
-    # 0 - Down to Push, Up to Pull
-    # 1 - Up to Push, Down to Pull
-    # 2 - Inventory Position Aware
-    # 3 - Inventory Position Aware, Inverted
-    #  [range: 0 ~ 3, default: 0]
-    I:WheelScrollDirection=0
+    # Hold shift, left click and drag without an item to "shift left click" items. [default: true]
+    B:"LMB tweak without item"=true
 
-    # Lets you quickly pick up or move items of the same type [default: true]
-    B:LMBTweakWithItem=false
+    # Like vanilla right click dragging, but dragging over a slot multiple times puts the item there multiple times. [default: true]
+    B:"RMB tweak"=true
 
-    # Quickly move items into another inventory [default: true]
-    B:LMBTweakWithoutItem=true
+    # This determines how many items are moved when you scroll. On some setups (notably macOS), scrolling the wheel with different speeds results in different distances scrolled per wheel "bump". To make those setups play nicely with Mouse Tweaks, set this option to "Always exactly one item".
+    # Possible values: [PROPORTIONAL, ALWAYS_ONE]
+    #  [default: PROPORTIONAL]
+    S:"Scroll item scaling"=PROPORTIONAL
 
-    # Scroll to quickly move items between inventories [default: true]
-    B:WheelTweak=false
+    # Scroll over items to move them between inventories. [default: true]
+    B:"Wheel tweak"=false
 
-    # Wheel Inventory Slot Search Order
-    # 0 - First to Last
-    # 1 - Last To First [range: 0 ~ 1, default: 1]
-    I:WheelSearchOrder=1
+    # Inventory position aware means scroll up to push items from the bottom inventory and pull into the top inventory, and vice versa.
+    # Possible values: [NORMAL, INVERTED, INVENTORY_POSITION_AWARE, INVENTORY_POSITION_AWARE_INVERTED]
+    #  [default: NORMAL]
+    S:"Wheel tweak scroll direction"=NORMAL
 
-    # Very similar to the standard RMB dragging mechanic, with one difference: if you drag over a slot multiple times, an item will be put there multiple times. Replaces the standard mechanic if enabled. [default: false]
-    B:RMBTweak=true
+    # How to pick the source slot when pulling items via scrolling.
+    # Possible values: [FIRST_TO_LAST, LAST_TO_FIRST]
+    #  [default: LAST_TO_FIRST]
+    S:"Wheel tweak search order"=LAST_TO_FIRST
 }
 
 


### PR DESCRIPTION
I moved Cleanroom's MouseTweaks into Inventory Bogo Sorter in (https://github.com/GTNewHorizons/InventoryBogoSorter/pull/28), those changes include updating the configs.  

Merge after including Inventory Bogo Sorter in the pack and MouseTweaks and InventoryTweaks is removed from the pack