### PR TITLE
remove efr new dyes

### DIFF
--- a/config/etfuturum/blocksitems.cfg
+++ b/config/etfuturum/blocksitems.cfg
@@ -333,7 +333,7 @@ equipment {
     B:enableMutton=false
 
     #  [default: true]
-    B:enableNewDyes=true
+    B:enableNewDyes=false
 
     # Appears in stronghold corridor and dungeon chests. [default: true]
     B:enableOtherside=true


### PR DESCRIPTION
we already have gt dyes for all colors that everything can be crafted into, so we dont need these. And having both just creates conflicts everywhere.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18690