### PR TITLE
remove VF prereq for MV SC

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/MVSuperconductor-AAAAAAAAAAAAAAAAAAAFfA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/MVSuperconductor-AAAAAAAAAAAAAAAAAAAFfA==.json
@@ -2,13 +2,9 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 81
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
       "questIDLow:4": 753
     },
-    "2:10": {
+    "1:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 78
     }


### PR DESCRIPTION
removes the VF prereq for mv SC, due to it not being hot anymore
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18722
together with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1155