### PR TITLE
Update meteor configs

### DIFF
--- a/config/BloodMagic/meteors/AsteroidLateGameOres.json
+++ b/config/BloodMagic/meteors/AsteroidLateGameOres.json
@@ -21,7 +21,5 @@
   ],
   "radius": 22,
   "cost": 100000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 10951
+  "focusItem": "gregtech:gt.blockmachines:10951"
 }

--- a/config/BloodMagic/meteors/CallistoMeteor.json
+++ b/config/BloodMagic/meteors/CallistoMeteor.json
@@ -23,8 +23,6 @@
   ],
   "radius": 20,
   "cost": 1000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32464,
+  "focusItem": "gregtech:gt.metaitem.01:32464",
   "fillerChance": 27
 }

--- a/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
+++ b/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
@@ -8,8 +8,6 @@
   ],
   "radius": 16,
   "cost": 1000000001,
-  "focusModId": "GalacticraftAmunRa",
-  "focusName": "tile.machines2",
-  "focusMeta": 1,
+  "focusItem": "GalacticraftAmunRa:tile.machines2:1",
   "fillerChance": 10
 }

--- a/config/BloodMagic/meteors/Chinfinity.json
+++ b/config/BloodMagic/meteors/Chinfinity.json
@@ -37,7 +37,5 @@
   ],
   "radius": 16,
   "cost": 80000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 1186
+  "focusItem": "gregtech:gt.blockmachines:1186"
 }

--- a/config/BloodMagic/meteors/ConcentratedLeadEV.json
+++ b/config/BloodMagic/meteors/ConcentratedLeadEV.json
@@ -7,7 +7,5 @@
   ],
   "radius": 9,
   "cost": 2000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 214
+  "focusItem": "gregtech:gt.blockmachines:214"
 }

--- a/config/BloodMagic/meteors/EndstoneHEE.json
+++ b/config/BloodMagic/meteors/EndstoneHEE.json
@@ -11,8 +11,6 @@
   ],
   "radius": 12,
   "cost": 500000,
-  "focusModId": "minecraft",
-  "focusName": "end_stone",
-  "focusMeta": 0,
+  "focusItem": "minecraft:end_stone",
   "fillerChance": 76
 }

--- a/config/BloodMagic/meteors/GraphiteMeteor.json
+++ b/config/BloodMagic/meteors/GraphiteMeteor.json
@@ -9,8 +9,6 @@
   ],
   "radius": 13,
   "cost": 420000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.02",
-  "focusMeta": 30500,
+  "focusItem": "gregtech:gt.metaitem.02:30500",
   "fillerChance": 25
 }

--- a/config/BloodMagic/meteors/GreaterEndstoneVariant.json
+++ b/config/BloodMagic/meteors/GreaterEndstoneVariant.json
@@ -42,8 +42,6 @@
   ],
   "radius": 18,
   "cost": 3250000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 1182,
+  "focusItem": "gregtech:gt.blockmachines:1182",
   "fillerChance": 7
 }

--- a/config/BloodMagic/meteors/ImpureSuperNiobiumSpaceMix.json
+++ b/config/BloodMagic/meteors/ImpureSuperNiobiumSpaceMix.json
@@ -13,8 +13,6 @@
   ],
   "radius": 18,
   "cost": 1000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32672,
+  "focusItem": "gregtech:gt.metaitem.01:32672",
   "fillerChance": 50
 }

--- a/config/BloodMagic/meteors/IndiumGreaterVariant.json
+++ b/config/BloodMagic/meteors/IndiumGreaterVariant.json
@@ -8,7 +8,5 @@
   ],
   "radius": 14,
   "cost": 50000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.03",
-  "focusMeta": 32094
+  "focusItem": "gregtech:gt.metaitem.03:32094"
 }

--- a/config/BloodMagic/meteors/LegacyGemBunch.json
+++ b/config/BloodMagic/meteors/LegacyGemBunch.json
@@ -25,8 +25,6 @@
   ],
   "radius": 12,
   "cost": 500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 24347,
+  "focusItem": "gregtech:gt.metaitem.01:24347",
   "fillerChance": 44
 }

--- a/config/BloodMagic/meteors/LegacyMarsMeteor.json
+++ b/config/BloodMagic/meteors/LegacyMarsMeteor.json
@@ -23,7 +23,5 @@
   ],
   "radius": 13,
   "cost": 500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32692
+  "focusItem": "gregtech:gt.metaitem.01:32692"
 }

--- a/config/BloodMagic/meteors/LegacyOWMeteor.json
+++ b/config/BloodMagic/meteors/LegacyOWMeteor.json
@@ -23,8 +23,6 @@
   ],
   "radius": 16,
   "cost": 300000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32680,
+  "focusItem": "gregtech:gt.metaitem.01:32680",
   "fillerChance": 18
 }

--- a/config/BloodMagic/meteors/LegacyVariousOreBunch.json
+++ b/config/BloodMagic/meteors/LegacyVariousOreBunch.json
@@ -11,7 +11,5 @@
   ],
   "radius": 9,
   "cost": 750000,
-  "focusModId": "minecraft",
-  "focusName": "nether_star",
-  "focusMeta": 0
+  "focusItem": "minecraft:nether_star"
 }

--- a/config/BloodMagic/meteors/MASTER1_GemMaster.json
+++ b/config/BloodMagic/meteors/MASTER1_GemMaster.json
@@ -29,7 +29,5 @@
   ],
   "radius": 32,
   "cost": 90000000,
-  "focusModId": "kubatech",
-  "focusName": "defc.casing",
-  "focusMeta": 8
+  "focusItem": "kubatech:defc.casing:8"
 }

--- a/config/BloodMagic/meteors/MagicalOres.json
+++ b/config/BloodMagic/meteors/MagicalOres.json
@@ -18,8 +18,6 @@
   ],
   "radius": 15,
   "cost": 800000,
-  "focusModId": "Thaumcraft",
-  "focusName": "ItemSanitySoap",
-  "focusMeta": 0,
+  "focusItem": "Thaumcraft:ItemSanitySoap",
   "fillerChance": 11
 }

--- a/config/BloodMagic/meteors/MysteriousMeteor.json
+++ b/config/BloodMagic/meteors/MysteriousMeteor.json
@@ -7,8 +7,6 @@
   ],
   "radius": 16,
   "cost": 44000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 10990,
+  "focusItem": "gregtech:gt.blockmachines:10990",
   "fillerChance": 60
 }

--- a/config/BloodMagic/meteors/NaquadahPure.json
+++ b/config/BloodMagic/meteors/NaquadahPure.json
@@ -7,7 +7,5 @@
   ],
   "radius": 16,
   "cost": 25000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.03",
-  "focusMeta": 32091
+  "focusItem": "gregtech:gt.metaitem.03:32091"
 }

--- a/config/BloodMagic/meteors/OWMeteorVersionTwo.json
+++ b/config/BloodMagic/meteors/OWMeteorVersionTwo.json
@@ -21,8 +21,6 @@
   ],
   "radius": 18,
   "cost": 300000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32690,
+  "focusItem": "gregtech:gt.metaitem.01:32690",
   "fillerChance": 17
 }

--- a/config/BloodMagic/meteors/OWMoonrockMix.json
+++ b/config/BloodMagic/meteors/OWMoonrockMix.json
@@ -19,8 +19,6 @@
   ],
   "radius": 15,
   "cost": 650000,
-  "focusModId": "harvestcraft",
-  "focusName": "cheeseItem",
-  "focusMeta": 0,
+  "focusItem": "harvestcraft:cheeseItem",
   "fillerChance": 50
 }

--- a/config/BloodMagic/meteors/Pufferfish.json
+++ b/config/BloodMagic/meteors/Pufferfish.json
@@ -11,8 +11,6 @@
   ],
   "radius": 16,
   "cost": 6666666,
-  "focusModId": "minecraft",
-  "focusName": "fish",
-  "focusMeta": 3,
+  "focusItem": "minecraft:fish:3",
   "fillerChance": 20
 }

--- a/config/BloodMagic/meteors/PureMarsRelatedOres.json
+++ b/config/BloodMagic/meteors/PureMarsRelatedOres.json
@@ -28,7 +28,5 @@
   ],
   "radius": 24,
   "cost": 6000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 463
+  "focusItem": "gregtech:gt.blockmachines:463"
 }

--- a/config/BloodMagic/meteors/PureMoonOreMeteor.json
+++ b/config/BloodMagic/meteors/PureMoonOreMeteor.json
@@ -13,7 +13,5 @@
   ],
   "radius": 16,
   "cost": 2000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32682
+  "focusItem": "gregtech:gt.metaitem.01:32682"
 }

--- a/config/BloodMagic/meteors/PureNetherOreVariant.json
+++ b/config/BloodMagic/meteors/PureNetherOreVariant.json
@@ -26,7 +26,5 @@
   ],
   "radius": 18,
   "cost": 1200000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 482
+  "focusItem": "gregtech:gt.blockmachines:482"
 }

--- a/config/BloodMagic/meteors/PureOWOreMeteor.json
+++ b/config/BloodMagic/meteors/PureOWOreMeteor.json
@@ -26,7 +26,5 @@
   ],
   "radius": 20,
   "cost": 600000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32670
+  "focusItem": "gregtech:gt.metaitem.01:32670"
 }

--- a/config/BloodMagic/meteors/RadioactivePure.json
+++ b/config/BloodMagic/meteors/RadioactivePure.json
@@ -10,7 +10,5 @@
   ],
   "radius": 12,
   "cost": 2500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 465
+  "focusItem": "gregtech:gt.blockmachines:465"
 }

--- a/config/BloodMagic/meteors/RainbowGlassMeteor.json
+++ b/config/BloodMagic/meteors/RainbowGlassMeteor.json
@@ -19,7 +19,5 @@
   ],
   "radius": 8,
   "cost": 123456,
-  "focusModId": "minecraft",
-  "focusName": "melon_block",
-  "focusMeta": 0
+  "focusItem": "minecraft:melon_block"
 }

--- a/config/BloodMagic/meteors/SomeBartOres.json
+++ b/config/BloodMagic/meteors/SomeBartOres.json
@@ -21,7 +21,5 @@
   ],
   "radius": 18,
   "cost": 10000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 406
+  "focusItem": "gregtech:gt.blockmachines:406"
 }

--- a/config/BloodMagic/meteors/SoulInducedMeteor.json
+++ b/config/BloodMagic/meteors/SoulInducedMeteor.json
@@ -4,7 +4,5 @@
   ],
   "radius": 16,
   "cost": 5000000,
-  "focusModId": "minecraft",
-  "focusName": "soul_sand",
-  "focusMeta": 0
+  "focusItem": "minecraft:soul_sand"
 }

--- a/config/BloodMagic/meteors/SpaceyOres.json
+++ b/config/BloodMagic/meteors/SpaceyOres.json
@@ -16,8 +16,6 @@
   ],
   "radius": 16,
   "cost": 1500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32674,
+  "focusItem": "gregtech:gt.metaitem.01:32674",
   "fillerChance": 28
 }

--- a/config/BloodMagic/meteors/SuperGTStones.json
+++ b/config/BloodMagic/meteors/SuperGTStones.json
@@ -7,7 +7,5 @@
   ],
   "radius": 20,
   "cost": 775000,
-  "focusModId": "minecraft",
-  "focusName": "tnt",
-  "focusMeta": 0
+  "focusItem": "minecraft:tnt"
 }

--- a/config/BloodMagic/meteors/SuperPlatinumGroupMetals.json
+++ b/config/BloodMagic/meteors/SuperPlatinumGroupMetals.json
@@ -10,7 +10,5 @@
   ],
   "radius": 14,
   "cost": 12500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 345
+  "focusItem": "gregtech:gt.blockmachines:345"
 }

--- a/config/BloodMagic/meteors/T1RocketStones.json
+++ b/config/BloodMagic/meteors/T1RocketStones.json
@@ -6,7 +6,5 @@
   ],
   "radius": 20,
   "cost": 500000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32462
+  "focusItem": "gregtech:gt.metaitem.01:32462"
 }

--- a/config/BloodMagic/meteors/T2RocketStones.json
+++ b/config/BloodMagic/meteors/T2RocketStones.json
@@ -11,7 +11,5 @@
   ],
   "radius": 20,
   "cost": 750000,
-  "focusModId": "gregtech",
-  "focusName": "gt.metaitem.01",
-  "focusMeta": 32463
+  "focusItem": "gregtech:gt.metaitem.01:32463"
 }

--- a/config/BloodMagic/meteors/T3RocketStones.json
+++ b/config/BloodMagic/meteors/T3RocketStones.json
@@ -15,7 +15,5 @@
   ],
   "radius": 20,
   "cost": 1000000,
-  "focusModId": "GalacticraftMars",
-  "focusName": "item.itemBasicAsteroids",
-  "focusMeta": 0
+  "focusItem": "GalacticraftMars:item.itemBasicAsteroids"
 }

--- a/config/BloodMagic/meteors/T4RocketStones.json
+++ b/config/BloodMagic/meteors/T4RocketStones.json
@@ -11,7 +11,5 @@
   ],
   "radius": 20,
   "cost": 7500000,
-  "focusModId": "dreamcraft",
-  "focusName": "item.HeavyDutyPlateTier4",
-  "focusMeta": 0
+  "focusItem": "dreamcraft:item.HeavyDutyPlateTier4"
 }

--- a/config/BloodMagic/meteors/T5RocketStones.json
+++ b/config/BloodMagic/meteors/T5RocketStones.json
@@ -16,7 +16,5 @@
   ],
   "radius": 20,
   "cost": 10000000,
-  "focusModId": "dreamcraft",
-  "focusName": "item.HeavyDutyPlateTier5",
-  "focusMeta": 0
+  "focusItem": "dreamcraft:item.HeavyDutyPlateTier5"
 }

--- a/config/BloodMagic/meteors/T6RocketStones.json
+++ b/config/BloodMagic/meteors/T6RocketStones.json
@@ -9,7 +9,5 @@
   ],
   "radius": 20,
   "cost": 15000000,
-  "focusModId": "dreamcraft",
-  "focusName": "item.HeavyDutyPlateTier6",
-  "focusMeta": 0
+  "focusItem": "dreamcraft:item.HeavyDutyPlateTier6"
 }

--- a/config/BloodMagic/meteors/T7RocketStones.json
+++ b/config/BloodMagic/meteors/T7RocketStones.json
@@ -12,7 +12,5 @@
   ],
   "radius": 20,
   "cost": 30000000,
-  "focusModId": "dreamcraft",
-  "focusName": "item.HeavyDutyPlateTier7",
-  "focusMeta": 0
+  "focusItem": "dreamcraft:item.HeavyDutyPlateTier7"
 }

--- a/config/BloodMagic/meteors/T8RocketStones.json
+++ b/config/BloodMagic/meteors/T8RocketStones.json
@@ -16,7 +16,5 @@
   ],
   "radius": 20,
   "cost": 50000000,
-  "focusModId": "dreamcraft",
-  "focusName": "item.HeavyDutyPlateTier8",
-  "focusMeta": 0
+  "focusItem": "dreamcraft:item.HeavyDutyPlateTier8"
 }

--- a/config/BloodMagic/meteors/T9Ores.json
+++ b/config/BloodMagic/meteors/T9Ores.json
@@ -9,7 +9,5 @@
   ],
   "radius": 16,
   "cost": 1000000001,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 14009
+  "focusItem": "gregtech:gt.blockmachines:14009"
 }

--- a/config/BloodMagic/meteors/YourResourcesHandItOver.json
+++ b/config/BloodMagic/meteors/YourResourcesHandItOver.json
@@ -15,7 +15,5 @@
   ],
   "radius": 18,
   "cost": 125000000,
-  "focusModId": "gregtech",
-  "focusName": "gt.blockmachines",
-  "focusMeta": 12526
+  "focusItem": "gregtech:gt.blockmachines:12526"
 }

--- a/config/BloodMagic/meteors/reagents/crystallos.json
+++ b/config/BloodMagic/meteors/reagents/crystallos.json
@@ -1,0 +1,3 @@
+{
+  "filler": ["minecraft:ice:0:180"]
+}

--- a/config/BloodMagic/meteors/reagents/incendium.json
+++ b/config/BloodMagic/meteors/reagents/incendium.json
@@ -1,0 +1,7 @@
+{
+  "filler": [
+    "minecraft:netherrack:0:60",
+    "minecraft:glowstone:0:60",
+    "minecraft:soul_sand:0:60"
+  ]
+}

--- a/config/BloodMagic/meteors/reagents/orbisTerrae.json
+++ b/config/BloodMagic/meteors/reagents/orbisTerrae.json
@@ -1,0 +1,4 @@
+{
+  "radiusChange": 2,
+  "fillerChanceChange": 20
+}

--- a/config/BloodMagic/meteors/reagents/tenebrae.json
+++ b/config/BloodMagic/meteors/reagents/tenebrae.json
@@ -1,0 +1,3 @@
+{
+  "filler": ["minecraft:obsidian:0:180"]
+}

--- a/config/BloodMagic/meteors/reagents/terrae.json
+++ b/config/BloodMagic/meteors/reagents/terrae.json
@@ -1,0 +1,4 @@
+{
+  "radiusChange": 1,
+  "fillerChanceChange": 10
+}


### PR DESCRIPTION
Add default meteor reagent configs.
Rewrite the meteor focus items to use the new format added in https://github.com/GTNewHorizons/BloodMagic/pull/67. Metadata value of 0 is default and does not need to be explicitly written, so it has been omitted from the relevant files.