### PR TITLE
Disable GalaxySpace ore generation

### DIFF
--- a/config/GalaxySpace/core.conf
+++ b/config/GalaxySpace/core.conf
@@ -76,5 +76,5 @@ worldgen {
     B:enableLeadGeneration=false
 
     # Enable/Disable Generation Ores on Planets/Moon (Global Config).
-    B:enableOresGeneration=true
+    B:enableOresGeneration=false
 }


### PR DESCRIPTION
Set enableOresGeneration to false in the GalaxySpace config so GalaxySpace ores will not generate.