### PR TITLE
Re-enable americium and europium bee mutatron

### DIFF
--- a/config/gendustry/overrides/tuning.cfg
+++ b/config/gendustry/overrides/tuning.cfg
@@ -185,8 +185,8 @@ cfg Genetics {
 	"gregtech.bee.speciesCosmicneutronium" = DISABLED
 	"gregtech.bee.speciesInfinitycatalyst" = DISABLED
 	"gregtech.bee.speciesInfinity" = DISABLED
-	"gregtech.bee.speciesAmericium" = DISABLED
-	"gregtech.bee.speciesEuropium" = DISABLED
+	"gregtech.bee.speciesAmericium" = REQUIREMENTS
+	"gregtech.bee.speciesEuropium" = REQUIREMENTS
 	"gregtech.bee.speciesKevlar" = REQUIREMENTS
 	"gregtech.bee.speciesDrake" = REQUIREMENTS
   }


### PR DESCRIPTION
Only merge if https://github.com/GTNewHorizons/GT5-Unofficial/pull/3894 gets merged.

Reverts the change happened in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/16977 due to compact controller removal, as it was enabled intentionally by https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/11921
Allows mutatron to be used for americium and europium bee, while still requiring the breeding blocks.

