### PR TITLE
Disable duplicate Mixins

### DIFF
--- a/config/bugtorch/mixins.cfg
+++ b/config/bugtorch/mixins.cfg
@@ -1,101 +1,258 @@
 # Configuration file
 
 "backported features" {
-    # Cobwebs can be collected with Shears without Silk Touch. From MC 1.9, fixes MC-93001 [default: true]
+    # Cobwebs can be collected with Shears without Silk Touch.
+    # From MC 1.9, fixes MC-93001 [default: true]
     B:cobwebsCanBeSheared=true
 
-    # Dead Bushes drop 0-2 Sticks. From MC 1.9 [default: true]
+    # Dead Bushes drop 0-2 Sticks.
+    # From MC 1.9 [default: true]
     B:deadBushesDropSticks=true
 
-    # Minecarts with TNT explode when hit by fire arrows. From MC 1.8, fixes MC-8987 [default: true]
+    # Minecarts with TNT explode when hit by fire arrows.
+    # From MC 1.8, fixes MC-8987 [default: true]
     B:fireArrowsDetonateTNTCarts=true
 
-    # Pumpkins and Jack o'Lanterns can be placed without a solid block below them. From MC 1.13, fixes MC-1947 [default: true]
+    # Pumpkins and Jack O' Lanterns can be placed without a solid block below them.
+    # From MC 1.13, fixes MC-1947 [default: true]
     B:fixPumpkinPlacementCheck=true
 
-    # Ender Pearls can be thrown in creative mode. From MC 1.9, fixes MC-438 [default: true]
-    B:throwEnderPearlsInCrativeMode=true
+    # Stops Redstone Torches from causing a memory leak by making them use a weak hash map to store burnt out torches.
+    # Fixes MC-101233 [default: true]
+    B:fixRedstoneTorchMemoryLeak=true
+
+    #  [default: true]
+    B:fixShearedBlocksDropExtraItems=true
+
+    # Ender Pearls can be thrown in creative mode.
+    # From MC 1.9, fixes MC-438 [default: true]
+    B:throwEnderPearlsInCreativeMode=true
 }
 
 
 "bug fixes" {
-    # Fire Charges have the correct use sound. From MC 1.8, fixes MC-1831 [default: true]
+    # Makes the anvil sound type step a valid sound
+    # Also prevents log errors when walking on anvils. [default: true]
+    B:fixAnvilSoundTypeStepSound=true
+
+    # Fixes rendering issues caused by enchantments changing glBlendFunc and never reverting it. [default: true]
+    B:fixEnchantmentBlendFunc=true
+
+    # Fire Charges have the correct use sound.
+    # From MC 1.8, fixes MC-1831 [default: true]
     B:fixFireChargeUseSound=true
 
-    # Lava will only hiss when mixing with water. From MC 1.8, fixes MC-32301 [default: true]
+    # Lava will only hiss when mixing with water.
+    # From MC 1.8, fixes MC-32301 [default: true]
     B:fixLavaHissOnAirReplace=true
 
-    # Shearing a block will not give drops in addition to itself [default: true]
-    B:fixShearedBlocksDropExtraItems=true
+    # Fixes edge case bugs when shift clicking item stacks
+    # An alternate version is used if CoFHCore is installed to fix dupes and item deletion it introduces. [default: true]
+    B:fixMergeItemStack=true
 
-    # Shears will take damage when used to mine any block. From MC 1.9, fixes MC-8180 [default: true]
+    # Fixes the air bubbles mineshafts create above their dirt rooms, affects all terrain but very noticeable in oceans.\nThese air pockets were supposed to be in the dirt rooms so this also fixes the dirt rooms having blocked off entrances to some branches.\nFrom MC 1.8, fixes MC-954 [default: true]
+    B:fixMineshaftAirPockets=true
+
+    # Fixes improperly terminated client connections sometimes causing a severe resource leak. [default: true]
+    B:fixNettyConnectionFailureResourceLeak=true
+
+    # Fixes particle depth being incorrectly calculated. [default: true]
+    B:fixParticleDepthSorting=true
+
+    # Shearing tall grass will not give drops in addition to itself. [default: true]
+    B:fixShearedGrassDropDupe=true
+
+    # Shearing leaves will not give drops in addition to itself. [default: true]
+    B:fixShearedLeavesDropDupe=true
+
+    # Shears will take damage when used to mine any block.
+    # Also stops Forge shearing logic from dropping things in creative mode.
+    # From MC 1.9, fixes MC-8180 [default: true]
     B:fixShearsNotTakingDamageFromNormalBlocks=true
 
-    # Sign update packets for signs in unloaded chunks will not send chat messages. From MC 1.9, fixes MC-3564 [default: true]
+    # Sign update packets for signs in unloaded chunks will not send chat messages.
+    # From MC 1.9, fixes MC-3564 [default: true]
     B:fixSignPacketChatMessages=true
 
-    # Stone Monster Eggs only spawn one Silverfish when broken. From MC 1.8, fixes MC-31081 [default: true]
+    # Stone Monster Eggs only spawn one Silverfish when broken.
+    # From MC 1.8, fixes MC-31081 [default: true]
     B:fixStoneMonsterEggDoubleSpawns=true
 
-    # Village paths will not have flowers or grass on top of them. From MC 1.10, fixes MC-3437 [default: true]
+    # Makes structure component downfilling also replace blocks flagged as replaceable.
+    # Mostly prevents tall grass and flowers from embedding in structure foundations. [default: true]
+    B:fixStructureComponentDownfillReplacement=true
+
+    # Village paths will not have flowers or grass on top of them.
+    # From MC 1.10, fixes MC-3437 [default: true]
     B:fixVillagePathsHavePlantsOnTop=true
 
-    # Zombies will seige villages that are large enough at night. From MC 1.8, fixes MC-7432 and MC-7488 [default: true]
+    # Zombies will siege villages that are large enough at night.
+    # From MC 1.8, fixes MC-7432 and MC-7488 [default: true]
     B:fixVillageSieges=true
 
-    # Wells in desert villages will use the correct material. From MC 1.8, fixes MC-32514 [default: true]
+    # Wells in desert villages will use the correct material.
+    # From MC 1.8, fixes MC-32514 [default: true]
     B:fixVillageWellDesertMaterial=true
+
+    # Villager trades will respect metadata.
+    # Currently unfinished and disabled internally.
+    # From MC 1.8 [default: true]
+    B:fixVillagerTradeMetadataDetection=true
 }
 
 
 "performance improvements" {
-    # Broken chests don't split apart dropped item stacks [default: true]
+    # Broken chests don't split apart dropped item stacks. [default: false]
     B:brokenChestsDontSplitStacks=true
 
-    # Dropped item nearby stack checks are faster for full stacks [default: true]
+    # Broken hoppers don't split apart dropped item stacks. [default: false]
+    B:brokenHoppersDontSplitStacks=false
+
+    # Dropped item nearby stack checks are faster for full stacks. [default: true]
     B:fasterDroppedItemStackingChecks=true
 
-    # isPotionActive returns faster with 0 active potions and setAir only updates it's datawatcher when needed [default: true]
+    # isPotionActive returns immediately if there are no active potions.
+    # setAir only updates its datawatcher when needed. [default: true]
     B:fasterEntityLivingBaseIsPotionActiveAndSetAir=true
 
-    # When something gets air from using its ID it will return faster [default: true]
+    # When something gets air blocks from ID it will return faster. [default: true]
     B:fasterGetBlockByIdForAirBlocks=false
 
-    # Non-layered snow block ticks are faster [default: true]
+    # Makes several functions used by option buttons faster. [default: false]
+    B:fasterOptionInteractions=false
+
+    # Makes the function that reads options.txt much faster. [default: false]
+    B:fasterOptionLoading=false
+
+    # Non-layered snow block ticking is faster. [default: true]
     B:fasterSnowBlockTicks=true
 
-    # Makes BlockChest.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInBlockChest=false
+    # The faces of layered snow get culled more accurately when chunk meshes are created. [default: true]
+    B:moreAccurateLayeredSnowFaceCulling=true
 
-    # Makes EffectRenderer.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInEffectRenderer=true
+    # Makes EffectRenderer.class use a faster implementation of random. [default: true]
+    B:replaceRandomInEffectRenderer=true
 
-    # Makes Entity.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInEntity=true
+    # Makes Entity.class use a faster implementation of random. [default: true]
+    B:replaceRandomInEntity=true
 
-    # Makes MinecraftServer.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInMinecraftServer=true
+    # Makes Item.class use a faster implementation of random. [default: true]
+    B:replaceRandomInItem=true
 
-    # Makes RenderItem.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInRenderItem=true
+    # Makes MinecraftServer.class use a faster implementation of random. [default: true]
+    B:replaceRandomInMinecraftServer=true
 
-    # !This changes world generation! Makes World.class use a faster implementation of random [default: false]
-    B:replaceRandomWithXSTRInWorld=false
+    # Makes RenderItem.class use a faster implementation of random. [default: true]
+    B:replaceRandomInRenderItem=true
 
-    # Makes WorldClient.class use a faster implementation of random [default: true]
-    B:replaceRandomWithXSTRInWorldClient=true
+    # Makes World.class use a faster implementation of random.
+    # !This impacts world generation slightly! [default: false]
+    B:replaceRandomInWorld=false
 
-    # Speeds up initial world loading by not waiting for as many chunks to preload [default: true]
+    # Makes WorldClient.class use a faster implementation of random. [default: true]
+    B:replaceRandomInWorldClient=true
+
+    # Speeds up initial world loading by not waiting for chunks to preload. [default: true]
     B:skipInitialWorldChunkLoad=false
 }
 
 
 tweaks {
-    # Override the port used when opening singleplayer to LAN [default: false]
+    # Makes Enchantment Tables emit particles for any block with enchantment power. [default: true]
+    B:enchantmentParticlesForPowerAboveZero=true
+
+    # Farmland can use hydroponics. [default: false]
+    B:farmlandHydroponics=false
+
+    # New side textures for both wet and dry farmland. [default: false]
+    B:farmlandNewTextures=false
+
+    # Farmland will no longer get trampled. [default: false]
+    B:farmlandNoTrample=false
+
+    # Override the port used when opening singleplayer to LAN. [default: false]
     B:lanPortOverride=false
 
-    # Port to use for lanPortOverride [range: 1024 ~ 49151, default: 25565]
-    I:lanPortToUSeForOverride=25565
+    # Port to use for lanPortOverride. [range: 1024 ~ 49151, default: 25565]
+    I:lanPortToUseForOverride=25565
+
+    # Place End Portals outside of the overworld without them getting removed. [default: false]
+    B:placeEndPortalsAnywhere=false
+
+    # Place pressure plates on almost any wall or fence. [default: true]
+    B:placePressurePlatesOnAnyWallOrFence=true
+
+    # Place torches on almost any fence. [default: true]
+    B:placeTorchesOnAnyFence=true
+
+    # Place torches on almost any wall. [default: true]
+    B:placeTorchesOnAnyWall=true
+
+    # Potion particles coming off of the player entity you control are always clear. [default: false]
+    B:potionParticlesAreClearForClientPlayer=false
+
+    # Reduces lightning volume and effective range.
+    # Set to 10,000 to disable. [range: 2.0 ~ 10000.0, default: 10000.0]
+    S:reduceLightningVolume=10000.0
+
+    # Removes "An attempt was made to register extended properties using an existing key" log spam caused by some mods. [default: true]
+    B:removeEntityDuplicateExtendedPropertiesIdentifierSpam=true
+
+    # Amount of flat player health to remove each drowning tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledDrowningDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each drowning tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledDrowningDamageMaxHealthMult=0.0
+
+    # Amount of flat player health to remove each fire tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledFireDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each fire tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledFireDamageMaxHealthMult=0.0
+
+    # Amount of flat player health to remove each lava tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledLavaDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each lava tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledLavaDamageMaxHealthMult=0.0
+
+    # Portion of max player health to remove each poison effect tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledPoisonDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each poison effect tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledPoisonDamageMaxHealthMult=0.0
+
+    # Amount of flat player health to remove each starvation tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledStarvationDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each starvation tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledStarvationDamageMaxHealthMult=0.0
+
+    # Portion of max player health to remove each suffocation tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledSuffocationDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each suffocation tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledSuffocationDamageMaxHealthMult=0.0
+
+    # Portion of max player health to remove each wither effect tick.
+    # Set to 0 to disable. [range: 0.0 ~ 20000.0, default: 0.0]
+    S:scaledWitherDamageMaxHealthFlat=0.0
+
+    # Portion of max player health to remove each wither effect tick.
+    # Set to 0 to disable. [range: 0.0 ~ 1.0, default: 0.0]
+    S:scaledWitherDamageMaxHealthMult=0.0
 }
 
 

--- a/config/bugtorch/mixins.cfg
+++ b/config/bugtorch/mixins.cfg
@@ -36,7 +36,7 @@
     B:fixAnvilSoundTypeStepSound=true
 
     # Fixes rendering issues caused by enchantments changing glBlendFunc and never reverting it. [default: true]
-    B:fixEnchantmentBlendFunc=true
+    B:fixEnchantmentBlendFunc=false
 
     # Fire Charges have the correct use sound.
     # From MC 1.8, fixes MC-1831 [default: true]
@@ -57,7 +57,7 @@
     B:fixNettyConnectionFailureResourceLeak=true
 
     # Fixes particle depth being incorrectly calculated. [default: true]
-    B:fixParticleDepthSorting=true
+    B:fixParticleDepthSorting=false
 
     # Shearing tall grass will not give drops in addition to itself. [default: true]
     B:fixShearedGrassDropDupe=true
@@ -128,7 +128,7 @@
     B:fasterSnowBlockTicks=true
 
     # The faces of layered snow get culled more accurately when chunk meshes are created. [default: true]
-    B:moreAccurateLayeredSnowFaceCulling=true
+    B:moreAccurateLayeredSnowFaceCulling=false
 
     # Makes EffectRenderer.class use a faster implementation of random. [default: true]
     B:replaceRandomInEffectRenderer=true
@@ -150,7 +150,7 @@
     B:replaceRandomInWorld=false
 
     # Makes WorldClient.class use a faster implementation of random. [default: true]
-    B:replaceRandomInWorldClient=true
+    B:replaceRandomInWorldClient=false
 
     # Speeds up initial world loading by not waiting for chunks to preload. [default: true]
     B:skipInitialWorldChunkLoad=false
@@ -159,7 +159,7 @@
 
 tweaks {
     # Makes Enchantment Tables emit particles for any block with enchantment power. [default: true]
-    B:enchantmentParticlesForPowerAboveZero=true
+    B:enchantmentParticlesForPowerAboveZero=false
 
     # Farmland can use hydroponics. [default: false]
     B:farmlandHydroponics=false

--- a/config/coretweaks.cfg
+++ b/config/coretweaks.cfg
@@ -293,7 +293,7 @@ tweaks {
 
     extend_sprint_time_limit {
         # In vanilla, the player can't sprint for longer than 30 seconds. This tweak increases this limit to be virtually infinite. Fixes MC-4839, fixed in 1.9 [default: true]
-        S:_enabled=true
+        S:_enabled=false
     }
 
     force_uncap_framerate {

--- a/config/eternalsingularity.cfg
+++ b/config/eternalsingularity.cfg
@@ -2,9 +2,7 @@
 
 general {
     S:classNameList <
-        com.rcx.aobdsingularities.item.AOBDItemSingularity
         fox.spiteful.avaritia.items.ItemSingularity
-        wanion.thermsingul.ThermalSingularityItem
         wealthyturtle.uiesingularities.UniversalSingularityItem
      >
 

--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -254,7 +254,7 @@ fixes {
     B:fixTooManyAllocationsChunkPositionIntPair=true
 
     # Fix exiting fullscreen when you tab out of the game [default: true]
-    B:fixUnfocusedFullscreen=true
+    B:fixUnfocusedFullscreen=false
 
     # Fix URISyntaxException in forge. [default: true]
     B:fixUrlDetection=true
@@ -364,7 +364,7 @@ speedups {
     B:optimizeTextureLoading=true
 
     # Optimize tileEntity removal in World.class [default: true]
-    B:optimizeTileentityRemoval=true
+    B:optimizeTileentityRemoval=false
 
     # Replace reflection in VoxelMap to directly access the fields instead. [default: true]
     B:replaceVoxelMapReflection=true


### PR DESCRIPTION
Some patches are done similarly by multiple mods. This PR disables one mixin for each such pair.

The two deleted lines in `eternalsingularity.cfg` are classes of mods we don't use in the pack.