### PR TITLE
Add roasted dusts to miner's backpack

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -3467,12 +3467,6 @@ backpacks {
             dustImpureRareEarthI
             dustImpureRareEarthII
             dustImpureRareEarthIII
-            dustImpureRareEarth
-            dustImpureRarestMetalResidue
-            dustImpureRawGasoline
-            dustImpureRawRadox
-            dustImpureRawRubber
-            dustImpureRawStyreneButadieneRubber
             dustImpureRealgar
             dustImpureRed
             dustImpureRedAlloy

--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -3464,6 +3464,9 @@ backpacks {
             dustImpureRadoxGas
             dustImpureRadoxPoly
             dustImpureRandomite
+            dustImpureRareEarthI
+            dustImpureRareEarthII
+            dustImpureRareEarthIII
             dustImpureRareEarth
             dustImpureRarestMetalResidue
             dustImpureRawGasoline

--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -4428,8 +4428,15 @@ backpacks {
             dustRhodiumSulfateSolution
             dustRhugnor
             dustRhyolite
+            dustRoastedAntimony
+            dustRoastedArsenic
+            dustRoastedCobalt
+            dustRoastedCopper
             dustRoastedIron
+            dustRoastedLead
             dustRoastedNickel
+            dustRoastedRareEarthOxides
+            dustRoastedZinc
             dustRockSalt
             dustRoquesite
             dustRoseGold


### PR DESCRIPTION
#19193 reports roasted nickel dust not going into miner's backpack. That was fixed by #18745, but other roasted dusts still were missing. Also added impure rare earth dusts and removed few dusts which don't seem to exist anymore.