### PR TITLE
Fix typo in ServerUtilities backup config

### DIFF
--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -33,7 +33,7 @@ backups {
     # List of additional paths to include in backup. Use / as directory separator! Use * as wildcard, and $WORLDNAME for the save name. If specifying a folder, the path should end with "/**" to match all subfolders and files. [default: [saves/NEI/global/**], [saves/NEI/local/$WORLDNAME/**]]
     S:additional_backup_files <
         journeymap/data/sp/$WORLDNAME/**
-        TCNodeTracker/$WORLDNAME/**"
+        TCNodeTracker/$WORLDNAME/**
         saves/NEI/global/**
         saves/NEI/local/$WORLDNAME/**
         visualprospecting/client/*/$WORLDNAME_*/**


### PR DESCRIPTION
Not sure where that quote came from, but it needs to be removed. Sorry about that...