### PR TITLE
Edited Quest description

### DIFF
--- a/config/txloader/load/betterquesting/lang/template.lang
+++ b/config/txloader/load/betterquesting/lang/template.lang
@@ -6959,7 +6959,7 @@ betterquesting.quest.AAAAAAAAAAAAAAAAAAAK5Q.desc=If you're still burning Creosot
 
 # Quest: Putting the 'Semi' Back Into Generators HV
 betterquesting.quest.AAAAAAAAAAAAAAAAAAAK5g.name=Putting the 'Semi' Back Into Generators HV
-betterquesting.quest.AAAAAAAAAAAAAAAAAAAK5g.desc=If you've built Distillation Towers to improve your Oil or Benzene processing line, you might have ended up with some extra fuels that are semifluids, such as Heavy Fuel or Creosote. If you've accumulated them so much that they've started voiding, you can instead make an HV Semifluid Generator and get free power out of them!%n%nThe Creosote from one DT that is processing Wood Tar is enough to power the DT itself, depending on the fuel efficiency. One HV generator is just enough to power it.
+betterquesting.quest.AAAAAAAAAAAAAAAAAAAK5g.desc=If you've built Distillation Towers to improve your Oil or Benzene processing line, you might have ended up with some extra fuels that are semifluids, such as Heavy Fuel or Creosote. If you've accumulated them so much that they've started voiding, you can instead make an HV Semifluid Generator and get free power out of them!%n%nThe Creosote from one DT that is processing Wood Tar is enough to power the DT itself, depending on the fuel efficiency. One HV generator is not quite enough to power it.
 
 # Quest: You Haven't Learned How to Separate Fluids Yet? Seriously?
 betterquesting.quest.AAAAAAAAAAAAAAAAAAAK5w.name=You Haven't Learned How to Separate Fluids Yet? Seriously?


### PR DESCRIPTION
Edited the Quest description of the "Putting the 'Semi' Back Into Generators HV" quest in the "How to Generate Power" line to reflect that one HV-Semi-Fluid Generator is not quite enough to power the DT.
See also the [bug-report](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19324)