### PR TITLE
Revert "Disable registry name tooltip from EnderCore"

### DIFF
--- a/config/endercore/endercore.cfg
+++ b/config/endercore/endercore.cfg
@@ -76,7 +76,7 @@ general {
     # 2 - Only with shift
     # 3 - Only in debug mode
     # [range: 0 ~ 3, default: 3]
-    I:showRegistryNameTooltips=0
+    I:showRegistryNameTooltips=3
 
     # 0 - Do nothing
     # 1 - Remove stacktraces, leave 1-line missing texture errors


### PR DESCRIPTION
Reverts GTNewHorizons/GT-New-Horizons-Modpack#9905

As it turns out, the other mod that added this information was probably Inventory Tweaks which has since been removed from the pack.