### PR TITLE
Make geodes more rare and allow budding amethyst to be silktouched

### DIFF
--- a/config/etfuturum/world.cfg
+++ b/config/etfuturum/world.cfg
@@ -76,7 +76,7 @@ generation {
     S:amethystOuterBlockID=etfuturum:tuff
 
     # How rare should amethyst geodes be? 1/x chance per chunk, 1 means a geode attempts to appear every chunk [range: 1 ~ 127, default: 53]
-    I:amethystRarity=53
+    I:amethystRarity=127
 
     # Whether bamboo should naturally spawn in the overworld. Turning this off allows you to use bamboo based blocks without bamboo world gen for mod compatability. [default: true]
     B:bambooWorldgen=false
@@ -84,7 +84,7 @@ generation {
     # 0 = Budding amethyst cannot be obtained at all even with silk touch. When using this option, attempting to push them using a piston will break it.
     # 1 = Budding amethyst will drop if you use a silk touch pickaxe.
     # 2 = Budding amethyst does not need silk touch, just a pickaxe. [range: 0 ~ 2, default: 0]
-    I:buddingAmethystMode=0
+    I:buddingAmethystMode=1
 
     # How rare should cherry trees be? 1/x chance per chunk, 1 means a tree attempts to appear every chunk. 0 = no cherry trees. They will spawn in mountain-type biomes. [range: 0 ~ 127, default: 72]
     I:cherryTreeRarity=72


### PR DESCRIPTION
I think that geodes should be spaced out a lot more, the highest value the config lets you do is to make them 2.4 times more rare

Also, if stuff like budding amethyst can be transported in AE2 spatial cells and with a dislocation focus and the like, I don't really see harm in letting them be silk touched