### PR TITLE
feat(config/dreamcraft_charcoal.zs): Add Charcoal Decompression Recipes

### DIFF
--- a/config/dreamcraft_charcoal.zs
+++ b/config/dreamcraft_charcoal.zs
@@ -1,0 +1,33 @@
+"""""
+// GTNH Dreamcraft Compressed Charcoal Decompression
+// Added by Agent - Allows decompression of higher-tier compressed charcoal blocks
+
+print("--- Loading Dreamcraft Charcoal Decompression Recipes ---");
+
+// Define items for clarity (optional but good practice)
+val quint = <dreamcraft:tile.QuintupleCompressedCharcoal>;
+val quad  = <dreamcraft:tile.QuadrupleCompressedCharcoal>;
+val triple = <dreamcraft:tile.TripleCompressedCharcoal>;
+val double = <dreamcraft:tile.DoubleCompressedCharcoal>;
+val single = <dreamcraft:tile.CompressedCharcoal>;
+
+// --- Decompression Recipes ---
+
+// Quintuple -> Quadruple
+recipes.addShapeless(quad * 9, [quint]);
+print("Added Decompression: Quintuple -> 9 Quadruple Charcoal");
+
+// Quadruple -> Triple
+recipes.addShapeless(triple * 9, [quad]);
+print("Added Decompression: Quadruple -> 9 Triple Charcoal");
+
+// Triple -> Double
+recipes.addShapeless(double * 9, [triple]);
+print("Added Decompression: Triple -> 9 Double Charcoal");
+
+// Double -> Single
+recipes.addShapeless(single * 9, [double]);
+print("Added Decompression: Double -> 9 Single Charcoal");
+
+print("--- Finished Loading Dreamcraft Charcoal Decompression Recipes ---");
+"""""


### PR DESCRIPTION
This pull request introduces decompression recipes for higher-tier compressed charcoal blocks in Dreamcraft. It allows players to uncompress quintuple, quadruple, triple, and double compressed charcoal into their respective lower tiers by using the forge hammer style shapeless recipes. The changes include:

- Adding a recipe to convert a quintuple compressed charcoal block into 9 quadruple compressed blocks.
- Adding a recipe to convert a quadruple compressed charcoal block into 9 triple compressed blocks.
- Adding a recipe to convert a triple compressed charcoal block into 9 double compressed blocks.
- Adding a recipe to convert a double compressed charcoal block into 9 single compressed blocks.

These modifications Closes [#19647](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19647) by providing a consistent method for decompressing charcoal blocks, thereby enhancing resource management options within the modpack.

All changes follow the pack's existing style and recipe conventions. Please review and merge.

---
*Created with [Repobird.ai](https://repobird.ai) 📦🐦*