### PR TITLE
re-enable optimizeTileentityRemoval

### DIFF
--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -500,7 +500,7 @@ speedups {
     B:optimizeTextureLoading=true
 
     # Optimize tileEntity removal in World.class [default: true]
-    B:optimizeTileentityRemoval=false
+    B:optimizeTileentityRemoval=true
 
     # Replace reflection in VoxelMap to directly access the fields instead. [default: true]
     B:replaceVoxelMapReflection=true


### PR DESCRIPTION
This was disabled in #19216 to prevent hodgepodge-AF conflict. since [AF now disable its removeAll() patches if hodgepodge is present](https://github.com/embeddedt/ArchaicFix/pull/142), hodgepodge's implementation must be re-enabled or else we'd be left with no one to fix the lag