### PR TITLE
Don't use experimental EFR features

### DIFF
--- a/config/etfuturum/experiments.cfg
+++ b/config/etfuturum/experiments.cfg
@@ -23,7 +23,7 @@
 
     # Enables the crimson nylium, wood, and plants. This must be on for the crimson forest biome to generate unless Netherlicious is installed.
     # The nether wart block is still a separate toggle, both this and the wart toggle must be turned off to disable the nether wart block, because crimson trees need the wart blocks. [default: false]
-    B:enableCrimsonBlocks=true
+    B:enableCrimsonBlocks=false
 
     # Partially functional. Does not naturally generate. [default: false]
     B:enableDripstone=false
@@ -32,16 +32,16 @@
     B:enableLightningRod=false
 
     # Enables mangrove wood and all of its wood subtypes, and the roots (+ muddy versions). [default: false]
-    B:enableMangroveBlocks=true
+    B:enableMangroveBlocks=false
 
     # Enables moss and azalea. Currently azalea saplings do not grow. [default: false]
-    B:enableMossAzalea=true
+    B:enableMossAzalea=false
 
     # Enables sculk-related blocks. [default: false]
-    B:enableSculk=true
+    B:enableSculk=false
 
     # Enables the warped nylium, wood, and plants. This must be on for the warped forest biome to generate unless Netherlicious is installed. Requires newNether to be enabled without Netherlicious. [default: false]
-    B:enableWarpedBlocks=true
+    B:enableWarpedBlocks=false
 
     # Enables outer end island generation from 1.9. Gateways are implemented but currently don't generate, but they work. The new dragon fight is currently not implemented and it does not spawn any gateways. [default: false]
     B:endDimensionProvider=false


### PR DESCRIPTION
https://discord.com/channels/181078474394566657/1321069193646444568/1369402563123871875 for context.

We currently don't need these features enough to justify any additional maintenance burden, so let's not use them until they're deemed final.

The stripped logs for crimson & warped trees will need to be removed from https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1228

Should be merged along with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1257 & https://github.com/GTNewHorizons/GT5-Unofficial/pull/4273