### PR TITLE
Small Fixes

### DIFF
--- a/config/EnhancedLootBags/LootBags.xml
+++ b/config/EnhancedLootBags/LootBags.xml
@@ -1887,7 +1887,6 @@
         <Loot Identifier="a00b915c-223b-4e8e-a06b-44186c3368d0" ItemName="OpenComputers:item:83" Amount="1" NBTTag="" Chance="50" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="0d90ca91-a09b-4a78-91e1-4216af813884" ItemName="OpenComputers:item:63" Amount="1" NBTTag="" Chance="65" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="bdbc0bac-d8ee-41f5-893f-c98988dd24bd" ItemName="OpenComputers:item:54" Amount="1" NBTTag="" Chance="65" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="58b74cf6-f06d-47c8-b998-c03eb9bac1c6" ItemName="OpenComputers:eeprom" Amount="1" NBTTag="{oc:data:{oc:readonly:0b,oc:eeprom:[1617 bytes],oc:label:&quot;EEPROM (Lua BIOS)&quot;}}" Chance="75" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="fcdc1466-405c-4e3b-bf3d-56fca7c0fdcc" ItemName="computronics:computronics.colorfulLamp" Amount="1" NBTTag="" Chance="65" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="2b61659b-f076-4414-a3a0-5a9292a9fcc7" ItemName="computronics:computronics.chatBox" Amount="1" NBTTag="" Chance="65" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="d90b909f-0c3b-4fe9-b703-614f17f5c376" ItemName="computronics:computronics.camera" Amount="1" NBTTag="" Chance="65" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/GasPlanets-AAAAAAAAAAAAAAAAAAAMiQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/GasPlanets-AAAAAAAAAAAAAAAAAAAMiQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You probably also want a good overview of what you can get with your Gas Siphon. So here we go:\n\n\nJupiter§r\n1 Hydrogen - 15000 L/s\n2 Helium - 500 L/s\n3 Nitrogen - 300 L/s\n4 Oxygen - 200 L/s\n\n§oSaturn§r\n1 Hydrogen - 18000 L/s\n2 Helium - 800 L/s\n3 Oxygen - 500 L/s\n4 Liquid Oxygen - 150 L/s\n\n§oUranus§r\n1 Deuterium - 5000 L/s\n2 Neon - 450 L/s\n3 Argon - 250 L/s\n4 Krypton - 100 L/s\n\n§oNeptune§r\n1 Tritium - 3000 L/s\n2 Helium-3 - 500 L/s\n3 Ammonia - 400 L/s\n4 Xenon - 350 L/s",
+      "desc:8": "You probably also want a good overview of what you can get with your Planetary Gas Siphon, and the tiers of the gas giants. So here we go:\n\nJupiter (Tier 3)\n1 Hydrogen - 15000 L/s\n2 Helium - 500 L/s\n3 Nitrogen - 300 L/s\n4 Oxygen - 200 L/s\n\nSaturn (Tier 5)\n1 Hydrogen - 18000 L/s\n2 Helium - 800 L/s\n3 Oxygen - 500 L/s\n4 Liquid Oxygen - 150 L/s\n\nUranus (Tier 5)\n1 Deuterium - 5000 L/s\n2 Neon - 450 L/s\n3 Argon - 250 L/s\n4 Krypton - 100 L/s\n\nNeptune (Tier 6)\n1 Tritium - 3000 L/s\n2 Helium-3 - 500 L/s\n3 Ammonia - 400 L/s\n4 Xenon - 350 L/s",
       "globalShare:1": 0,
       "icon:10": {
         "Count:3": 1,

--- a/config/txloader/load/betterquesting/lang/template.lang
+++ b/config/txloader/load/betterquesting/lang/template.lang
@@ -14384,7 +14384,7 @@ betterquesting.quest.AAAAAAAAAAAAAAAAAAAMeA.desc=Some turbine materials are not 
 
 # Quest: Gas Planets
 betterquesting.quest.AAAAAAAAAAAAAAAAAAAMiQ.name=Gas Planets
-betterquesting.quest.AAAAAAAAAAAAAAAAAAAMiQ.desc=You probably also want a good overview of what you can get with your Gas Siphon. So here we go:%n%n%nJupiter§r%n1 Hydrogen - 15000 L/s%n2 Helium - 500 L/s%n3 Nitrogen - 300 L/s%n4 Oxygen - 200 L/s%n%n§oSaturn§r%n1 Hydrogen - 18000 L/s%n2 Helium - 800 L/s%n3 Oxygen - 500 L/s%n4 Liquid Oxygen - 150 L/s%n%n§oUranus§r%n1 Deuterium - 5000 L/s%n2 Neon - 450 L/s%n3 Argon - 250 L/s%n4 Krypton - 100 L/s%n%n§oNeptune§r%n1 Tritium - 3000 L/s%n2 Helium-3 - 500 L/s%n3 Ammonia - 400 L/s%n4 Xenon - 350 L/s
+betterquesting.quest.AAAAAAAAAAAAAAAAAAAMiQ.desc=You probably also want a good overview of what you can get with your Planetary Gas Siphon, and the tiers of the gas giants. So here we go:%n%nJupiter (Tier 3)%n1 Hydrogen - 15000 L/s%n2 Helium - 500 L/s%n3 Nitrogen - 300 L/s%n4 Oxygen - 200 L/s%n%nSaturn (Tier 5)%n1 Hydrogen - 18000 L/s%n2 Helium - 800 L/s%n3 Oxygen - 500 L/s%n4 Liquid Oxygen - 150 L/s%n%nUranus (Tier 5)%n1 Deuterium - 5000 L/s%n2 Neon - 450 L/s%n3 Argon - 250 L/s%n4 Krypton - 100 L/s%n%nNeptune (Tier 6)%n1 Tritium - 3000 L/s%n2 Helium-3 - 500 L/s%n3 Ammonia - 400 L/s%n4 Xenon - 350 L/s
 
 # Quest: Hypogen Coil Upgrade
 betterquesting.quest.AAAAAAAAAAAAAAAAAAAMkg.name=§6§lHypogen Coil Upgrade


### PR DESCRIPTION
Two very small changes.
1. Remove EEPROM (Lua BIOS) from the lootbag pool because it does NOT work and causes a "no bootable medium found" error
2. Adds the tiers of the gas giants to the quest book.