### PR TITLE
Restore the original catastrophical explosion

### DIFF
--- a/config/DraconicEvolution.cfg
+++ b/config/DraconicEvolution.cfg
@@ -2,7 +2,7 @@
 
 "draconic reactor" {
     # Setting this to false will reduce the reactor explosion to little more then a tnt blast
-    B:EnableBigExplosion=false
+    B:EnableBigExplosion=true
 
     # Use this to adjust the output of the reactor
     I:EnergyOutputMultiplier=1


### PR DESCRIPTION
Revert the config change introduced in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/19259
It's a config, people can always disable it, but for pack default, it should be on.