### PR TITLE
Fix ProjectRed Lamps grouping for Inverted White Lamp

### DIFF
--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -349,7 +349,7 @@ projectred.illumination.cagelamp.inv
 projectred.illumination.cagelamp
 projectred.illumination.lightbutton
 projectred.illumination.flightbutton
-projectred.illumination.lamp 0-16
+projectred.illumination.lamp 0-15
 projectred.illumination.lamp 16-31
 projectred.core.part 19-34
 #projectred lily seed


### PR DESCRIPTION
Fixed off by one ProjectRed Lamp groupings - **Inverted White Lamp** is in normal lamps group.

Previous:
![image](https://github.com/user-attachments/assets/2a058ff3-c865-49cb-9996-298828fecefe)

After the fix:
![image](https://github.com/user-attachments/assets/1baa5a21-66ab-4311-a2e2-53ceff50f595)
