### PR TITLE
Make dirty portal generator optional, so you don't have to make it again

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SearchingforAnsw-AAAAAAAAAAAAAAAAAAAA4Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SearchingforAnsw-AAAAAAAAAAAAAAAAAAAA4Q==.json
@@ -100,7 +100,7 @@
           "id:8": "dreamcraft:item.TwilightCrystal"
         }
       },
-      "taskID:8": "bq_standard:retrieval"
+      "taskID:8": "bq_standard:optional_retrieval"
     },
     "1:10": {
       "biome:3": -1,


### PR DESCRIPTION
Problem:
The "Searching for Answers" quest has two requirements, the "Welcome to Tier 1,LV" will probably be completed before you can complete this quest (unless you free ride through someones portal in MP), and the "What's That...?" quest that requires you to collect a silver wood sap and log and greater wood sap and log, the tasks from the latter quest are not a strict requirement to make a dirty portal gen, so if you by any chance forget to complete this quest and make a dirty portal gen and use it to open the portal, you are not going to be able to complete this quest because you don't have the dirty portal gen anymore but have entered the twilight forest, of course unless you make another dirty portal gen, but then yo just wasted 4 circuits and a diamond and can't even recycle it.
![image](https://github.com/user-attachments/assets/fa9961f6-6aa3-4edd-b239-6958b6613cac)

So this change makes it so the dirty portal gen is a optional requirement to complete the quest.
