### PR TITLE
Bees attempt to plant Enderlotuses

### DIFF
--- a/config/forestry/apiculture.cfg
+++ b/config/forestry/apiculture.cfg
@@ -32,6 +32,7 @@ beekeeping {
                 minecraft:red_flower:7
                 minecraft:red_flower:8
                 minecraft:yellow_flower:0
+                BiomesOPlenty:flowers:11
              >
         }
 


### PR DESCRIPTION
Ensures the Enderlotus is still being dropped by bees attempting to plant them.

Required by: https://github.com/GTNewHorizons/ForestryMC/pull/94

This ensure this behaviour is maintained in GTNH while being patched in other packs where it is not intended