### PR TITLE
Fix Industrial Arc Furnace Quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Baskinthecurrent-AAAAAAAAAAAAAAAAAAAH7Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Baskinthecurrent-AAAAAAAAAAAAAAAAAAAH7Q==.json
@@ -12,7 +12,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "The best source for hundreds of thousands of glass for...something? I dunno, think of something interesting and impress me!\n\nThe \"effective\" voltage for the High Current Arc furnace is one tier lower than the energy hatch. For example, with an MV tier energy hatch, it will do LV tier arc furnace recipes.\n\nThis machine also does plasma arc furnace recipes.\n\n[note]This multi is LuV and requires Thorium 232.[/note]",
+      "desc:8": "The best source for hundreds of thousands of glass for...something? I dunno, think of something interesting and impress me!\n\nThis machine also does plasma arc furnace recipes.\n\n[note]This multi is LuV and requires Thorium 232.[/note]",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,


### PR DESCRIPTION
This line in the quest book is just incorrect. Tested in-game with a single UXV energy hatch trying to run a UXV recipe (it worked).