### PR TITLE
Update ArchitectureCraft config to properly support shapes of "neon" blocks

### DIFF
--- a/config/ArchitectureCraft.cfg
+++ b/config/ArchitectureCraft.cfg
@@ -18,5 +18,13 @@ materials {
         tile.chisel.stained_glass_magenta
         tile.chisel.stained_glass_orange
         tile.chisel.stained_glass_white
+        tile.extrautils:greenscreen
     >
+    
+    # Blocks that will be rendered with full brightness [default: [ExtraUtilities:greenscreen], [chisel:antiBlock], [chisel:neonite]]
+    S:EmissiveItemIDs <
+        ExtraUtilities:greenscreen
+        chisel:antiBlock
+        chisel:neonite
+     >
 }


### PR DESCRIPTION
This adds Lapis Caelestis to the ArchitectureCraft block whitelist and makes shapes crafted from those as well as AntiBlocks and Neonite "glow" like their material blocks. This requires ArchitectureCraft [1.10.3](https://github.com/GTNewHorizons/ArchitectureCraft/releases/tag/1.10.3) or later to have any effect.