### PR TITLE
Update QuantumComputer-AAAAAAAAAAAAAAAAAAAH1w==.json

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/QuantumComputer-AAAAAAAAAAAAAAAAAAAH1w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/QuantumComputer-AAAAAAAAAAAAAAAAAAAH1w==.json
@@ -91,7 +91,7 @@
         },
         "1:10": {
           "Count:3": 1,
-          "Damage:2": 15430,
+          "Damage:2": 15431,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockmachines"
         },


### PR DESCRIPTION
Changes Uncertainty Resolver (deprecated) to Uncertainty Resolver X, the actual block you need to craft for the Quantum Computer

Closes: #20014 