### PR TITLE
backport red sandstone 3rd floor to the desert dungeon

### DIFF
--- a/config/roguelike_dungeons/settings/theme_desert.json
+++ b/config/roguelike_dungeons/settings/theme_desert.json
@@ -11,21 +11,66 @@
                 "base": "SANDSTONE"
             }
         },
-             "2": {
+        "2": {
             "theme": {
-                "base": "SANDSTONERED"
-            }
+                "base": "SANDSTONERED",
+			"primary" : {
+				"walls" : {
+					"type" : "WEIGHTED",
+					"data" : [
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone"}, "weight" : 30},
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 1}, "weight" : 1},
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 2}, "weight" : 1}
+						]
+					},
+					"pillar" : {
+						"type" : "METABLOCK",
+						"data" : {
+							"name" : "etfuturum:smooth_red_sandstone",
+							"meta" : "0"
+						}
+					},
+					"stair" : {
+						"type" : "METABLOCK",
+						"data" : {
+							"name" : "etfuturum:red_sandstone_stairs"
+						}
+					}
+				},
+			"secondary" : {
+				"walls" : {
+					"type" : "METABLOCK",
+					"data" : {
+						"name" : "etfuturum:red_sandstone",
+						"meta" : "0"
+						}
+					},
+					"pillar" : {
+						"type" : "METABLOCK",
+						"data" : {
+							"name" : "etfuturum:smooth_red_sandstone",
+							"meta" : "0"
+						}
+					},
+					"stair" : {
+						"type" : "METABLOCK",
+						"data" : {
+							"name" : "etfuturum:red_sandstone_stairs"
+						}
+					}
+				}
+
         },
-             "3": {
+        "3": {
             "theme": {
                 "base": "CRYPT"
             }
         },
-     
         "4": {
             "theme": {
                 "base": "NETHER"
             }
         }
     }
+}
 }

--- a/config/roguelike_dungeons/settings/theme_desert.json
+++ b/config/roguelike_dungeons/settings/theme_desert.json
@@ -18,9 +18,10 @@
 				"walls" : {
 					"type" : "WEIGHTED",
 					"data" : [
-						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone"}, "weight" : 30},
-						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 1}, "weight" : 1},
-						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 2}, "weight" : 1}
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone"}, "weight" : 94},
+						{"type" : "METABLOCK", "data" : {"name" : "minecraft:sand", "meta" : 1}, "weight" : 5},
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 1}, "weight" : 3},
+						{"type" : "METABLOCK", "data" : {"name" : "etfuturum:red_sandstone", "meta" : 2}, "weight" : 3}
 						]
 					},
 					"pillar" : {

--- a/config/roguelike_dungeons/settings/theme_desert.json
+++ b/config/roguelike_dungeons/settings/theme_desert.json
@@ -43,7 +43,7 @@
 					"type" : "METABLOCK",
 					"data" : {
 						"name" : "etfuturum:red_sandstone",
-						"meta" : "0"
+						"meta" : "1"
 						}
 					},
 					"pillar" : {


### PR DESCRIPTION
In the code of roguelike dungeons, the 3rd floor desert dungeon should be red, but red sandstone does not exist in 1.7.10 until it was back ported by EFR. This uses the EFR red sandstone to recreate what it might look like.