### PR TITLE
SpaceRace quest url fix

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/RocketLaunchPad-AAAAAAAAAAAAAAAAAAADNA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/RocketLaunchPad-AAAAAAAAAAAAAAAAAAADNA==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "Every rocket needs a launch pad. Build a 3x3 launch pad and place your rocket on top of it.\n\nStorms and other events that affect entities can knock your rocket off (but not lightning warp anymore), so make sure to not leave it alone.\n\n[warn]Before liftoff, make sure you clear the airspace above you![/warn]\n\nBe sure to check out [url]https://wiki.gtnewhorizons.com/wiki/Rockets[/url] for a Departure Checklist!\n\n[note]Also note that they emit pollution, lots of it. So either put it far from your base, or use a scrubber while launching. You probably won\u0027t have to worry until T4 or so though.[/note]",
+      "desc:8": "Every rocket needs a launch pad. Build a 3x3 launch pad and place your rocket on top of it.\n\nStorms and other events that affect entities can knock your rocket off (but not lightning warp anymore), so make sure to not leave it alone.\n\n[warn]Before liftoff, make sure you clear the airspace above you![/warn]\n\nBe sure to check out [url]https://wiki.gtnewhorizons.com/wiki/Rocket[/url] for a Departure Checklist!\n\n[note]Also note that they emit pollution, lots of it. So either put it far from your base, or use a scrubber while launching. You probably won\u0027t have to worry until T4 or so though.[/note]",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,


### PR DESCRIPTION
Removes trailing `s` letter that leads to a non-existing page.

Fixes issue #19801