### PR TITLE
Too Many (Hidden) Items

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -16,8 +16,9 @@
 #
 minecraft:portal
 minecraft:end_portal
-minecraft:fire
-minecraft:lava
+r/minecraft:fire$/
+r/minecraft:water$/
+r/minecraft:lava$/
 minecraft:mob_spawner
 minecraft:anvil !0
 minecraft:flowing_water


### PR DESCRIPTION
Use regex to fix lava buckets, fire charges, fireworks, and firework stars being hidden unintentionally. For example, minecraft:lava matches minecraft:lava_bucket. The $ in "r/minecraft:lava$/" matches the end of the string, so lava_bucket is now no longer matched and hidden.

Also hide water sources, since lava sources and flowing water/lava were hidden. It was probably not hidden before because of this problem (it would have accidentally hidden lily pads and water buckets).

This is fixed by https://github.com/GTNewHorizons/NotEnoughItems/pull/641 for fresh generations of `hiddenitems.cfg`, but it needs to be fixed here too because of the other added configs like the WG stuff.