### PR TITLE
Disable the EFR Damage Indicator

### DIFF
--- a/config/etfuturum/world.cfg
+++ b/config/etfuturum/world.cfg
@@ -44,7 +44,7 @@ biomes {
 
 client {
     # Heart Damage Indicator [default: true]
-    B:enableDmgIndicator=true
+    B:enableDmgIndicator=false
 }
 
 


### PR DESCRIPTION
This turns off the "black hearts" that indicate how much damage you do to a mob when you hit it. We already have ToroHealth (the mod that adds the number popup when mobs take damage or heal), which makes this feature redundant.