### PR TITLE
Change waila HUD size to 100% for nice font rendering

### DIFF
--- a/config/Waila.cfg
+++ b/config/Waila.cfg
@@ -14,7 +14,7 @@ general {
     B:waila.cfg.newfilters=true
     I:waila.cfg.posx=10000
     I:waila.cfg.posy=10000
-    I:waila.cfg.scale=88
+    I:waila.cfg.scale=100
     B:waila.cfg.shiftblock=false
     B:waila.cfg.shiftents=false
     B:waila.cfg.show=true


### PR DESCRIPTION
Using a size different from 100% makes the font rendering on the HUD look compressed and it looks super ugly, for comparison : 

this is the current of 88% 
![image](https://github.com/user-attachments/assets/d8084118-9c54-4f27-9933-f8d300479b20)

this is the new with 100%
![image](https://github.com/user-attachments/assets/21efb022-eac6-4c61-af0a-23dd37a11cfc)

I just want the game to look nice