### PR TITLE
Set waila icon render to false and edit default colors

### DIFF
--- a/config/Waila.cfg
+++ b/config/Waila.cfg
@@ -1,11 +1,11 @@
 # Configuration file
 
 general {
-    I:waila.cfg.alpha=62
-    I:waila.cfg.bgcolor=1048592
+    I:waila.cfg.alpha=80
+    I:waila.cfg.bgcolor=3357055
     I:waila.cfg.fontcolor=10526880
-    I:waila.cfg.gradient1=5243135
-    I:waila.cfg.gradient2=2621567
+    I:waila.cfg.gradient1=4409791
+    I:waila.cfg.gradient2=4409791
     I:waila.cfg.heartsperline=20
     B:waila.cfg.keybind=true
     B:waila.cfg.liquid=true
@@ -19,6 +19,7 @@ general {
     B:waila.cfg.shiftents=false
     B:waila.cfg.show=true
     B:waila.cfg.showmode=true
+    B:waila.cfg.showicon=false
 }
 
 


### PR DESCRIPTION
I removed the block rendering, there is no reason to have this, why would you need to have a separate HUD that renders a second time the block you are looking at when it's already in the middle of your screen right in front of you ? It takes screenspace for no added value and adds an ugly left padding.

I changed the colors a bit too to reduce the contrast in between the outer line and the background, I'm open to suggestion for the colors.

![image](https://github.com/user-attachments/assets/71799550-e812-4a61-a0a3-cc16c423fb0f)