### PR TITLE
Thaumcraft Research

### DIFF
--- a/config/Thaumcraft.cfg
+++ b/config/Thaumcraft.cfg
@@ -148,7 +148,7 @@ research {
     I:aspect_total_cap=500
 
     # 0 = normal, -1 = easy (all research items are directly purchased with RP), 1 = Hard (all research items need to be solved via the research table)
-    I:research_difficulty=1
+    I:research_difficulty=0
 }
 
 


### PR DESCRIPTION
This makes some Thaumonomicon researches take research points instead of giving a research note to play the minigame with for every research.