### PR TITLE
Add EFR blocks to biggers backpack

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -12258,6 +12258,12 @@ backpacks {
             appliedenergistics2:tile.BlockSkyStone
             appliedenergistics2:tile.BlockSkyStone:1
             etfuturum:magma
+            etfuturum:deepslate
+            etfuturum:tuff
+            etfuturum:tuff:0
+            etfuturum:calcite
+            etfuturum:amethyst_block
+            etfuturum:coarse_dirt
          >
 
         # Add ore dictionary names for the digger's backpack here in the format 'oreDictName'.

--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -12259,7 +12259,6 @@ backpacks {
             appliedenergistics2:tile.BlockSkyStone:1
             etfuturum:magma
             etfuturum:deepslate
-            etfuturum:tuff
             etfuturum:tuff:0
             etfuturum:calcite
             etfuturum:amethyst_block


### PR DESCRIPTION
This PR adds relevant worldgen blocks to the diggers backpack, as requested in #20252 .

Specifically:
            - deepslate
            - tuff
            - calcite
            - amethyst_block
            - coarse_dirt