### PR TITLE
Enables StorageDrawers Fancy Item Render Mode

### DIFF
--- a/config/StorageDrawers.cfg
+++ b/config/StorageDrawers.cfg
@@ -89,7 +89,7 @@ general {
 
     # Inverts how shift works with drawers. If this is true, shifting will only give one item, where regular clicks will give a full stack. Leave false for default behavior.
     B:invertShift=false
-    S:itemRenderType=fast
+    S:itemRenderType=fancy
     B:renderStorageUpgrades=true
     S:wailaStackRemainder=stack + remainder
 }


### PR DESCRIPTION
Fancy Render Mode has been significantly optimized:
- Over 10× faster rendering
- 100× fewer temporary object allocations

With these improvements, enabling 3D item display over drawers is now practical and efficient.

See details and benchmarks in:
https://github.com/GTNewHorizons/StorageDrawers/pull/44