### PR TITLE
Early Game Wood oreDict Questbook Fixes & "Wood" replacing "Flint"

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/TheHellisThat-AAAAAAAAAAAAAAAAAAAAMQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/TheHellisThat-AAAAAAAAAAAAAAAAAAAAMQ==.json
@@ -195,7 +195,7 @@
         "0:10": {
           "Count:3": 1,
           "Damage:2": 0,
-          "OreDict:8": "",
+          "OreDict:8": "fenceWood",
           "id:8": "minecraft:fence"
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/HowtoOpenYourWoo-AAAAAAAAAAAAAAAAAAAJHQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/HowtoOpenYourWoo-AAAAAAAAAAAAAAAAAAAJHQ==.json
@@ -131,7 +131,7 @@
         "0:10": {
           "Count:3": 10,
           "Damage:2": 0,
-          "OreDict:8": "",
+          "OreDict:8": "pressurePlateWood",
           "id:8": "minecraft:wooden_pressure_plate"
         }
       },
@@ -148,7 +148,7 @@
         "0:10": {
           "Count:3": 10,
           "Damage:2": 0,
-          "OreDict:8": "",
+          "OreDict:8": "buttonWood",
           "id:8": "minecraft:wooden_button"
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/TinkerTime-AAAAAAAAAAAAAAAAAAAAIQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/TinkerTime-AAAAAAAAAAAAAAAAAAAAIQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "While using your flint tools is fun in terms of killing pigs and cows, they are not long-lasting and can\u0027t be repaired. Plus Infernals laugh at your attempts to kill them. You discovered how to craft tools that can be repaired and upgraded, but for that you definitely need a more advanced crafting technique.\n\nIf you have to use wood other than oak to make your tables, you can convert them to the default oak wood type to complete this quest.",
+      "desc:8": "While using your wooden tools is fun in terms of killing pigs and cows, they are not long-lasting and can\u0027t be repaired. Plus Infernals laugh at your attempts to kill them. You discovered how to craft tools that can be repaired and upgraded, but for that you definitely need a more advanced crafting technique.\n\nIf you have to use wood other than oak to make your tables, you can convert them to the default oak wood type to complete this quest.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/WoodenDoor-AAAAAAAAAAAAAAAAAAAG_g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/WoodenDoor-AAAAAAAAAAAAAAAAAAAG_g==.json
@@ -104,7 +104,7 @@
         "1:10": {
           "Count:3": 1,
           "Damage:2": 0,
-          "OreDict:8": "",
+          "OreDict:8": "trapdoorWood",
           "id:8": "minecraft:trapdoor"
         },
         "2:10": {
@@ -133,7 +133,7 @@
         "0:10": {
           "Count:3": 1,
           "Damage:2": 0,
-          "OreDict:8": "",
+          "OreDict:8": "doorWood",
           "id:8": "minecraft:wooden_door"
         }
       },


### PR DESCRIPTION
## Changes:
- Replacing "Flint" with "Wooden" in describing pre-tinkers tools. There are no longer flint tools, so yeah.
- Allowing for oreDict on a few different early game wooden quest required objects. (I've also noted some items I'll be adding to the oreDict in game)

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20265
This should fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20048

I would include photos but the code makes it very clear what changed.