### PR TITLE
Grapple Recipe Mismatch Fix

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/Grapple-AAAAAAAAAAAAAAAAAAAFwA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/Grapple-AAAAAAAAAAAAAAAAAAAFwA==.json
@@ -106,9 +106,9 @@
         },
         "2:10": {
           "Count:3": 1,
-          "Damage:2": 28341,
+          "Damage:2": 24341,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.metaitem.01"
+          "id:8": "gregtech:gt.metaitem.02"
         }
       },
       "taskID:8": "bq_standard:optional_retrieval"


### PR DESCRIPTION
## Changes:
- The optional task was changes to a meteoric steel spring rather than the meteoric steel ring that it had. This is now in line with the actual crafting recipe. 

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19911

## In-game Photos:

### Recipe for Reference:
<img width="390" height="186" alt="image" src="https://github.com/user-attachments/assets/96317f43-ba79-4b75-ae69-4c83b4bb7938" />

### Pre-Change:
<img width="872" height="518" alt="image" src="https://github.com/user-attachments/assets/52406229-3ed2-4b9b-9ef6-80b60943e0e6" />

### Post Change:
<img width="1117" height="722" alt="image" src="https://github.com/user-attachments/assets/3ed2caa7-8581-4caf-8b5c-9a4603754ef9" />
