### PR TITLE
Adds Optional Raw Ore to Ore Exchange Quests

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Coal Ore for vanilla Coal Ore.",
+      "desc:8": "You can exchange your Stack of GT Coal Ore / Raw Coal Ore for vanilla Coal Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 535,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5535,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Copper Ore for IC2 Copper Ore.",
+      "desc:8": "You can exchange your Stack of GT Copper Ore / Raw Copper Ore for IC2 Copper Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 35,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5035,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Diamond Ore for vanilla Diamond Ore.",
+      "desc:8": "You can exchange your Stack of GT Diamond Ore / Raw Diamond Ore for vanilla Diamond Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 500,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5500,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/GoldOreexchange-AAAAAAAAAAAAAAAAAAAJew==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/GoldOreexchange-AAAAAAAAAAAAAAAAAAAJew==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Gold Ore for vanilla Gold Ore.",
+      "desc:8": "You can exchange your Stack of GT Gold Ore / Raw Gold Ore for vanilla Gold Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 86,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 1,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5086,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/IronOreexchange-AAAAAAAAAAAAAAAAAAAJKQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/IronOreexchange-AAAAAAAAAAAAAAAAAAAJKQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Iron Ore for vanilla Iron Ore.",
+      "desc:8": "You can exchange your Stack of GT Iron Ore / Raw Iron Ore for vanilla Iron Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 32,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 1,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5032,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Lapis Ore for vanilla Lapis Ore.",
+      "desc:8": "You can exchange your Stack of GT Lapis Ore / Raw Lapis Ore for vanilla Lapis Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 526,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5526,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Lead Ore for IC2 Lead Ore.",
+      "desc:8": "You can exchange your Stack of GT Lead Ore / Raw Lead Ore for IC2 Lead Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 89,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5089,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Nether Quartz Ore for vanilla Nether Quartz Ore.",
+      "desc:8": "You can exchange your Stack of GT Nether Quartz Ore / Raw Nether Quartz Ore for vanilla Nether Quartz Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 1522,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5522,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Redstone Ore for vanilla Redstone Ore.",
+      "desc:8": "You can exchange your Stack of GT Redstone Ore / Raw Redstone Ore for vanilla Redstone Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 810,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5810,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Tin Ore for IC2 Tin Ore.",
+      "desc:8": "You can exchange your Stack of GT Tin Ore / Raw Tin Ore for IC2 Tin Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 57,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5057,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can exchange your Stack of GT Uranium Ore for IC2 Uranium Ore.",
+      "desc:8": "You can exchange your Stack of GT Uranium Ore / Raw Uranium Ore for IC2 Uranium Ore.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -28,7 +28,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -69,6 +69,29 @@
           "Damage:2": 98,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 50,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "dreamcraft:item.CoinSmith"
+        },
+        "1:10": {
+          "Count:3": 64,
+          "Damage:2": 5098,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
## Changes:
- As title says, adds raw ore option to ore exchange quests in coins tab.

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19187.

## In-Game Photo: 

### Picture this x11 quests
<img width="2457" height="1276" alt="image" src="https://github.com/user-attachments/assets/a187d20c-b10c-4395-b630-cd27907cce3c" />
