### PR TITLE
General Purpose Fermenting Bacteria Quest Fix

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/GeneralPurposeFe-AAAAAAAAAAAAAAAAAAAKmw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/GeneralPurposeFe-AAAAAAAAAAAAAAAAAAAKmw==.json
@@ -71,22 +71,23 @@
           "OreDict:8": "",
           "id:8": "bartworks:BioLabParts",
           "tag:10": {
-            "Breedable:1": 0,
+            "Breedable:1": 1,
             "Color:11": [
-              110,
-              40,
-              25
+              149,
+              132,
+              75
             ],
             "DNA:10": {
               "Chance:3": 10000,
-              "Name:8": "beta-Lactamase",
+              "Name:8": "Escherichia koli",
               "Rarity:1": 1,
               "Tier:3": 0
             },
-            "Name:8": "Escherichia cadaver",
+            "Fluid:8": "escherichiakolifluid",
+            "Name:8": "Escherichia koli",
             "Plasmid:10": {
               "Chance:3": 10000,
-              "Name:8": "beta-Lactamase",
+              "Name:8": "Escherichia koli",
               "Rarity:1": 1,
               "Tier:3": 0
             },

--- a/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/GeneralPurposeFe-AAAAAAAAAAAAAAAAAAAKmw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/GeneralPurposeFe-AAAAAAAAAAAAAAAAAAAKmw==.json
@@ -372,7 +372,7 @@
             ],
             "DNA:10": {
               "Chance:3": 10000,
-              "Name:8": "beta-Lactamase",
+              "Name:8": "Escherichia koli",
               "Rarity:1": 1,
               "Tier:3": 0
             },


### PR DESCRIPTION
## Changes: 
- Corrects the quest "General Purpose Fermenting Bacteria" to have proper petri dish culture at beginning for breeding bacteria. 
- Fixes the last petri item so it shows in NEI

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19265.

### In-Game Photo:
<img width="1140" height="431" alt="image" src="https://github.com/user-attachments/assets/0915eb44-da21-4378-9fed-bdfb61e04055" />
