### PR TITLE
Update InGameInfo.xml - Detailed Light Levels

### DIFF
--- a/config/InGameInfoXML/InGameInfo.xml
+++ b/config/InGameInfoXML/InGameInfo.xml
@@ -115,7 +115,7 @@
             <icon>
                 <str>minecraft:torch</str>
             </icon>
-            <str> Light: </str>
+            <str> Light: Real </str>
             <max>
                 <var>light</var>
                 <num>7.5</num>
@@ -123,7 +123,23 @@
                 <str>{red}</str>
             </max>
             <var>light</var>
-            <str> {white}(Feet: </str>
+            <str>{white}, Sky </str>
+            <max>
+                <var>lightsun</var>
+                <num>7.5</num>
+                <str>{yellow}</str>
+                <str>{red}</str>
+            </max>
+            <var>lightsun</var>
+            <str>{white}, Block </str>
+            <max>
+                <var>lightnosun</var>
+                <num>7.5</num>
+                <str>{yellow}</str>
+                <str>{red}</str>
+            </max>
+            <var>lightnosun</var>
+            <str>{white} (Feet: rl</str>
             <max>
                 <var>lightfeet</var>
                 <num>7.5</num>
@@ -131,7 +147,23 @@
                 <str>{red}</str>
             </max>
             <var>lightfeet</var>
-            <str>{white})</str>
+            <str>{white}, sl</str>
+            <max>
+                <var>lightsunfeet</var>
+                <num>7.5</num>
+                <str>{yellow}</str>
+                <str>{red}</str>
+            </max>
+            <var>lightsunfeet</var>
+            <str>{white}, bl</str>
+            <max>
+                <var>lightnosunfeet</var>
+                <num>7.5</num>
+                <str>{yellow}</str>
+                <str>{red}</str>
+            </max>
+            <var>lightnosunfeet</var>
+	    <str>{white})</str>
         </line>
         <line>
             <icon>


### PR DESCRIPTION
Something that I didn't realize until just now was that there was a lack of blocklight information shown by InGameInfoXML. Considering how that can be valuable to the user for quick glances (separate from the NEI F7 method), I figured I could write up a quick PR for it. It's a very small QoL change which doesn't affect any gameplay mechanic, so maybe it could be considered for 2.8? If not since feature freeze, that's fine as well.

Thanks,
-Piano

<img width="603" height="30" alt="image" src="https://github.com/user-attachments/assets/c2a32b58-3cf7-419d-83f0-ca39722b97f4" />
