### PR TITLE
Add bogosorter.cfg + disable usage ticker HUD

### DIFF
--- a/config/bogosorter.cfg
+++ b/config/bogosorter.cfg
@@ -89,7 +89,7 @@ general {
         B:enableMainHand=true
 
         # Enable usage ticker module. [default: true]
-        B:enableModule=true
+        B:enableModule=false
 
         # Show usage ticker for off hand. [default: true]
         B:enableOffHand=true

--- a/config/bogosorter.cfg
+++ b/config/bogosorter.cfg
@@ -1,0 +1,100 @@
+# Configuration file
+
+general {
+    # The damage threshold for auto-refill. If the item has less than this amount of durability, it will be refilled. [range: -2147483648 ~ 2147483647, default: 1]
+    I:autoRefillDamageThreshold=1
+
+    # The color of the sort button in hex format (e.g. #FFFFFFFF or 0xFFFFFFFF). [default: #FFFFFFFF]
+    S:buttonColor=#FFFFFFFF
+
+    # Enable the auto-refill feature. [default: true]
+    B:enableAutoRefill=true
+
+    # Enable the hotbar sort feature. [default: true]
+    B:enableHotbarSort=true
+
+    # Enable the hotbar swap feature. [default: true]
+    B:enableHotbarSwap=true
+
+    # If enabled, items with max stack size of 1 (e.g., tools, armor, etc.)
+    # will not be split when sorting. This helps avoid cluttering the inventory with duplicate single-item stacks. [default: true]
+    B:preventSplit=true
+
+    # Sound played when the sort button is pressed. [default: gui.button.press]
+    S:sortSound=gui.button.press
+
+    ##########################################################################################################
+    # dropoff
+    #--------------------------------------------------------------------------------------------------------#
+    # DropOff Configuration
+    ##########################################################################################################
+
+    dropoff {
+        # Show a chat message after dropping off items. [default: true]
+        B:dropoffChatMessage=true
+
+        # Throttle drop-off packets in milliseconds. [range: -2147483648 ~ 2147483647, default: 500]
+        I:dropoffPacketThrottleInMS=500
+
+        # Time quota for drop-off in milliseconds. [range: -2147483648 ~ 2147483647, default: 1]
+        I:dropoffQuotaInMS=1
+
+        # The radius (in blocks) around the player to scan for drop-off targets. [range: -2147483648 ~ 2147483647, default: 4]
+        I:dropoffRadius=4
+
+        # Render a highlight on eligible drop-off containers. [default: true]
+        B:dropoffRender=true
+
+        # Valid inventory names for drop-off targeting (substring match). [default: [Chest], [Barrel], [Drawer], [Crate]]
+        S:dropoffTargetNames <
+            Chest
+            Barrel
+            Drawer
+            Crate
+         >
+
+        # Enable the drop-off button in the player inventory. [default: true]
+        B:enableDropOff=true
+
+        ##########################################################################################################
+        # button
+        #--------------------------------------------------------------------------------------------------------#
+        # DropOff Button Configuration
+        ##########################################################################################################
+
+        button {
+            # X position of the drop-off button in the player inventory. [range: -2147483648 ~ 2147483647, default: 160]
+            I:buttonX=160
+
+            # Y position of the drop-off button in the player inventory. [range: -2147483648 ~ 2147483647, default: 5]
+            I:buttonY=5
+
+            # Show the drop-off button in the player inventory. [default: true]
+            B:showButton=true
+        }
+
+    }
+
+    ##########################################################################################################
+    # usageticker
+    #--------------------------------------------------------------------------------------------------------#
+    # Usage Ticker Configuration
+    ##########################################################################################################
+
+    usageticker {
+        # Show usage ticker for armor. [default: true]
+        B:enableArmor=true
+
+        # Show usage ticker for main hand. [default: true]
+        B:enableMainHand=true
+
+        # Enable usage ticker module. [default: true]
+        B:enableModule=true
+
+        # Show usage ticker for off hand. [default: true]
+        B:enableOffHand=true
+    }
+
+}
+
+


### PR DESCRIPTION
Adds the default config file for bogosorter mod

Disabled the `usageticker` HUD by default, it's the hud that pops up at the bottom left of your hotbat and renders the items you have in hand and also when you equip armor. We do not need more clutter on the HUD.