### PR TITLE
Ore trade quests now consume raw ore

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
@@ -75,7 +75,7 @@
     },
     "1:10": {
       "autoConsume:1": 0,
-      "consume:1": 0,
+      "consume:1": 1,
       "groupDetect:1": 0,
       "ignoreNBT:1": 1,
       "index:3": 1,


### PR DESCRIPTION
Fixes #20539 

Coal, Copper, Diamond, Lapis, lead, Nether Quartz, Redstone, Tin, and Uranium quest trades now correctly consume raw ore.

<img width="2462" height="1218" alt="image" src="https://github.com/user-attachments/assets/79785267-ed35-492b-abed-907c3f33cb50" />
