### PR TITLE
Standardizes trigger quest names

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerBallthing-AAAAAAAAAAAAAAAAAAAFVQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerBallthing-AAAAAAAAAAAAAAAAAAAFVQ==.json
@@ -15,7 +15,7 @@
       "isMain:1": 0,
       "isSilent:1": 1,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Ballthingy",
+      "name:8": "Trigger: Ballthingy",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerCtHunlock-AAAAAAAAAAAAAAAAAAAISw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerCtHunlock-AAAAAAAAAAAAAAAAAAAISw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:CtH (unlock)",
+      "name:8": "Trigger: CtH (unlock)",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerEpoxidSki-AAAAAAAAAAAAAAAAAAAL2w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerEpoxidSki-AAAAAAAAAAAAAAAAAAAL2w==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Epoxid Skip",
+      "name:8": "Trigger: Epoxid Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerFlippers-AAAAAAAAAAAAAAAAAAALVA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerFlippers-AAAAAAAAAAAAAAAAAAALVA==.json
@@ -15,7 +15,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "Trigger Flippers",
+      "name:8": "Trigger: Flippers",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerGrapheneS-MdXhDkN_TECH5kMp4OM2Gg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerGrapheneS-MdXhDkN_TECH5kMp4OM2Gg==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Graphene Skip",
+      "name:8": "Trigger: Graphene Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLife-AAAAAAAAAAAAAAAAAAAByA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLife-AAAAAAAAAAAAAAAAAAAByA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger Life",
+      "name:8": "Trigger: Life",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLifeandSo-AAAAAAAAAAAAAAAAAAABxg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLifeandSo-AAAAAAAAAAAAAAAAAAABxg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger Life and Soul Shard",
+      "name:8": "Trigger: Life and Soul Shard",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLoC-AAAAAAAAAAAAAAAAAAABww==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLoC-AAAAAAAAAAAAAAAAAAABww==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger LoC",
+      "name:8": "Trigger: LoC",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLootGame-AAAAAAAAAAAAAAAAAAALOw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerLootGame-AAAAAAAAAAAAAAAAAAALOw==.json
@@ -14,7 +14,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Loot Game",
+      "name:8": "Trigger: Loot Game",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerMjolnir-AAAAAAAAAAAAAAAAAAAFVA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerMjolnir-AAAAAAAAAAAAAAAAAAAFVA==.json
@@ -15,7 +15,7 @@
       "isMain:1": 0,
       "isSilent:1": 1,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Mjolnir",
+      "name:8": "Trigger: Mjolnir",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNaqlineSk-AAAAAAAAAAAAAAAAAAAL3A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNaqlineSk-AAAAAAAAAAAAAAAAAAAL3A==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Naqline Skip",
+      "name:8": "Trigger: Naqline Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerNetherSki-qFco17HGS0SxmpVn-uWJZQ==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 1,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Nether Skip",
+      "name:8": "Trigger: Nether Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPBISkip-AAAAAAAAAAAAAAAAAAALVw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPBISkip-AAAAAAAAAAAAAAAAAAALVw==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:PBI Skip",
+      "name:8": "Trigger: PBI Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPTFESkip-AAAAAAAAAAAAAAAAAAAL2Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPTFESkip-AAAAAAAAAAAAAAAAAAAL2Q==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:PTFE Skip",
+      "name:8": "Trigger: PTFE Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineI-AAAAAAAAAAAAAAAAAAALWw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineI-AAAAAAAAAAAAAAAAAAALWw==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Iridium Skip",
+      "name:8": "Trigger: Platline Iridium Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineO-AAAAAAAAAAAAAAAAAAALXA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineO-AAAAAAAAAAAAAAAAAAALXA==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Osmium Skip",
+      "name:8": "Trigger: Platline Osmium Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineP-AAAAAAAAAAAAAAAAAAALVg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineP-AAAAAAAAAAAAAAAAAAALVg==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Platinum Skip",
+      "name:8": "Trigger: Platline Platinum Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineP-AAAAAAAAAAAAAAAAAAALWA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineP-AAAAAAAAAAAAAAAAAAALWA==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Palladium Skip",
+      "name:8": "Trigger: Platline Palladium Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineR-AAAAAAAAAAAAAAAAAAALWQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineR-AAAAAAAAAAAAAAAAAAALWQ==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Rhodium Skip",
+      "name:8": "Trigger: Platline Rhodium Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineR-AAAAAAAAAAAAAAAAAAALWg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPlatlineR-AAAAAAAAAAAAAAAAAAALWg==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Platline Ruthenium Skip",
+      "name:8": "Trigger: Platline Ruthenium Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolypheny-gg1I91tdRK2us5ETzB2VjA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolypheny-gg1I91tdRK2us5ETzB2VjA==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Polyphenylene Sulfide Skip",
+      "name:8": "Trigger: Polyphenylene Sulfide Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolystyre-AAAAAAAAAAAAAAAAAAAL2g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerPolystyre-AAAAAAAAAAAAAAAAAAAL2g==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Polystyrene Skip",
+      "name:8": "Trigger: Polystyrene Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerRing-AAAAAAAAAAAAAAAAAAAFUw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerRing-AAAAAAAAAAAAAAAAAAAFUw==.json
@@ -15,7 +15,7 @@
       "isMain:1": 0,
       "isSilent:1": 1,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Ring",
+      "name:8": "Trigger: Ring",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerShardofCr-AAAAAAAAAAAAAAAAAAABxQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerShardofCr-AAAAAAAAAAAAAAAAAAABxQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger Shard of Creation",
+      "name:8": "Trigger: Shard of Creation",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSiliconeR-AAAAAAAAAAAAAAAAAAAL2A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSiliconeR-AAAAAAAAAAAAAAAAAAAL2A==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Silicone Rubber Skip",
+      "name:8": "Trigger: Silicone Rubber Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSingulari-AAAAAAAAAAAAAAAAAAABxA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerSingulari-AAAAAAAAAAAAAAAAAAABxA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger Singularity",
+      "name:8": "Trigger: Singularity",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerStyreneBu-cQkx83QYT4m3mwovgZIKvA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerStyreneBu-cQkx83QYT4m3mwovgZIKvA==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Styrene-Butadiene rubber",
+      "name:8": "Trigger: Styrene-Butadiene Rubber Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerTitaniumM-AAAAAAAAAAAAAAAAAAALVQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerTitaniumM-AAAAAAAAAAAAAAAAAAALVQ==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Titanium Moon Skip",
+      "name:8": "Trigger: Titanium Moon Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerTungstens-AAAAAAAAAAAAAAAAAAALXQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerTungstens-AAAAAAAAAAAAAAAAAAALXQ==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger:Tungstensteel Mars Skip",
+      "name:8": "Trigger: Tungstensteel Mars Skip",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerUnknownCr-AAAAAAAAAAAAAAAAAAABxw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoQuestLine/TriggerUnknownCr-AAAAAAAAAAAAAAAAAAABxw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Trigger Unknown Crystal",
+      "name:8": "Trigger: Unknown Crystal",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,


### PR DESCRIPTION
Make the quest name consistent across all trigger quests. Also moves Graphene trigger skip from EV folder to "NoQuestLine" folder.