### PR TITLE
Fixes Quests to Account for Fuel Cell Changes

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AlternateNuclear-AAAAAAAAAAAAAAAAAAAAxg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AlternateNuclear-AAAAAAAAAAAAAAAAAAAAxg==.json
@@ -14,8 +14,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "bartworks:gt.Tiberiumcell",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "bartworks:gt.Tiberiumcell",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -47,8 +51,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "bartworks:gt.Tiberiumcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "bartworks:gt.Tiberiumcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AlternateNuclear-AAAAAAAAAAAAAAAAAAAAxg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/AlternateNuclear-AAAAAAAAAAAAAAAAAAAAxg==.json
@@ -14,12 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "bartworks:gt.Tiberiumcell",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.rodTiberium",
+        "tag:10": {}
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -51,12 +47,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "bartworks:gt.Tiberiumcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodTiberium",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/ObscenelyDangero-AAAAAAAAAAAAAAAAAAAB6g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/ObscenelyDangero-AAAAAAAAAAAAAAAAAAAB6g==.json
@@ -18,8 +18,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "bartworks:gt.Core_Reactor_Cell",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "bartworks:gt.Core_Reactor_Cell",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -51,8 +55,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "bartworks:gt.Core_Reactor_Cell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "bartworks:gt.Core_Reactor_Cell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/ObscenelyDangero-AAAAAAAAAAAAAAAAAAAB6g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/ObscenelyDangero-AAAAAAAAAAAAAAAAAAAB6g==.json
@@ -18,12 +18,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "bartworks:gt.Core_Reactor_Cell",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.rodNaquadah32",
+        "tag:10": {}
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -55,12 +51,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "bartworks:gt.Core_Reactor_Cell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodNaquadah32",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAAvw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAAvw==.json
@@ -14,11 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.reactorUraniumSimple",
-          "orig_meta:3": 0
-        }
+        "id:8": "gregtech:gt.rodUranium",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -79,12 +76,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.reactorUraniumSimple",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodUranium",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAAvw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAAvw==.json
@@ -14,7 +14,11 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.reactorUraniumSimple"
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.reactorUraniumSimple",
+          "orig_meta:3": 0
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -75,8 +79,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumSimple",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.reactorUraniumSimple",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAHaA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAHaA==.json
@@ -18,8 +18,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.Naquadahcell",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.Naquadahcell",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -80,8 +84,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Naquadahcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Naquadahcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAHaA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/StandardNuclearF-AAAAAAAAAAAAAAAAAAAHaA==.json
@@ -18,12 +18,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.Naquadahcell",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.rodNaquadah",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -84,12 +80,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Naquadahcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodNaquadah",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAAwA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAAwA==.json
@@ -14,7 +14,11 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.reactorMOXSimple"
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.reactorMOXSimple",
+          "orig_meta:3": 0
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -75,8 +79,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorMOXSimple",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.reactorMOXSimple",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAAwA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAAwA==.json
@@ -14,11 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.reactorMOXSimple",
-          "orig_meta:3": 0
-        }
+        "id:8": "gregtech:gt.rodMOX",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -79,12 +76,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.reactorMOXSimple",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodMOX",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAHaQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAHaQ==.json
@@ -14,8 +14,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.MNqCell",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.MNqCell",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -88,8 +92,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.MNqCell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.MNqCell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAHaQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/HowtoGeneratePow-AAAAAAAAAAAAAAAAAAAACQ==/TrickyNuclearFue-AAAAAAAAAAAAAAAAAAAHaQ==.json
@@ -14,12 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.MNqCell",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.rodNaquadria",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -92,12 +88,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.MNqCell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodNaquadria",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BasicNuclearFuel-AAAAAAAAAAAAAAAAAAAAwQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BasicNuclearFuel-AAAAAAAAAAAAAAAAAAAAwQ==.json
@@ -14,11 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.Thoriumcell",
-          "orig_meta:3": 0
-        }
+        "id:8": "gregtech:gt.rodThorium",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -79,12 +76,8 @@
           "Count:3": 4,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Thoriumcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodThorium",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BasicNuclearFuel-AAAAAAAAAAAAAAAAAAAAwQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BasicNuclearFuel-AAAAAAAAAAAAAAAAAAAAwQ==.json
@@ -14,7 +14,11 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.Thoriumcell"
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.Thoriumcell",
+          "orig_meta:3": 0
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -75,8 +79,12 @@
           "Count:3": 4,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Thoriumcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Thoriumcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DoubletheFun-AAAAAAAAAAAAAAAAAAAHaw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DoubletheFun-AAAAAAAAAAAAAAAAAAAHaw==.json
@@ -14,11 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.Double_Thoriumcell",
-          "orig_meta:3": 0
-        }
+        "id:8": "gregtech:gt.rodThorium2",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -48,12 +45,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Quad_Thoriumcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodThorium4",
+          "tag:10": {}
         }
       }
     },
@@ -84,12 +77,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Double_Thoriumcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodThorium2",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -106,12 +95,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Quad_Thoriumcell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.rodThorium4",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DoubletheFun-AAAAAAAAAAAAAAAAAAAHaw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/DoubletheFun-AAAAAAAAAAAAAAAAAAAHaw==.json
@@ -14,7 +14,11 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.Double_Thoriumcell"
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.Double_Thoriumcell",
+          "orig_meta:3": 0
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -44,8 +48,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_Thoriumcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Quad_Thoriumcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       }
     },
@@ -76,8 +84,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Double_Thoriumcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Double_Thoriumcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -94,8 +106,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_Thoriumcell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Quad_Thoriumcell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UnfortunatelyThe-AAAAAAAAAAAAAAAAAAAHbA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UnfortunatelyThe-AAAAAAAAAAAAAAAAAAAHbA==.json
@@ -14,12 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.rodThorium4",
+        "tag:10": {}
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -49,12 +45,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.depletedRodThorium4",
+          "tag:10": {}
         }
       }
     },
@@ -85,12 +77,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.depletedRodThorium4",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UnfortunatelyThe-AAAAAAAAAAAAAAAAAAAHbA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/UnfortunatelyThe-AAAAAAAAAAAAAAAAAAAHbA==.json
@@ -14,8 +14,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.Quad_ThoriumcellDep",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -45,8 +49,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_ThoriumcellDep",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       }
     },
@@ -77,8 +85,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_ThoriumcellDep",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.Quad_ThoriumcellDep",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ExcitedFluidNuke-AAAAAAAAAAAAAAAAAAAMZQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ExcitedFluidNuke-AAAAAAAAAAAAAAAAAAAMZQ==.json
@@ -14,7 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "GoodGenerator:rodLiquidPlutoniumDepleted4"
+        "id:8": "gregtech:gt.depletedRodExcitedPlutonium4",
+        "tag:10": {}
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -46,14 +47,14 @@
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodLiquidUranium4",
+          "id:8": "gregtech:gt.rodExcitedUranium4",
           "tag:10": {}
         },
         "1:10": {
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodLiquidPlutonium4",
+          "id:8": "gregtech:gt.rodExcitedPlutonium4",
           "tag:10": {}
         }
       },
@@ -71,7 +72,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodLiquidUranium4",
+          "id:8": "gregtech:gt.rodExcitedUranium4",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/HighDensityVacuu-AAAAAAAAAAAAAAAAAAAMYw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/HighDensityVacuu-AAAAAAAAAAAAAAAAAAAMYw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "GoodGenerator:rodCompressedUranium4",
+        "id:8": "gregtech:gt.rodHighDensityUranium4",
         "tag:10": {}
       },
       "isMain:1": 0,
@@ -47,14 +47,14 @@
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodCompressedUranium4",
+          "id:8": "gregtech:gt.rodHighDensityUranium4",
           "tag:10": {}
         },
         "1:10": {
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodCompressedPlutonium4",
+          "id:8": "gregtech:gt.rodHighDensityPlutonium4",
           "tag:10": {}
         }
       },
@@ -72,7 +72,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "GoodGenerator:rodCompressedUranium4",
+          "id:8": "gregtech:gt.rodHighDensityUranium4",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/MOXNukes-AAAAAAAAAAAAAAAAAAAMZw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/MOXNukes-AAAAAAAAAAAAAAAAAAAMZw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.reactorMOXQuad",
+        "id:8": "gregtech:gt.rodMOX4",
         "tag:10": {}
       },
       "isMain:1": 0,
@@ -67,7 +67,7 @@
           "Count:3": 5,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorMOXQuad",
+          "id:8": "gregtech:gt.rodMOX4",
           "tag:10": {}
         }
       },
@@ -85,7 +85,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorMOXQuad",
+          "id:8": "gregtech:gt.rodMOX4",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/NukesSummarized-AAAAAAAAAAAAAAAAAAAMZg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/NukesSummarized-AAAAAAAAAAAAAAAAAAAMZg==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "bartworks:gt.Core_Reactor_Cell",
+        "id:8": "gregtech:gt.rodNaquadah32",
         "tag:10": {}
       },
       "isMain:1": 0,
@@ -58,7 +58,7 @@
           "Count:3": 40,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "bartworks:gt.Core_Reactor_Cell",
+          "id:8": "gregtech:gt.rodNaquadah32",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/PoweringupFluidN-AAAAAAAAAAAAAAAAAAAMXg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/PoweringupFluidN-AAAAAAAAAAAAAAAAAAAMXg==.json
@@ -46,7 +46,7 @@
           "Count:3": 8,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_Thoriumcell",
+          "id:8": "gregtech:gt.rodThorium4",
           "tag:10": {}
         }
       },
@@ -64,14 +64,14 @@
           "Count:3": 3,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumQuad",
+          "id:8": "gregtech:gt.rodUranium4",
           "tag:10": {}
         },
         "1:10": {
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumDual",
+          "id:8": "gregtech:gt.rodUranium2",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ThoriumasBreedin-AAAAAAAAAAAAAAAAAAAMUw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ThoriumasBreedin-AAAAAAAAAAAAAAAAAAAMUw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.ThoriumcellDep",
+        "id:8": "gregtech:gt.rodThorium4",
         "tag:10": {}
       },
       "isMain:1": 0,
@@ -47,7 +47,7 @@
           "Count:3": 16,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_Thoriumcell",
+          "id:8": "gregtech:gt.rodThorium4",
           "tag:10": {}
         },
         "1:10": {
@@ -68,7 +68,7 @@
           "Count:3": 16,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_ThoriumcellDep",
+          "id:8": "gregtech:gt.depletedRodThorium4",
           "tag:10": {}
         },
         "4:10": {

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ThoriumasEarlyPo-AAAAAAAAAAAAAAAAAAAMTw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/ThoriumasEarlyPo-AAAAAAAAAAAAAAAAAAAMTw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.Thoriumcell",
+        "id:8": "gregtech:gt.rodThorium",
         "tag:10": {}
       },
       "isMain:1": 0,
@@ -59,7 +59,7 @@
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Quad_Thoriumcell",
+          "id:8": "gregtech:gt.rodThorium4",
           "tag:10": {}
         }
       },
@@ -77,7 +77,7 @@
           "Count:3": 10,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.Thoriumcell",
+          "id:8": "gregtech:gt.rodThorium",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/UraniumBasicNuke-AAAAAAAAAAAAAAAAAAAMYQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/UraniumBasicNuke-AAAAAAAAAAAAAAAAAAAMYQ==.json
@@ -66,7 +66,7 @@
           "Count:3": 7,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumQuad",
+          "id:8": "gregtech:gt.rodUranium4",
           "tag:10": {}
         }
       },
@@ -84,7 +84,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumQuad",
+          "id:8": "gregtech:gt.rodUranium4",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/VacuumNukes-AAAAAAAAAAAAAAAAAAAMXw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/VacuumNukes-AAAAAAAAAAAAAAAAAAAMXw==.json
@@ -53,7 +53,7 @@
           "Count:3": 40,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.reactorUraniumQuad",
+          "id:8": "gregtech:gt.rodUranium4",
           "tag:10": {}
         }
       },

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PoweroftheSunfro-AAAAAAAAAAAAAAAAAAAMAg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PoweroftheSunfro-AAAAAAAAAAAAAAAAAAAMAg==.json
@@ -14,12 +14,8 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "betterquesting:placeholder",
-        "tag:10": {
-          "orig_id:8": "gregtech:gt.sunnariumCell",
-          "orig_meta:3": 0,
-          "orig_tag:10": {}
-        }
+        "id:8": "gregtech:gt.depletedRodGlowstone",
+        "tag:10": {}
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -84,11 +80,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.glowstoneCell",
-            "orig_meta:3": 0
-          }
+          "id:8": "gregtech:gt.rodGlowstone"
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -105,12 +97,8 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "betterquesting:placeholder",
-          "tag:10": {
-            "orig_id:8": "gregtech:gt.sunnariumCell",
-            "orig_meta:3": 0,
-            "orig_tag:10": {}
-          }
+          "id:8": "gregtech:gt.depletedRodGlowstone",
+          "tag:10": {}
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PoweroftheSunfro-AAAAAAAAAAAAAAAAAAAMAg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PoweroftheSunfro-AAAAAAAAAAAAAAAAAAAMAg==.json
@@ -14,8 +14,12 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.sunnariumCell",
-        "tag:10": {}
+        "id:8": "betterquesting:placeholder",
+        "tag:10": {
+          "orig_id:8": "gregtech:gt.sunnariumCell",
+          "orig_meta:3": 0,
+          "orig_tag:10": {}
+        }
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -80,7 +84,11 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.glowstoneCell"
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.glowstoneCell",
+            "orig_meta:3": 0
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -97,8 +105,12 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.sunnariumCell",
-          "tag:10": {}
+          "id:8": "betterquesting:placeholder",
+          "tag:10": {
+            "orig_id:8": "gregtech:gt.sunnariumCell",
+            "orig_meta:3": 0,
+            "orig_tag:10": {}
+          }
         }
       },
       "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
### Changes:
- Fixes all quests in EV, How to Generate Power, Powerful Nuclear Physics (rewards, tasks, icons) to account for new fuel cell IDs in experimental 19.

Notably, the Excited Plutonium Fuel Cells are misnamed, not having a dual or quad variety, after those are changed this could possibly need another follow up PR. Additionally I will follow up if there was anything I missed.