### PR TITLE
Allows Biomass Quest to Use Forestry Biomass

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/Biomass-AAAAAAAAAAAAAAAAAAAFKw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/Biomass-AAAAAAAAAAAAAAAAAAAFKw==.json
@@ -36,7 +36,7 @@
       "simultaneous:1": 0,
       "snd_complete:8": "random.levelup",
       "snd_update:8": "random.levelup",
-      "taskLogic:8": "AND",
+      "taskLogic:8": "OR",
       "visibility:8": "NORMAL"
     }
   },
@@ -108,6 +108,23 @@
           "Damage:2": 6,
           "OreDict:8": "",
           "id:8": "IC2:itemCellEmpty"
+        }
+      },
+      "taskID:8": "bq_standard:retrieval"
+    },
+    "1:10": {
+      "autoConsume:1": 0,
+      "consume:1": 0,
+      "groupDetect:1": 0,
+      "ignoreNBT:1": 1,
+      "index:3": 1,
+      "partialMatch:1": 1,
+      "requiredItems:9": {
+        "0:10": {
+          "Count:3": 64,
+          "Damage:2": 30704,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.metaitem.01"
         }
       },
       "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
### Changes:
- Allows Biomass quest to complete with creation of Forestry biomass in addition to GT biomass. It's made using the same machines, just a slightly different recipe and the same amount of tedium. Honestly I don't know why there are two to begin with, but this will permit either to complete the quest. 

### In-Game Photo
<img width="2443" height="1208" alt="image" src="https://github.com/user-attachments/assets/34a5a02d-2792-43d7-96db-72d3210e97c1" />
