### PR TITLE
Applied Energistics 2 Meteorite Generation and loot update

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -444,16 +444,35 @@ wireless {
 }
 
 
+##########################################################################################################
+# worldgen
+#--------------------------------------------------------------------------------------------------------#
+# The meteorite dimension whitelist list can be used alone or in unison with the meteorite (in)valid blocks whitelist. 
+# Default debris is the following (in this order) Stone, Cobblestone, biomeFillerBlock (what's under the top block, usually dirt), Gravel, biomeTopBlock (usually grass) 
+# Format: dimensionID, modID:blockID:metadata, modID:blockID:metadata, modID:blockID:metadata, modID:blockID:metadata, modID:blockID:metadata 
+# --------------------------------------------------------------------------------------------------------# 
+# The meteorite (in)valid spawn blocks list can be used alone or in unison with the meteorite dimension whitelist. Format: modId:blockID, modId:blockID, etc. 
+##########################################################################################################
+
+
 worldgen {
-    D:meteoriteClusterChance=0.1
-    I:meteoriteDimensionWhitelist <
-        0
+    S:meteoriteDimensionWhitelist <
+        0, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT
+        29, GalacticraftMars:tile.mars:9, GalacticraftMars:tile.mars:4, GalacticraftMars:tile.mars:6, minecraft:sand:1, GalacticraftMars:tile.mars:5
      >
-    D:meteoriteSpawnChance=0.3
-    I:minMeteoriteDistance=707
+    S:meteoriteInvalidSpawnBlocks <
+     >
+    S:meteoriteSpawnChance <
+        0=0.3
+     >
+    S:meteoriteValidSpawnBlocks <
+        GalacticraftMars:tile.mars
+     >
+    S:minMeteoriteDistance <
+        0=707
+     >
     I:quartzOresClusterAmount=15
     I:quartzOresPerCluster=4
     D:spawnChargedChance=0.07999998331069946
 }
-
 


### PR DESCRIPTION
# This PR is currently created as a placeholder for me to soon test a few different configs and loot tables. 
# Right now, this PR is unready for testing and especially merging. 

## This PR is necessary for at the very least the first commit in this branch
 - After this https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/733 got merged, the normal config for world generation doesn't work. This PR aims to fix that as well as introduce new loot tables, as was suggested [here](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/733#issuecomment-2817308335) by dream-master.

## Food for thought
 - Which planets and moons should meteorites generate on? 
   - What should the chances be, more likely on certain planets, to incentivize space exploration further than what's currently done?
  - What should spawn in the meteorites? 
    - What should be the most common and most rare loot tables for each dimension?
    
 I'm not as familiar with the nuances of the later game stages as I'd like to be, so I'm glad to take any feedback and thoughts on the loot tables and what should go into them!
 
 