### PR TITLE
Enable the enchantability of EMT tols

### DIFF
--- a/config/EMT.cfg
+++ b/config/EMT.cfg
@@ -131,7 +131,7 @@
     B:"Enable capes"=true
 
     # Warning: the enchantability is low.
-    B:"Enable enchanting tools"=false
+    B:"Enable enchanting tools"=true
 
     # The impact of rain on all wings
     B:"Impact of rain"=true


### PR DESCRIPTION
Attempt to enable enchanting for the non Thaumic boots mod boots, this might also enable enchantability of other things, if that is an issue it might be best to try and rectify this at the source code which could be done as well, which would simply require removing the config option and changing it on the boots to be always enabled