### PR TITLE
Update Witchery Quest to fix mismatch=

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/LooktotheEdges-AAAAAAAAAAAAAAAAAAAAGw==/DiamondVapor-AAAAAAAAAAAAAAAAAAAGJg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/LooktotheEdges-AAAAAAAAAAAAAAAAAAAAGw==/DiamondVapor-AAAAAAAAAAAAAAAAAAAGJg==.json
@@ -119,7 +119,7 @@
       "partialMatch:1": 1,
       "requiredItems:9": {
         "0:10": {
-          "Count:3": 8,
+          "Count:3": 4,
           "Damage:2": 29,
           "OreDict:8": "",
           "id:8": "witchery:ingredient"


### PR DESCRIPTION
Change the required amount of Diamond Vapor to match the optional task requirements amount of crafts

This quest seems to be weirdly configured to require 8 Diamond vapors when it only requests enough ingredients for 2 crafts or 4 worth, this could be changed the other way, however I just took the simpler approach on the requirement side instead of increasing the optional task