### PR TITLE
Fix Incorrect Item in "Find Some Meteoric Iron" Quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FindSomeMeteoric-AAAAAAAAAAAAAAAAAAAFkg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FindSomeMeteoric-AAAAAAAAAAAAAAAAAAAFkg==.json
@@ -119,9 +119,9 @@
       "requiredItems:9": {
         "0:10": {
           "Count:3": 16,
-          "Damage:2": 0,
+          "Damage:2": 5340,
           "OreDict:8": "",
-          "id:8": "GalacticraftCore:item.meteoricIronRaw"
+          "id:8": "gregtech:gt.metaitem.03"
         }
       },
       "taskID:8": "bq_standard:retrieval"


### PR DESCRIPTION
Since the addition of this PR [GC Raw Meteoric Iron OreDict](https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1321), The quest "Find Some Meteoric Iron" needs to use the GT version of Raw Meteoric Iron instead of the GC version.

Before
<img width="1818" height="979" alt="Fix Meteoric Quest Before" src="https://github.com/user-attachments/assets/29571799-0483-4429-a097-8cf301bf711d" />
After
<img width="1819" height="983" alt="Fix Meteoric Quest After" src="https://github.com/user-attachments/assets/ef204e48-1cd0-437d-b4db-c2c3a0f510b7" />
