### PR TITLE
remove large cells from the blocked items

### DIFF
--- a/config/GTNewHorizons/blocklimiter.cfg
+++ b/config/GTNewHorizons/blocklimiter.cfg
@@ -17,15 +17,6 @@ main {
     # Define your Items here. Syntax is: [modID]:[ItemID];[DimID];... if you don't add a Dimension (e.g. minecraft:dirt instead of minecraft:dirt;12) it will be denied in every dimension [default: ]
     S:ItemList <
         Avaritia:Endest_Pearl;0;-1;1;7;
-        gregtech:gt.metaitem.01:32405;
-        gregtech:gt.metaitem.01:32406;
-        gregtech:gt.metaitem.01:32407;
-        gregtech:gt.metaitem.01:32408;
-        gregtech:gt.metaitem.01:32409;
-        gregtech:gt.metaitem.01:32410;
-        gregtech:gt.metaitem.01:32411;
-        gregtech:gt.metaitem.01:32412;
-        gregtech:gt.metaitem.01:32413;
         TConstruct:buckets:24;0;-1;1;7;
         IguanaTweaksTConstruct:clayBucketsTinkers:24;0;-1;1;7;
         TwilightForest:item.tfspawnegg:182;0;-1;1;26;27;28;29;30;


### PR DESCRIPTION
This PR removes the large cells from being blocked by the game when you try to right click with them. They work correctly from what i can tell, and they were blacklisted 9 years ago, so probably something that got fixed without us noticing.