### PR TITLE
Egg & SE Dependency Removal

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/KillAlltheThings-AAAAAAAAAAAAAAAAAAAAJQ==/ThePowerofInfini-AAAAAAAAAAAAAAAAAAABlQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/KillAlltheThings-AAAAAAAAAAAAAAAAAAAAJQ==/ThePowerofInfini-AAAAAAAAAAAAAAAAAAABlQ==.json
@@ -27,10 +27,6 @@
     "6:10": {
       "questIDHigh:4": 0,
       "questIDLow:4": 399
-    },
-    "7:10": {
-      "questIDHigh:4": 0,
-      "questIDLow:4": 2111
     }
   },
   "properties:10": {

--- a/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/SpaceElevator-AAAAAAAAAAAAAAAAAAAM0w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier8UV-AAAAAAAAAAAAAAAAAAAALQ==/SpaceElevator-AAAAAAAAAAAAAAAAAAAM0w==.json
@@ -2,10 +2,6 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 2641
-    },
-    "1:10": {
-      "questIDHigh:4": 0,
       "questIDLow:4": 2623
     }
   },


### PR DESCRIPTION
### Changes:
- Removes King Slime completion quest dependency for secret witchery infinity egg quest, all of the other boss requirements make sense for this quest but this one is out of left field
- Removes Tier 7 plate quest requirement for Space Elevator quest, this was inhibiting completion of the quest for anyone doing a no rocket run, and you need the T7 plates to make the item anyway so the quest dependency is doing nothing helpful. 

This will close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20723.