### PR TITLE
Backpack & Shulker Bans

### DIFF
--- a/config/Backpack.cfg
+++ b/config/Backpack.cfg
@@ -60,7 +60,9 @@ general {
     # 
     # This will disallow dirt in backpacks.
     # ##############
-    S:disallowItems=
+    S:disallowItems <
+        etfuturum:shulker_box
+     >
 
     # ##############
     # Recipe to craft ender backpack

--- a/config/adventurebackpack.cfg
+++ b/config/adventurebackpack.cfg
@@ -167,6 +167,7 @@ items {
 
         # Disallow items by internal ID. Case sensitive. Example: minecraft:dirt [default: ]
         S:"By Internal ID" <
+        etfuturum:shulker_box
          >
 
         # Disallow items by internal ID. Case sensitive. Will be disallowed all items containing that word in their IDs. Use with caution. Example: minecraft:di [default: ]

--- a/config/etfuturum/functions.cfg
+++ b/config/etfuturum/functions.cfg
@@ -150,6 +150,7 @@ settings {
         adventurebackpack:adventureBackpack
         arsmagica2:essenceBag
         arsmagica2:runeBag
+        Backpack:backpack
         betterstorage:backpack
         betterstorage:cardboardBox
         betterstorage:thaumcraftBackpack


### PR DESCRIPTION
### Changes:
- Bans backpack from shulker box
- Bans shulker box from adventure backpack
- Bans shulker box from backpack

Shulker was already banned from adventure backpack

This contributes towards https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20769