### PR TITLE
Replaces Hard to Read Dark Blue Quest Titles

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BakedPotatoes-AAAAAAAAAAAAAAAAAAABug==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BakedPotatoes-AAAAAAAAAAAAAAAAAAABug==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§l\"Baked\" Potatoes",
+      "name:8": "§9§l\"Baked\" Potatoes",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BambooFence-AAAAAAAAAAAAAAAAAAADsg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BambooFence-AAAAAAAAAAAAAAAAAAADsg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lBamboo Fence",
+      "name:8": "§9§lBamboo Fence",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BerryMedley-AAAAAAAAAAAAAAAAAAAB1g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/BerryMedley-AAAAAAAAAAAAAAAAAAAB1g==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lBerry Medley",
+      "name:8": "§9§lBerry Medley",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CanYouHeartheCar-AAAAAAAAAAAAAAAAAAAB5A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CanYouHeartheCar-AAAAAAAAAAAAAAAAAAAB5A==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lCan You Hear the Carrots Grow?",
+      "name:8": "§9§lCan You Hear the Carrots Grow?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CaughtintheWeb-AAAAAAAAAAAAAAAAAAAHMw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CaughtintheWeb-AAAAAAAAAAAAAAAAAAAHMw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lCaught in the Web",
+      "name:8": "§9§lCaught in the Web",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CollectingSomeBe-AAAAAAAAAAAAAAAAAAAB1Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CollectingSomeBe-AAAAAAAAAAAAAAAAAAAB1Q==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lCollecting Some Berries",
+      "name:8": "§9§lCollecting Some Berries",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CowsAreSupposedt-AAAAAAAAAAAAAAAAAAAFww==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CowsAreSupposedt-AAAAAAAAAAAAAAAAAAAFww==.json
@@ -33,7 +33,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lCows Are Supposed to Moo!",
+      "name:8": "§9§lCows Are Supposed to Moo!",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CraftingTime-AAAAAAAAAAAAAAAAAAAEtA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CraftingTime-AAAAAAAAAAAAAAAAAAAEtA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lCrafting Time",
+      "name:8": "§9§lCrafting Time",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CreepingDread-AAAAAAAAAAAAAAAAAAAHMg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/CreepingDread-AAAAAAAAAAAAAAAAAAAHMg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lCreeping Dread",
+      "name:8": "§9§lCreeping Dread",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Evenmorechalleng-AAAAAAAAAAAAAAAAAAABjQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Evenmorechalleng-AAAAAAAAAAAAAAAAAAABjQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lEven more challenges needed?",
+      "name:8": "§9§lEven more challenges needed?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FireFireGrandpa-AAAAAAAAAAAAAAAAAAAACQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FireFireGrandpa-AAAAAAAAAAAAAAAAAAAACQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lFire, Fire, Grandpa!",
+      "name:8": "§9§lFire, Fire, Grandpa!",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FluffyandRed-AAAAAAAAAAAAAAAAAAAADA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FluffyandRed-AAAAAAAAAAAAAAAAAAAADA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lFluffy and Red",
+      "name:8": "§9§lFluffy and Red",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FoodVariants-AAAAAAAAAAAAAAAAAAAB1w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/FoodVariants-AAAAAAAAAAAAAAAAAAAB1w==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§2§1§lFood Variants",
+      "name:8": "§9§lFood Variants",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/GetThatStone-AAAAAAAAAAAAAAAAAAAACA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/GetThatStone-AAAAAAAAAAAAAAAAAAAACA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lGet That Stone",
+      "name:8": "§9§lGet That Stone",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Goals-AAAAAAAAAAAAAAAAAAABjA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Goals-AAAAAAAAAAAAAAAAAAABjA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lGoals",
+      "name:8": "§9§lGoals",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/LoadingtheChunks-AAAAAAAAAAAAAAAAAAALOg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/LoadingtheChunks-AAAAAAAAAAAAAAAAAAALOg==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lLoading the Chunks",
+      "name:8": "§9§lLoading the Chunks",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/MonsterTrap-AAAAAAAAAAAAAAAAAAADYQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/MonsterTrap-AAAAAAAAAAAAAAAAAAADYQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lMonster Trap",
+      "name:8": "§9§lMonster Trap",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/OakTreesAreNotAp-AAAAAAAAAAAAAAAAAAABuA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/OakTreesAreNotAp-AAAAAAAAAAAAAAAAAAABuA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lOak Trees Are Not Apple Trees",
+      "name:8": "§9§lOak Trees Are Not Apple Trees",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/PermanentOffhand-U7JoxM0mRaWx0MYriD2LtQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/PermanentOffhand-U7JoxM0mRaWx0MYriD2LtQ==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "Permanent Offhand!",
+      "name:8": "§9§lPermanent Offhand!",
       "questLogic:8": "AND",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/PorkchopsWithAtt-AAAAAAAAAAAAAAAAAAAHNA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/PorkchopsWithAtt-AAAAAAAAAAAAAAAAAAAHNA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lPorkchops With Attitude",
+      "name:8": "§9§lPorkchops With Attitude",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/RestinPieces-AAAAAAAAAAAAAAAAAAAACg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/RestinPieces-AAAAAAAAAAAAAAAAAAAACg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lRest in Pieces",
+      "name:8": "§9§lRest in Pieces",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SOTIREDMUSTSLEEP-AAAAAAAAAAAAAAAAAAAADQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SOTIREDMUSTSLEEP-AAAAAAAAAAAAAAAAAAAADQ==.json
@@ -24,7 +24,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lSO...TIRED...MUST...SLEEP...",
+      "name:8": "§9§lSO...TIRED...MUST...SLEEP...",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SoftMalletAdvent-AAAAAAAAAAAAAAAAAAABvA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SoftMalletAdvent-AAAAAAAAAAAAAAAAAAABvA==.json
@@ -27,7 +27,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lSoft Mallet Adventure",
+      "name:8": "§9§lSoft Mallet Adventure",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/StayingCoolinthe-AAAAAAAAAAAAAAAAAAAHQA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/StayingCoolinthe-AAAAAAAAAAAAAAAAAAAHQA==.json
@@ -24,7 +24,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lStaying Cool in the Heat",
+      "name:8": "§9§lStaying Cool in the Heat",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SticksnStones-AAAAAAAAAAAAAAAAAAAAAg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SticksnStones-AAAAAAAAAAAAAAAAAAAAAg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lSticks \u0027n Stones",
+      "name:8": "§9§lSticks \u0027n Stones",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/StorageForDays-AAAAAAAAAAAAAAAAAAAAAw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/StorageForDays-AAAAAAAAAAAAAAAAAAAAAw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lStorage For Days",
+      "name:8": "§9§lStorage For Days",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/TellMeWhenWeReac-AAAAAAAAAAAAAAAAAAAHOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/TellMeWhenWeReac-AAAAAAAAAAAAAAAAAAAHOQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lTell Me When We Reach 20",
+      "name:8": "§9§lTell Me When We Reach 20",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Tools-AAAAAAAAAAAAAAAAAAAABQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/Tools-AAAAAAAAAAAAAAAAAAAABQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lTools",
+      "name:8": "§9§lTools",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WhatYouSow-AAAAAAAAAAAAAAAAAAAABw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WhatYouSow-AAAAAAAAAAAAAAAAAAAABw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§l...What You Sow",
+      "name:8": "§9§l...What You Sow",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WherestheFlint-AAAAAAAAAAAAAAAAAAAAAQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WherestheFlint-AAAAAAAAAAAAAAAAAAAAAQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lWhere\u0027s the Flint?",
+      "name:8": "§9§lWhere\u0027s the Flint?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/YouReap-AAAAAAAAAAAAAAAAAAAABg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/YouReap-AAAAAAAAAAAAAAAAAAAABg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lYou Reap...",
+      "name:8": "§9§lYou Reap...",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/YourFirstNight-AAAAAAAAAAAAAAAAAAAAAA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/YourFirstNight-AAAAAAAAAAAAAAAAAAAAAA==.json
@@ -15,7 +15,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§d§3§2§1§lYour First Night",
+      "name:8": "§9§lYour First Night",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/AllAloneintheNig-AAAAAAAAAAAAAAAAAAAF1w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/AllAloneintheNig-AAAAAAAAAAAAAAAAAAAF1w==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lAll Alone in the Night",
+      "name:8": "§9§lAll Alone in the Night",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BackupYourStuff-AAAAAAAAAAAAAAAAAAAF3Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BackupYourStuff-AAAAAAAAAAAAAAAAAAAF3Q==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lBackup Your Stuff...",
+      "name:8": "§9§lBackup Your Stuff...",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BetterQuesting-AAAAAAAAAAAAAAAAAAAF3A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BetterQuesting-AAAAAAAAAAAAAAAAAAAF3A==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lBetter Questing?",
+      "name:8": "§9§lBetter Questing?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ETOOMANYKEYS-AAAAAAAAAAAAAAAAAAAIYQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ETOOMANYKEYS-AAAAAAAAAAAAAAAAAAAIYQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lE_TOO_MANY_KEYS",
+      "name:8": "§9§lE_TOO_MANY_KEYS",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MainQuestsandSec-AAAAAAAAAAAAAAAAAAAABA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MainQuestsandSec-AAAAAAAAAAAAAAAAAAAABA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lMain Quests and Secondary Quests",
+      "name:8": "§9§lMain Quests and Secondary Quests",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MonsterHunter-AAAAAAAAAAAAAAAAAAAACw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MonsterHunter-AAAAAAAAAAAAAAAAAAAACw==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 1,
-      "name:8": "§1§lMonster Hunter",
+      "name:8": "§9§lMonster Hunter",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MoronsManualforM-AAAAAAAAAAAAAAAAAAAHMQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MoronsManualforM-AAAAAAAAAAAAAAAAAAAHMQ==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lMoron\u0027s Manual for Massacring Monsters",
+      "name:8": "§9§lMoron\u0027s Manual for Massacring Monsters",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MushroomBiomesWh-AAAAAAAAAAAAAAAAAAAHKg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MushroomBiomesWh-AAAAAAAAAAAAAAAAAAAHKg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lMushroom Biomes? Why Are There So Many?",
+      "name:8": "§9§lMushroom Biomes? Why Are There So Many?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/NumbersintheCorn-AAAAAAAAAAAAAAAAAAAJZg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/NumbersintheCorn-AAAAAAAAAAAAAAAAAAAJZg==.json
@@ -19,7 +19,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lNumbers in the Corner?",
+      "name:8": "§9§lNumbers in the Corner?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShieldUpdate-AAAAAAAAAAAAAAAAAAABwA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShieldUpdate-AAAAAAAAAAAAAAAAAAABwA==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lShield Update",
+      "name:8": "§9§lShield Update",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShieldsUP-AAAAAAAAAAAAAAAAAAABvg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShieldsUP-AAAAAAAAAAAAAAAAAAABvg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lShields UP",
+      "name:8": "§9§lShields UP",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/WhatsThat-AAAAAAAAAAAAAAAAAAAADg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/WhatsThat-AAAAAAAAAAAAAAAAAAAADg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lWhat\u0027s That...?",
+      "name:8": "§9§lWhat\u0027s That...?",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/YourFirstLongRan-AAAAAAAAAAAAAAAAAAABwg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/YourFirstLongRan-AAAAAAAAAAAAAAAAAAABwg==.json
@@ -20,7 +20,7 @@
       "isMain:1": 0,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§1§lYour First \u0027Long Range\u0027 Weapon",
+      "name:8": "§9§lYour First \u0027Long Range\u0027 Weapon",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,


### PR DESCRIPTION
## Changes:
- Does exactly as title describes, the dark blue was hard on the eyes and a pain to read (even on midnight theme), this lightens the blue and keeps the bold but makes it friendly on all themes of the questbook. 

### Old Look:
<img width="184" height="58" alt="image" src="https://github.com/user-attachments/assets/03e11a79-c1e0-4d91-bfd7-a467e66e0618" />

### Side-By-Side Difference:
<img width="672" height="386" alt="image" src="https://github.com/user-attachments/assets/8894ede2-18a8-4d14-9864-d2a08af20dec" />

### New Look:
<img width="707" height="455" alt="image" src="https://github.com/user-attachments/assets/be17eb93-e14d-41fe-a283-bda4a4f93d6c" />
