### PR TITLE
Ore refactor changes

### DIFF
--- a/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
+++ b/config/BloodMagic/meteors/CheatyVeryLowQuantityRawTengam.json
@@ -3,7 +3,7 @@
     "OREDICT:oreMarbleSalt:69"
   ],
   "filler": [
-    "gregtech:gt.blockores:817:72",
+    "gregtech:gt.blockores2:817:72",
     "OREDICT:oreTengamRaw:1"
   ],
   "radius": 16,

--- a/config/EnhancedLootBags/LootBags.xml
+++ b/config/EnhancedLootBags/LootBags.xml
@@ -178,10 +178,10 @@
     <LootGroup GroupMetaID="2" GroupName="dreamcraft.lootbag.group.steam_age" Rarity="0" MinItems="1" MaxItems="2" CombineTrashGroup="true" TrashGroup="1" LootbagIcon="enhancedlootbags:steam_age">
         <Loot Identifier="0af8494c-84ee-4da2-9183-caac33026400" ItemName="gregtech:gt.blockmachines:1" Amount="1" NBTTag="" Chance="50" LimitedDropCount="8" RandomAmount="false"/>
         <Loot Identifier="d408b251-f7ed-4826-af9a-faf46216b6a6" ItemName="IC2:itemHarz" Amount="16" NBTTag="" Chance="60" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="df4b97a8-7f10-4f30-8ece-c833d5ac3fb4" ItemName="gregtech:gt.blockores:817" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="7bbfd16f-ee63-4d00-a036-b6f53ec0db10" ItemName="gregtech:gt.blockores:57" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="43f85d9c-678e-4fbf-bdc1-3904a1c21a83" ItemName="gregtech:gt.blockores:32" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="6ef0c03f-f7fd-4e70-9f0e-c165dfbe36bb" ItemName="gregtech:gt.blockores:35" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="df4b97a8-7f10-4f30-8ece-c833d5ac3fb4" ItemName="gregtech:gt.blockores2:817" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="7bbfd16f-ee63-4d00-a036-b6f53ec0db10" ItemName="gregtech:gt.blockores2:57" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="43f85d9c-678e-4fbf-bdc1-3904a1c21a83" ItemName="gregtech:gt.blockores2:32" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="6ef0c03f-f7fd-4e70-9f0e-c165dfbe36bb" ItemName="gregtech:gt.blockores2:35" Amount="16" NBTTag="" Chance="65" LimitedDropCount="0" RandomAmount="true"/>
         <Loot Identifier="d55dc146-a8ff-4c1c-9a96-7702202144d5" ItemName="minecraft:sticky_piston" Amount="1" NBTTag="" Chance="50" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="d957e6d0-67f0-4557-82e8-9993aa877171" ItemName="minecraft:piston" Amount="1" NBTTag="" Chance="50" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="98fc20c9-6524-4fab-934f-c87341653d93" ItemName="minecraft:brick_block" Amount="8" NBTTag="" Chance="60" LimitedDropCount="0" RandomAmount="true"/>
@@ -244,13 +244,13 @@
         <Loot Identifier="f9abe881-adac-4590-9610-c1003d82959c" ItemName="gregtech:gt.metaitem.02:32243" Amount="2" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="54001efc-8108-48c0-9a2f-18a1becc2921" ItemName="harvestcraft:hushpuppiesItem" Amount="4" NBTTag="" Chance="45" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="7b1788b6-ea19-4886-bb04-94b9973d437f" ItemName="harvestcraft:shrimpokrahushpuppiesItem" Amount="4" NBTTag="" Chance="45" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="e31b9490-eb49-4c4e-8cf2-adff8920ced8" ItemName="gregtech:gt.blockores:526" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="168aba17-5606-4b0d-8074-f0bcaa5c3c04" ItemName="gregtech:gt.blockores:810" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="b8c2271e-dccb-41d6-9674-39c4036f1780" ItemName="gregtech:gt.blockores:935" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="cb3bfcd4-96d3-4ea6-8c8e-f9fe33d5505d" ItemName="gregtech:gt.blockores:500" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="9ad14c4c-759e-4ddb-8def-00066260da0d" ItemName="gregtech:gt.blockores:57" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="da84a002-2885-4878-93d6-604dd7427059" ItemName="gregtech:gt.blockores:35" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="bd5f9233-dbc2-4da3-8094-8909f8ff39b5" ItemName="gregtech:gt.blockores:32" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="e31b9490-eb49-4c4e-8cf2-adff8920ced8" ItemName="gregtech:gt.blockores2:526" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="168aba17-5606-4b0d-8074-f0bcaa5c3c04" ItemName="gregtech:gt.blockores2:810" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="b8c2271e-dccb-41d6-9674-39c4036f1780" ItemName="gregtech:gt.blockores2:935" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="cb3bfcd4-96d3-4ea6-8c8e-f9fe33d5505d" ItemName="gregtech:gt.blockores2:500" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="9ad14c4c-759e-4ddb-8def-00066260da0d" ItemName="gregtech:gt.blockores2:57" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="da84a002-2885-4878-93d6-604dd7427059" ItemName="gregtech:gt.blockores2:35" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="bd5f9233-dbc2-4da3-8094-8909f8ff39b5" ItemName="gregtech:gt.blockores2:32" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="ef675b81-535e-4943-936c-b62a4ac213a9" ItemName="minecraft:spawn_egg:94" Amount="1" NBTTag="" Chance="75" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="d0266732-2b4f-4211-8227-fea5250a3709" ItemName="minecraft:spawn_egg:100" Amount="1" NBTTag="" Chance="75" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="04e92352-2618-4520-9d9d-3796cb897543" ItemName="TConstruct:SpeedBlock" Amount="32" NBTTag="" Chance="55" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
@@ -612,17 +612,17 @@
         <Loot Identifier="9f9aa3ee-dfe9-4498-826a-e8c4ce934e5f" ItemName="gregtech:gt.metaitem.01:11635" Amount="32" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="b2d9cea7-1910-40be-ac65-a73d72b68666" ItemName="gregtech:gt.metaitem.01:11471" Amount="64" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="ee4cf91c-dc45-4b4d-af4f-c5e6639d0a5b" ItemName="gregtech:gt.metaitem.01:11874" Amount="128" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="52687ad3-7398-4d99-ae49-3ee273606e34" ItemName="gregtech:gt.blockores:817" Amount="64" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="fbeaf863-e114-4dd6-82e9-66636c8362d1" ItemName="gregtech:gt.blockores:1839" Amount="64" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="210bb829-5fec-4659-87fe-2d05130b47e3" ItemName="gregtech:gt.blockores:907" Amount="48" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
-        <Loot Identifier="f00578a2-e2a4-4c5c-9754-b6dde5469063" ItemName="gregtech:gt.blockores:901" Amount="32" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="52687ad3-7398-4d99-ae49-3ee273606e34" ItemName="gregtech:gt.blockores2:817" Amount="64" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="fbeaf863-e114-4dd6-82e9-66636c8362d1" ItemName="gregtech:gt.blockores2:1839" Amount="64" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="210bb829-5fec-4659-87fe-2d05130b47e3" ItemName="gregtech:gt.blockores2:907" Amount="48" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="f00578a2-e2a4-4c5c-9754-b6dde5469063" ItemName="gregtech:gt.blockores2:901" Amount="32" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="true"/>
     </LootGroup>
     <LootGroup GroupMetaID="8" GroupName="dreamcraft.lootbag.group.tier_5_iv" Rarity="2" MinItems="1" MaxItems="2" CombineTrashGroup="true" TrashGroup="7" LootbagIcon="enhancedlootbags:iv">
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:2" Amount="1" NBTTag="" Chance="2" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:4" Amount="1" NBTTag="" Chance="2" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:6" Amount="1" NBTTag="" Chance="1" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="ff263b56-39cb-4dc6-aa40-389eb8d22b77" ItemName="gregtech:gt.metaitem.01:32714" Amount="3" NBTTag="" Chance="100" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores:324" Amount="32" NBTTag="" Chance="80" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores2:324" Amount="32" NBTTag="" Chance="80" LimitedDropCount="0" RandomAmount="true"/>
         <Loot Identifier="b17218f9-6275-4de0-9b91-9a982b7adf91" ItemName="EnderIO:blockTransceiver" Amount="2" NBTTag="" Chance="50" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="3a6a65fc-d45e-4532-aa61-3b39de548f10" ItemName="EnderStorage:enderChest" Amount="2" NBTTag="" Chance="50" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="a7bc9dcc-4f45-4c8b-b24c-c6e7ff34c23d" ItemName="EnderStorage:enderChest:4096" Amount="2" NBTTag="" Chance="50" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
@@ -685,7 +685,7 @@
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:4" Amount="1" NBTTag="" Chance="2" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:6" Amount="1" NBTTag="" Chance="1" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="ff263b56-39cb-4dc6-aa40-389eb8d22b77" ItemName="gregtech:gt.metaitem.01:32714" Amount="6" NBTTag="" Chance="100" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores:326" Amount="32" NBTTag="" Chance="80" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores2:326" Amount="32" NBTTag="" Chance="80" LimitedDropCount="0" RandomAmount="true"/>
         <Loot Identifier="cc5bbc6a-6895-438a-aa47-d0762854b3a3" ItemName="gregtech:gt.blockmachines:1135" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="b17218f9-6275-4de0-9b91-9a982b7adf91" ItemName="EnderIO:blockTransceiver" Amount="2" NBTTag="" Chance="25" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="3a6a65fc-d45e-4532-aa61-3b39de548f10" ItemName="EnderStorage:enderChest" Amount="2" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
@@ -749,7 +749,7 @@
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:4" Amount="1" NBTTag="" Chance="2" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="0ef801b1-1b39-4864-973f-4204f2955af8" ItemName="TConstruct:heartCanister:6" Amount="1" NBTTag="" Chance="1" ItemGroup="" LimitedDropCount="10" RandomAmount="false"/>
         <Loot Identifier="ff263b56-39cb-4dc6-aa40-389eb8d22b77" ItemName="gregtech:gt.metaitem.01:32713" Amount="24" NBTTag="" Chance="150" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores:327" Amount="32" NBTTag="" Chance="60" LimitedDropCount="0" RandomAmount="true"/>
+        <Loot Identifier="11de8e54-d5a1-4c9a-a70e-0acd87f2c357" ItemName="gregtech:gt.blockores2:327" Amount="32" NBTTag="" Chance="60" LimitedDropCount="0" RandomAmount="true"/>
         <Loot Identifier="cc5bbc6a-6895-438a-aa47-d0762854b3a3" ItemName="gregtech:gt.blockmachines:1136" Amount="1" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="b17218f9-6275-4de0-9b91-9a982b7adf91" ItemName="EnderIO:blockTransceiver" Amount="2" NBTTag="" Chance="25" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="3a6a65fc-d45e-4532-aa61-3b39de548f10" ItemName="EnderStorage:enderChest" Amount="2" NBTTag="" Chance="25" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
@@ -847,7 +847,7 @@
         <Loot Identifier="51635a8e-9008-4075-bda2-80ff7ca8f52a" ItemName="gregtech:gt.blockmachines:47" Amount="4" NBTTag="" Chance="90" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="b5e162da-ac7a-4075-b3b6-00d7d5d08446" ItemName="gregtech:gt.metaitem.03:32105" Amount="32" NBTTag="" Chance="40" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="92539180-9f52-49b0-b380-a2638ed3e72d" ItemName="gregtech:gt.blockmachines:1806" Amount="64" NBTTag="" Chance="80" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
-        <Loot Identifier="8b3dc34e-f151-486a-ab11-b6a83e433820" ItemName="gregtech:gt.blockores:327" Amount="32" NBTTag="{LootBagDrop:{LBDCF3:4.27d,LBDCF1:1.84d,LBDAmount:32,LBDLimit:0,LBDCF2:2.55d,LBDID:&quot;11de8e54-d5a1-4c9a-a70e-0acd87f2c357&quot;,LBDRnd:1b,LBDTrash:1b,LBDWeight:60,LBDGroup:&quot;- no group -&quot;,LBDCF0:1.44d}}" Chance="100" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
+        <Loot Identifier="8b3dc34e-f151-486a-ab11-b6a83e433820" ItemName="gregtech:gt.blockores2:327" Amount="32" NBTTag="{LootBagDrop:{LBDCF3:4.27d,LBDCF1:1.84d,LBDAmount:32,LBDLimit:0,LBDCF2:2.55d,LBDID:&quot;11de8e54-d5a1-4c9a-a70e-0acd87f2c357&quot;,LBDRnd:1b,LBDTrash:1b,LBDWeight:60,LBDGroup:&quot;- no group -&quot;,LBDCF0:1.44d}}" Chance="100" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
         <Loot Identifier="b162dc8a-4e18-45e9-a4a6-908d81731bfd" ItemName="berriespp:BppPotions:8" Amount="32" NBTTag="" Chance="40" ItemGroup="" LimitedDropCount="0" RandomAmount="false"/>
     </LootGroup>
     <LootGroup GroupMetaID="44" GroupName="dreamcraft.lootbag.group.tier_9_uhv" Rarity="4" MinItems="1" MaxItems="2" CombineTrashGroup="true" TrashGroup="43" LootbagIcon="enhancedlootbags:uhv">

--- a/config/GTNewHorizons/angermod.cfg
+++ b/config/GTNewHorizons/angermod.cfg
@@ -3,7 +3,7 @@
 blacklist {
     # Define all Blocks here where Enderman should become angry when you break them [default: [gregtech:gt.blockores]]
     S:EndBlocks <
-        gregtech:gt.blockores
+        gregtech:gt.blockores2
      >
 
     # If the player is using one of these items, entities will not explode if they are killed [default: [flint]]
@@ -18,7 +18,7 @@ blacklist {
 
     # Define all Blocks here where Pigmen should become angry when you break them [default: [gregtech:gt.blockores]]
     S:NetherBlocks <
-        gregtech:gt.blockores
+        gregtech:gt.blockores2
      >
 }
 

--- a/config/bartworks.cfg
+++ b/config/bartworks.cfg
@@ -56,7 +56,7 @@ general {
 
         # This is a blacklist for the Void Miner, blacklisted ores will not enter the drop prize pool.
         # Please fill in the Unique Identifier of Ore and connect Damage with a colon,
-        # For example: gregtech:gt.blockores:32 [default: ]
+        # For example: gregtech:gt.blockores2:32 [default: ]
         S:voidMinerBlacklist <
          >
     }

--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/FluixCrystals-AAAAAAAAAAAAAAAAAAAAtQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/FluixCrystals-AAAAAAAAAAAAAAAAAAAAtQ==.json
@@ -47,7 +47,7 @@
           "Count:3": 8,
           "Damage:2": 1516,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/ImmaCharginMy-AAAAAAAAAAAAAAAAAAAFCg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AppliedEnergisti-AAAAAAAAAAAAAAAAAAAAIw==/ImmaCharginMy-AAAAAAAAAAAAAAAAAAAFCg==.json
@@ -45,13 +45,13 @@
           "Count:3": 8,
           "Damage:2": 1516,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 8,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CalciteGettingyo-AAAAAAAAAAAAAAAAAAAHGA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CalciteGettingyo-AAAAAAAAAAAAAAAAAAAHGA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 823,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -44,7 +44,7 @@
           "Count:3": 64,
           "Damage:2": 823,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CantFindThoseOre-AAAAAAAAAAAAAAAAAAAF8w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CantFindThoseOre-AAAAAAAAAAAAAAAAAAAF8w==.json
@@ -41,85 +41,85 @@
           "Count:3": 1,
           "Damage:2": 937,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 1,
           "Damage:2": 35,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 1,
           "Damage:2": 870,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 1,
           "Damage:2": 834,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 1,
           "Damage:2": 500,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "5:10": {
           "Count:3": 1,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "6:10": {
           "Count:3": 1,
           "Damage:2": 526,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "7:10": {
           "Count:3": 1,
           "Damage:2": 530,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "8:10": {
           "Count:3": 1,
           "Damage:2": 523,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "9:10": {
           "Count:3": 1,
           "Damage:2": 535,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "10:10": {
           "Count:3": 1,
           "Damage:2": 57,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "11:10": {
           "Count:3": 1,
           "Damage:2": 936,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "12:10": {
           "Count:3": 1,
           "Damage:2": 935,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "13:10": {
           "Count:3": 1,
           "Damage:2": 838,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CoalOreexchange-AAAAAAAAAAAAAAAAAAAJfA==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 535,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/CopperOreexchang-AAAAAAAAAAAAAAAAAAAJgQ==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 35,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/DiamondOreexchan-AAAAAAAAAAAAAAAAAAAJfg==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 500,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/GoldOreexchange-AAAAAAAAAAAAAAAAAAAJew==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/GoldOreexchange-AAAAAAAAAAAAAAAAAAAJew==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 86,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/IronOreexchange-AAAAAAAAAAAAAAAAAAAJKQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/IronOreexchange-AAAAAAAAAAAAAAAAAAAJKQ==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 32,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LapisOreexchange-AAAAAAAAAAAAAAAAAAAJfQ==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 526,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/LeadOreexchange-AAAAAAAAAAAAAAAAAAAJhA==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 89,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/ManganeseOre-AAAAAAAAAAAAAAAAAAAHZw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/ManganeseOre-AAAAAAAAAAAAAAAAAAAHZw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 31,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -44,7 +44,7 @@
           "Count:3": 8,
           "Damage:2": 31,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/NetherquartzOree-AAAAAAAAAAAAAAAAAAAJgA==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 1522,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/PyrochloreOre-AAAAAAAAAAAAAAAAAAAEFg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/PyrochloreOre-AAAAAAAAAAAAAAAAAAAEFg==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 607,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -44,7 +44,7 @@
           "Count:3": 64,
           "Damage:2": 607,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/RedstoneOreexcha-AAAAAAAAAAAAAAAAAAAJfw==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/TinOreexchange-AAAAAAAAAAAAAAAAAAAJgg==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 57,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/UraniumOreexchan-AAAAAAAAAAAAAAAAAAAJgw==.json
@@ -68,7 +68,7 @@
           "Count:3": 64,
           "Damage:2": 98,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/YouCantSpellLign-AAAAAAAAAAAAAAAAAAAIZw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/CoinsCoinsCoins-AAAAAAAAAAAAAAAAAAAAEA==/YouCantSpellLign-AAAAAAAAAAAAAAAAAAAIZw==.json
@@ -44,7 +44,7 @@
           "Count:3": 64,
           "Damage:2": 538,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }

--- a/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/JustCoverYourPri-AAAAAAAAAAAAAAAAAAAHiQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/JustCoverYourPri-AAAAAAAAAAAAAAAAAAAHiQ==.json
@@ -44,7 +44,7 @@
           "Count:3": 32,
           "Damage:2": 873,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 2,

--- a/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/MetalsFromtheSky-AAAAAAAAAAAAAAAAAAAHAw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/MetalsFromtheSky-AAAAAAAAAAAAAAAAAAAHAw==.json
@@ -79,13 +79,13 @@
           "Count:3": 2,
           "Damage:2": 2084,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 2,
           "Damage:2": 2083,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/SonofOdinOneEye-AAAAAAAAAAAAAAAAAAAHiA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/FishingFarmingCo-AAAAAAAAAAAAAAAAAAAACg==/SonofOdinOneEye-AAAAAAAAAAAAAAAAAAAHiA==.json
@@ -44,7 +44,7 @@
           "Count:3": 16,
           "Damage:2": 96,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/ForestryandMulti-AAAAAAAAAAAAAAAAAAAAEg==/FindingApatite-AAAAAAAAAAAAAAAAAAACTA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/ForestryandMulti-AAAAAAAAAAAAAAAAAAAAEg==/FindingApatite-AAAAAAAAAAAAAAAAAAACTA==.json
@@ -93,19 +93,19 @@
           "Count:3": 64,
           "Damage:2": 530,
           "OreDict:8": "oreApatite",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,
           "Damage:2": 534,
           "OreDict:8": "orePhosphorite",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 607,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Dancingincircles-AAAAAAAAAAAAAAAAAAAFjw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Dancingincircles-AAAAAAAAAAAAAAAAAAAFjw==.json
@@ -50,7 +50,7 @@
           "Count:3": 64,
           "Damage:2": 34,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     },

--- a/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Therocksinthewas-AAAAAAAAAAAAAAAAAAAFjg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MassProcessing-AAAAAAAAAAAAAAAAAAAAEQ==/Therocksinthewas-AAAAAAAAAAAAAAAAAAAFjg==.json
@@ -47,19 +47,19 @@
           "Count:3": 64,
           "Damage:2": 944,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 64,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 64,
           "Damage:2": 526,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BatteryAlloy-AAAAAAAAAAAAAAAAAAACYQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/BatteryAlloy-AAAAAAAAAAAAAAAAAAACYQ==.json
@@ -45,25 +45,25 @@
           "Count:3": 16,
           "Damage:2": 826,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,
           "Damage:2": 933,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 907,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 839,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShakeThatBooty-AAAAAAAAAAAAAAAAAAAFjA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/ShakeThatBooty-AAAAAAAAAAAAAAAAAAAFjA==.json
@@ -51,61 +51,61 @@
           "Count:3": 64,
           "Damage:2": 502,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 64,
           "Damage:2": 501,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 64,
           "Damage:2": 503,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 64,
           "Damage:2": 514,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "5:10": {
           "Count:3": 64,
           "Damage:2": 542,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "6:10": {
           "Count:3": 64,
           "Damage:2": 543,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "7:10": {
           "Count:3": 64,
           "Damage:2": 541,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "8:10": {
           "Count:3": 64,
           "Damage:2": 540,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "9:10": {
           "Count:3": 64,
           "Damage:2": 545,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "10:10": {
           "Count:3": 64,
           "Damage:2": 544,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "11:10": {
           "Count:3": 2,

--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/InfusedStones-AAAAAAAAAAAAAAAAAAAA5Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/InfusedStones-AAAAAAAAAAAAAAAAAAAA5Q==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 541,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -81,49 +81,49 @@
           "Count:3": 16,
           "Damage:2": 543,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,
           "Damage:2": 541,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 540,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 542,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 16,
           "Damage:2": 545,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "5:10": {
           "Count:3": 16,
           "Damage:2": 544,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "6:10": {
           "Count:3": 16,
           "Damage:2": 514,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "7:10": {
           "Count:3": 16,
           "Damage:2": 826,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/LeadGalenaSilver-AAAAAAAAAAAAAAAAAAACYg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/LeadGalenaSilver-AAAAAAAAAAAAAAAAAAACYg==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 830,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -81,25 +81,25 @@
           "Count:3": 32,
           "Damage:2": 830,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 54,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 89,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 699,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/ShadowMetal-NO4JlNzcR_-1gaQi-kb3JA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/ShadowMetal-NO4JlNzcR_-1gaQi-kb3JA==.json
@@ -72,7 +72,7 @@
           "Count:3": 5,
           "Damage:2": 368,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:optional_retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SourceofNickel-AAAAAAAAAAAAAAAAAAAGTQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/NoviceThaumaturg-AAAAAAAAAAAAAAAAAAAAFg==/SourceofNickel-AAAAAAAAAAAAAAAAAAAGTQ==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 906,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -106,25 +106,25 @@
           "Count:3": 32,
           "Damage:2": 906,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 34,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 827,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 909,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/SummontheMeteor-s4B77B7FSamWlvHY8hfqqA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PayingtheHighest-AAAAAAAAAAAAAAAAAAAAHA==/SummontheMeteor-s4B77B7FSamWlvHY8hfqqA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 2398,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isMain:1": 0,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/CanWeGetUraniumH-AAAAAAAAAAAAAAAAAAAMYA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/PowerfulNuclearP-AAAAAAAAAAAAAAAAAAAAGg==/CanWeGetUraniumH-AAAAAAAAAAAAAAAAAAAMYA==.json
@@ -52,7 +52,7 @@
           "Count:3": 2,
           "Damage:2": 1096,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 7,

--- a/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FindSomeMeteoric-AAAAAAAAAAAAAAAAAAAFkg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/SpaceRace-AAAAAAAAAAAAAAAAAAAAIg==/FindSomeMeteoric-AAAAAAAAAAAAAAAAAAAFkg==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 340,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/StoringandTransf-AAAAAAAAAAAAAAAAAAAAIQ==/LapotronicEnergy-AAAAAAAAAAAAAAAAAAAHHA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/StoringandTransf-AAAAAAAAAAAAAAAAAAAAIQ==/LapotronicEnergy-AAAAAAAAAAAAAAAAAAAHHA==.json
@@ -64,7 +64,7 @@
           "Count:3": 128,
           "Damage:2": 526,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 8,

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/ExtraModifier-AAAAAAAAAAAAAAAAAAAEag==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/ExtraModifier-AAAAAAAAAAAAAAAAAAAEag==.json
@@ -48,7 +48,7 @@
           "Count:3": 16,
           "Damage:2": 86,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 8,

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/Gypsum-AAAAAAAAAAAAAAAAAAADZA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 934,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -106,25 +106,25 @@
           "Count:3": 32,
           "Damage:2": 935,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 936,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 928,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 934,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/HowtoMakeRubber-AAAAAAAAAAAAAAAAAAAB8A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/HowtoMakeRubber-AAAAAAAAAAAAAAAAAAAB8A==.json
@@ -98,19 +98,19 @@
           "Count:3": 64,
           "Damage:2": 1022,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 1834,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 1839,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/LapisLazuriteSod-AAAAAAAAAAAAAAAAAAADYw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/LapisLazuriteSod-AAAAAAAAAAAAAAAAAAADYw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 526,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -106,25 +106,25 @@
           "Count:3": 32,
           "Damage:2": 524,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 525,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 526,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 823,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/OooShinyNotPlati-AAAAAAAAAAAAAAAAAAAB7w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier05Steam-AAAAAAAAAAAAAAAAAAAAAg==/OooShinyNotPlati-AAAAAAAAAAAAAAAAAAAB7w==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 500,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -112,19 +112,19 @@
           "Count:3": 64,
           "Damage:2": 865,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 500,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 535,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/CopperOre-AAAAAAAAAAAAAAAAAAADOQ==.json
@@ -87,25 +87,25 @@
           "Count:3": 32,
           "Damage:2": 855,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 32,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 834,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 35,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/DivineRodoftheGo-AAAAAAAAAAAAAAAAAAAF4A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/DivineRodoftheGo-AAAAAAAAAAAAAAAAAAAF4A==.json
@@ -42,25 +42,25 @@
           "Count:3": 1,
           "Damage:2": 35,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 1,
           "Damage:2": 937,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 1,
           "Damage:2": 870,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 1,
           "Damage:2": 834,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/IronOre-AAAAAAAAAAAAAAAAAAADOg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/IronOre-AAAAAAAAAAAAAAAAAAADOg==.json
@@ -87,31 +87,31 @@
           "Count:3": 16,
           "Damage:2": 917,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,
           "Damage:2": 32,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 870,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 931,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 16,
           "Damage:2": 930,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Malachite-AAAAAAAAAAAAAAAAAAAB4A==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 871,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -87,25 +87,25 @@
           "Count:3": 32,
           "Damage:2": 930,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 931,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 917,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 871,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RareOres-AAAAAAAAAAAAAAAAAAAGCg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RareOres-AAAAAAAAAAAAAAAAAAAGCg==.json
@@ -41,25 +41,25 @@
           "Count:3": 1,
           "Damage:2": 35,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 1,
           "Damage:2": 523,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 1,
           "Damage:2": 535,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 1,
           "Damage:2": 824,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/Redstone-AAAAAAAAAAAAAAAAAAAB7g==.json
@@ -87,19 +87,19 @@
           "Count:3": 64,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 502,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 826,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RedstoneEarlyGam-AAAAAAAAAAAAAAAAAAACFw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RedstoneEarlyGam-AAAAAAAAAAAAAAAAAAACFw==.json
@@ -57,7 +57,7 @@
           "Count:3": 10,
           "Damage:2": 810,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "ignoreDisabled:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/TooManyLeaves-AAAAAAAAAAAAAAAAAAAKoA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/TooManyLeaves-AAAAAAAAAAAAAAAAAAAKoA==.json
@@ -39,7 +39,7 @@
           "Count:3": 4,
           "Damage:2": 32,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier10UEV-D_aFb1hFQH2PDkN0_KvAEQ==/TheFinalFrontier-X1tb5rwVSVi5SR5rY7vQIw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier10UEV-D_aFb1hFQH2PDkN0_KvAEQ==/TheFinalFrontier-X1tb5rwVSVi5SR5rY7vQIw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 110,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isMain:1": 1,
       "isSilent:1": 0,
@@ -46,7 +46,7 @@
           "Count:3": 64,
           "Damage:2": 110,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/BetterGalliumand-AAAAAAAAAAAAAAAAAAAHBA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/BetterGalliumand-AAAAAAAAAAAAAAAAAAAHBA==.json
@@ -44,7 +44,7 @@
           "Count:3": 1,
           "Damage:2": 37,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodium-AAAAAAAAAAAAAAAAAAACbQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodium-AAAAAAAAAAAAAAAAAAACbQ==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 933,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -87,25 +87,25 @@
           "Count:3": 32,
           "Damage:2": 877,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 902,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 933,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 909,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodiuman-AAAAAAAAAAAAAAAAAAACbg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/HowtoGetSodiuman-AAAAAAAAAAAAAAAAAAACbg==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 817,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -87,25 +87,25 @@
           "Count:3": 32,
           "Damage:2": 817,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 944,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 907,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 920,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MagnesiumSource-AAAAAAAAAAAAAAAAAAAGBA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MagnesiumSource-AAAAAAAAAAAAAAAAAAAGBA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 908,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -106,7 +106,7 @@
           "Count:3": 16,
           "Damage:2": 908,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Mercury-AAAAAAAAAAAAAAAAAAACaA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Mercury-AAAAAAAAAAAAAAAAAAACaA==.json
@@ -44,7 +44,7 @@
           "Count:3": 8,
           "Damage:2": 826,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 4,

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MicaOre-AAAAAAAAAAAAAAAAAAALpw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/MicaOre-AAAAAAAAAAAAAAAAAAALpw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 901,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -81,25 +81,25 @@
           "Count:3": 32,
           "Damage:2": 901,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 924,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 824,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 919,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/OilsandorHowYouG-AAAAAAAAAAAAAAAAAAAG_w==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 878,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -106,7 +106,7 @@
           "Count:3": 128,
           "Damage:2": 878,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/QuartziteVeins-AAAAAAAAAAAAAAAAAAAEjg==.json
@@ -112,19 +112,19 @@
           "Count:3": 32,
           "Damage:2": 1523,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 1904,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 48,
           "Damage:2": 1516,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/TetrahedriteStib-AAAAAAAAAAAAAAAAAAACVQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/TetrahedriteStib-AAAAAAAAAAAAAAAAAAACVQ==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 1840,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -98,19 +98,19 @@
           "Count:3": 64,
           "Damage:2": 1840,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 1035,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 1945,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/TantalumOre-AAAAAAAAAAAAAAAAAAAHKw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/TantalumOre-AAAAAAAAAAAAAAAAAAAHKw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 921,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -94,25 +94,25 @@
           "Count:3": 64,
           "Damage:2": 921,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 64,
           "Damage:2": 838,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 64,
           "Damage:2": 943,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 64,
           "Damage:2": 831,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -129,25 +129,25 @@
           "Count:3": 32,
           "Damage:2": 1921,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 1838,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 1943,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 32,
           "Damage:2": 1831,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/Chloroform-AAAAAAAAAAAAAAAAAAAHFQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/Chloroform-AAAAAAAAAAAAAAAAAAAHFQ==.json
@@ -44,7 +44,7 @@
           "Count:3": 64,
           "Damage:2": 944,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     },

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/EvenLARGERTanks-AAAAAAAAAAAAAAAAAAAHEw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/EvenLARGERTanks-AAAAAAAAAAAAAAAAAAAHEw==.json
@@ -54,7 +54,7 @@
           "Count:3": 16,
           "Damage:2": 19,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     },

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBastnasiteMo-AAAAAAAAAAAAAAAAAAAGTA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBastnasiteMo-AAAAAAAAAAAAAAAAAAAGTA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 67,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -87,19 +87,19 @@
           "Count:3": 64,
           "Damage:2": 905,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 520,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 67,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBauxite-AAAAAAAAAAAAAAAAAAAD8w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindBauxite-AAAAAAAAAAAAAAAAAAAD8w==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 822,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -87,19 +87,19 @@
           "Count:3": 32,
           "Damage:2": 822,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 48,
           "Damage:2": 918,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 19,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindIlmenite-AAAAAAAAAAAAAAAAAAAFkA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/FindIlmenite-AAAAAAAAAAAAAAAAAAAFkA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 28,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -87,25 +87,25 @@
           "Count:3": 32,
           "Damage:2": 918,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 825,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 842,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 925,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/ForgetSomething-AAAAAAAAAAAAAAAAAAAJjw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier3HV-AAAAAAAAAAAAAAAAAAAABQ==/ForgetSomething-AAAAAAAAAAAAAAAAAAAJjw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 1812,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -74,25 +74,25 @@
           "Count:3": 32,
           "Damage:2": 1836,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 1948,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 32,
           "Damage:2": 1812,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 1911,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/CriticalMaterial-AAAAAAAAAAAAAAAAAAAHYw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/CriticalMaterial-AAAAAAAAAAAAAAAAAAAHYw==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 4841,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -81,19 +81,19 @@
           "Count:3": 64,
           "Damage:2": 4884,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 32,
           "Damage:2": 4910,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 4841,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/HypochlorousAcid-AAAAAAAAAAAAAAAAAAADWw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/HypochlorousAcid-AAAAAAAAAAAAAAAAAAADWw==.json
@@ -41,7 +41,7 @@
           "Count:3": 16,
           "Damage:2": 826,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/OtherOres-AAAAAAAAAAAAAAAAAAAE3A==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/OtherOres-AAAAAAAAAAAAAAAAAAAE3A==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 393,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -85,37 +85,37 @@
           "Count:3": 16,
           "Damage:2": 58,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 16,
           "Damage:2": 39,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "2:10": {
           "Count:3": 16,
           "Damage:2": 90,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "3:10": {
           "Count:3": 16,
           "Damage:2": 812,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "4:10": {
           "Count:3": 16,
           "Damage:2": 6,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "5:10": {
           "Count:3": 16,
           "Damage:2": 393,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PureUraniumOres-AAAAAAAAAAAAAAAAAAAFhw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/PureUraniumOres-AAAAAAAAAAAAAAAAAAAFhw==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 98,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -85,13 +85,13 @@
           "Count:3": 64,
           "Damage:2": 922,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 48,
           "Damage:2": 98,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/ReactorFuels-AAAAAAAAAAAAAAAAAAAE2w==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/ReactorFuels-AAAAAAAAAAAAAAAAAAAE2w==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 4873,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -85,13 +85,13 @@
           "Count:3": 64,
           "Damage:2": 4873,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 48,
           "Damage:2": 4922,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"
@@ -108,13 +108,13 @@
           "Count:3": 64,
           "Damage:2": 873,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         },
         "1:10": {
           "Count:3": 48,
           "Damage:2": 922,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/CallistoTrip-AAAAAAAAAAAAAAAAAAAF_Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/CallistoTrip-AAAAAAAAAAAAAAAAAAAF_Q==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 389,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -87,7 +87,7 @@
           "Count:3": 64,
           "Damage:2": 389,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/CeresTrip-AAAAAAAAAAAAAAAAAAAGAg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/CeresTrip-AAAAAAAAAAAAAAAAAAAGAg==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 828,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/EuropaTrip-AAAAAAAAAAAAAAAAAAAF_g==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/EuropaTrip-AAAAAAAAAAAAAAAAAAAF_g==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 390,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,
@@ -87,7 +87,7 @@
           "Count:3": 64,
           "Damage:2": 390,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/IoTrip-AAAAAAAAAAAAAAAAAAAKig==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/IoTrip-AAAAAAAAAAAAAAAAAAAKig==.json
@@ -14,7 +14,7 @@
         "Count:3": 16,
         "Damage:2": 607,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isMain:1": 1,
       "isSilent:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/MercuryTrip-AAAAAAAAAAAAAAAAAAAGtA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/MercuryTrip-AAAAAAAAAAAAAAAAAAAGtA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 84,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/VenusTrip-AAAAAAAAAAAAAAAAAAAGtQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier5IV-AAAAAAAAAAAAAAAAAAAABw==/VenusTrip-AAAAAAAAAAAAAAAAAAAGtQ==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 391,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isGlobal:1": 0,
       "isMain:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/WorkingwithOil-AAAAAAAAAAAAAAAAAAAADw==/MoreOilOptions-AAAAAAAAAAAAAAAAAAALuA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/WorkingwithOil-AAAAAAAAAAAAAAAAAAAADw==/MoreOilOptions-AAAAAAAAAAAAAAAAAAALuA==.json
@@ -14,7 +14,7 @@
         "Count:3": 1,
         "Damage:2": 878,
         "OreDict:8": "",
-        "id:8": "gregtech:gt.blockores"
+        "id:8": "gregtech:gt.blockores2"
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -42,7 +42,7 @@
           "Count:3": 32,
           "Damage:2": 878,
           "OreDict:8": "",
-          "id:8": "gregtech:gt.blockores"
+          "id:8": "gregtech:gt.blockores2"
         }
       }
     }


### PR DESCRIPTION
A few config updates for the ore refactor PR. I had to change the main ore block from `gt.blockores` to `gt.blockores2`, so I had to update all of these.

loosely depends on: https://github.com/GTNewHorizons/GT5-Unofficial/pull/3662 (doesn't have a hard dependency/need a specific tag order, but they do need to be put in the same release)