### PR TITLE
Change "Kill Demon" requirement

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/KillAlltheThings-AAAAAAAAAAAAAAAAAAAAJQ==/KillDemon-AAAAAAAAAAAAAAAAAAABlA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/KillAlltheThings-AAAAAAAAAAAAAAAAAAAAJQ==/KillDemon-AAAAAAAAAAAAAAAAAAABlA==.json
@@ -2,7 +2,7 @@
   "preRequisites:9": {
     "0:10": {
       "questIDHigh:4": 0,
-      "questIDLow:4": 345
+      "questIDLow:4": 1571
     }
   },
   "properties:10": {


### PR DESCRIPTION
Currently, the "Kill Demon" task requires you to complete the "Seeping Shoes" quest. I'm not sure if this is some sort of lore requirement, but i really don't see the point. The requirement is now "Distillery", the same as most other Witchery killing task.