### PR TITLE
Change the IC2 config ignoreWrenchRequirement to true

### DIFF
--- a/config/IC2.ini
+++ b/config/IC2.ini
@@ -54,7 +54,7 @@ recyclerBlacklist = minecraft:glass_pane, minecraft:stick, minecraft:snowball, m
 ; The format is the same as the blacklist.
 recyclerWhitelist = 
 ; Allow to pick blocks up using just a pickaxe instead of needing a wrench.
-ignoreWrenchRequirement = false
+ignoreWrenchRequirement = true
 
 ; Base energy generation factors - increase for higher energy yield.
 [balance / energy / generator]


### PR DESCRIPTION
Just by changing a config the problems from IC2 in form of dropping teleporter (and other shenanigans) can be almost completely fixed. The only unaffected blocks are Reactor Chambers (drop as Basic Casings) and Charge Pads (they all drop as basic version in form of BatBox), at least from the batches i tested.
Just getting the PR in here to give as an option to fix some IC2 annoyances before proper Mixins are made (if any will be made). If there are some other reasons why it wasn't done before that i don't know of, then it's fine to ignore this.
Confirmed on the latest Beta 2 that the option works and no more teleporters drop when breaking with pickaxe/vajra. Kinda important since there are still 5 machines that can be crafted and used to "make" teleporters.