### PR TITLE
Remove `tile.blockPortalNothing.name` from the lang overrides to allow Salis Arcana's definition to exist.

### DIFF
--- a/config/txloader/forceload/____gtnhoverridenames/lang/en_US.lang
+++ b/config/txloader/forceload/____gtnhoverridenames/lang/en_US.lang
@@ -577,7 +577,6 @@ tile.blockJar.name=Jar
 tile.blockMagicalLeaves.name=Leaves
 tile.blockMagicalLog.name=Log
 tile.blockMetalDevice.name=Metal Device
-tile.blockPortalNothing.name=Portal
 tile.blockStoneDevice.name=Stone Device
 tile.blockTable.name=Table
 tile.blockTaint.name=Taint


### PR DESCRIPTION
Salis Arcana defines `tile.blockPortalNothing.name` as "Portal to Nothing" (which is also the name FTBWiki uses for the block.) Therefore, this line is no longer necessary.