### PR TITLE
Increase Big Backpack slots by 1

### DIFF
--- a/config/Backpack.cfg
+++ b/config/Backpack.cfg
@@ -12,19 +12,19 @@ general {
     B:allowSoulbound=true
 
     # ##############
-    # Number of slots a backpack has
+    # Number of slots a large backpack has
     # valid: integers 1-128
     # ##############
-    I:backpackSlotsL=90
+    I:backpackSlotsL=91
 
     # ##############
-    # Number of slots a backpack has
+    # Number of slots a medium backpack has
     # valid: integers 1-128
     # ##############
     I:backpackSlotsM=63
 
     # ##############
-    # Number of slots a backpack has
+    # Number of slots a small backpack has
     # valid: integers 1-128
     # ##############
     I:backpackSlotsS=36


### PR DESCRIPTION
This is a followup for https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/15.

The changes introduced with https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/14 made the Big Backpack inventory fit better with auto gui scale. Previously, or backpack sizes were multiples of 9 in accordance with the standard Minecraft inventory slot layout. However, with the new layout, the Big Backpacks in GTNH are now missing a slot in the last row.

This adds one slot to the Big Backpack to fill out the layout. This is very much just an aesthetic change, but I don't see any downsides with it.

This will not affect existing backpacks.

Before:
<img width="1280" height="720" alt="2025-08-29_19 34 09" src="https://github.com/user-attachments/assets/90b70af6-8715-4db4-a01c-0930eca569a5" />

After:
<img width="854" height="480" alt="2025-08-30_09 47 35" src="https://github.com/user-attachments/assets/6dc7b717-d244-4cec-abd8-c86fdf65d5c3" />
