### PR TITLE
tempFix(StorageDrawers): return to fast rendering of items

### DIFF
--- a/config/StorageDrawers.cfg
+++ b/config/StorageDrawers.cfg
@@ -89,7 +89,7 @@ general {
 
     # Inverts how shift works with drawers. If this is true, shifting will only give one item, where regular clicks will give a full stack. Leave false for default behavior.
     B:invertShift=false
-    S:itemRenderType=fancy
+    S:itemRenderType=fast
     B:renderStorageUpgrades=true
     S:wailaStackRemainder=stack + remainder
 }


### PR DESCRIPTION
This is a temporary workaround for #20901

Until the fancy rendering can be improved for Gregtech blocks and heads, which use an unusual non-standard orientation; fast rendering restores visibility of Gregtech cables which are invisible in current fancy rendering.