### PR TITLE
Enable Concrete in EFR configs

### DIFF
--- a/config/etfuturum/blocksitems.cfg
+++ b/config/etfuturum/blocksitems.cfg
@@ -255,7 +255,7 @@ equipment {
     B:enableChain=true
 
     #  [default: true]
-    B:enableConcrete=false
+    B:enableConcrete=true
 
     # Copper sub-blocks and items. Disable copper but keep this on if you want the new copper items and blocks made of it, without the main ingot, ore or copper block itself. [default: true]
     B:enableCopperSubItems=true


### PR DESCRIPTION
Enables EFR concrete in the configs to provide more blocks for decoration. Currently there's no way to craft the EFR concrete blocks, and so this PR should be approved along with https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1359, which gives them chisel crafting recipes.