### PR TITLE
Add collapsible NEI groups for Et Futurum Requiem

### DIFF
--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -511,6 +511,7 @@ railcraft:lantern
 etfuturum:banner
 etfuturum:concrete_powder
 etfuturum:concrete
+r/etfuturum:.*_glazed_terracotta/
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -526,6 +526,16 @@ etfuturum:shulker_box tag.Type=5
 etfuturum:shulker_box tag.Type=6
 etfuturum:shulker_box tag.Type=7
 etfuturum:shulker_box
+etfuturum:copper_block 0-3
+etfuturum:copper_block 4-7
+etfuturum:copper_block 8-11
+etfuturum:copper_block 12-15
+etfuturum:chiseled_copper 0-3
+etfuturum:chiseled_copper 4-7
+etfuturum:copper_grate 0-3
+etfuturum:copper_grate 4-7
+etfuturum:copper_bulb 0-3
+etfuturum:copper_bulb 8-11
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -513,6 +513,7 @@ etfuturum:concrete_powder
 etfuturum:concrete
 etfuturum:lingering_potion
 r/etfuturum:.*glazed_terracotta/
+r/etfuturum:light$/
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -514,6 +514,14 @@ etfuturum:concrete
 etfuturum:lingering_potion
 r/etfuturum:.*glazed_terracotta/
 r/etfuturum:light$/
+r/etfuturum:shulker_box$/ tag.Type=1
+r/etfuturum:shulker_box$/ tag.Type=2
+r/etfuturum:shulker_box$/ tag.Type=3
+r/etfuturum:shulker_box$/ tag.Type=4
+r/etfuturum:shulker_box$/ tag.Type=5
+r/etfuturum:shulker_box$/ tag.Type=6
+r/etfuturum:shulker_box$/ tag.Type=7
+r/etfuturum:shulker_box$/
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -492,7 +492,7 @@ malisisdoors:curtain_
 gt.metaitem.02 25008-27000 | thaumcraft:primalArrow | gt.metaitem.01 32225-32258 | battlegear2:mb.arrow
 gt.metaitem.01 32200-32208
 #flower / plant
-minecraft:tallgrass | r/minecraft:.*_flower/ | minecraft:deadbush | minecraft:vine | minecraft:waterlily | minecraft:double_plant | biomesoplenty:plants | biomesoplenty:flower | biomesoplenty:willow !stairs | biomesoplenty:ivy | biomesoplenty:treeMoss | biomesoplenty:wisteria | :lilyBop | biomesoplenty:foliage | botany:itemflower | botany: plant | amunra:tile.basePlant | mars:tile.cavernvines | galaxyspace: dandelion | hardcoreender crossed_decoration | TFPlant | witchery:plantmine | witchery: bramble | harvestcraft:pam crop | harvestthenether: crop | taintFibres | etfuturum:cornflower | etfuturum:lily_of_the_valley | etfuturum:wither_rose | etfuturum:pink_petals | etfuturum:glow_lichen | r/etfuturum:cave_vine/
+minecraft:tallgrass | r/minecraft:.*_flower/ | minecraft:deadbush | minecraft:vine | minecraft:waterlily | minecraft:double_plant | biomesoplenty:plants | biomesoplenty:flower | biomesoplenty:willow !stairs | biomesoplenty:ivy | biomesoplenty:treeMoss | biomesoplenty:wisteria | :lilyBop | biomesoplenty:foliage | botany:itemflower | botany: plant | amunra:tile.basePlant | mars:tile.cavernvines | galaxyspace: dandelion | hardcoreender crossed_decoration | TFPlant | witchery:plantmine | witchery: bramble | harvestcraft:pam crop | harvestthenether: crop | taintFibres | etfuturum:rose | etfuturum:cornflower | etfuturum:lily_of_the_valley | etfuturum:wither_rose | etfuturum:pink_petals | etfuturum:glow_lichen | r/etfuturum:cave_vine/
 #thaumichorizons
 thaumichorizons:crystalTH
 thaumichorizons:cloudGlowingTH

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -694,7 +694,7 @@ ztones:tile.ztylBlock
 extratrees:gate | minecraft:fence_gate | natura:fencegate | r/malisisdoors:.*fencegate/ | r/witchery:.*fencegate/
 extratrees:fence | minecraft:fence | natura.fence | witchery:icefence | forestry:fences | extratrees:multifence | minecraft:nether_brick_fence | hardcoreenderexpansionraveged_brick_fence | ic2:blockfenceiron | r/railcraft:post.metal$/ | r/railcraft:post$/ 0-2
 botany:soil !soilmeter | r/botany:flower\w/ | botany:loam | botania: altGrass | r/biomesoplenty:.*grass/ | biomesoplenty:newBopDirt | biomesoplenty:newBopFarmland | hardcoreenderexpansion:end_stone_terrain
-natura:button | r/minecraft:.*_button/ | natura:netherbutton
+natura:button | r/minecraft:.*_button/ | natura:netherbutton | r/etfuturum:.*button/
 extratrees:carpentry
 extratrees:stainedglass
 miscutils:itemcustommetacover

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -753,15 +753,15 @@ gregtech:gt.comb | extrabees:honeycomb | gendustry:honeycomb | miscutils:gtpp.co
 forbiddenmagic:mobcrystal
 $plankWood !$plateWood | botania:shimmerwoodPlanks | botania:dreamwood :2 | botania:livingwood :2 | bloodarsenal:blood_infused_planks
 #shovel + list of mod names
-shovel minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,botania,DraconicEvolution,extrautilities,forbiddenmagic,galacticraft,ic2,natura,galaxyspace,projectred,railcraft,thaumcraft,tconstruct,tinkerer,twilightforest,harvestthenether,thaumicbases | spade galacticraft,ic2,appliedenergistics2 | forestry: bronzeShovel | gt.metatool.01 4
+shovel minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,botania,DraconicEvolution,extrautilities,forbiddenmagic,galacticraft,ic2,natura,galaxyspace,projectred,railcraft,thaumcraft,tconstruct,tinkerer,twilightforest,harvestthenether,thaumicbases | spade galacticraft,ic2,appliedenergistics2,etfuturum | forestry: bronzeShovel | gt.metatool.01 4
 #hoe + list of mod names
-hoe minecraft,biomesoplenty,DraconicEvolution,EMT:,galacticraft,extrautilities,galaxyspace,ic2,projectred,taintedmagic,thaumcraft,appliedenergistics2,harvestthenether,thaumicbases,railcraft,twilightforest !ic2:fluid | gt.metatool.01 8
+hoe minecraft,biomesoplenty,DraconicEvolution,EMT:,galacticraft,extrautilities,galaxyspace,ic2,projectred,taintedmagic,thaumcraft,appliedenergistics2,harvestthenether,thaumicbases,railcraft,twilightforest,etfuturum !ic2:fluid | gt.metatool.01 8
 #pickaxe + list of mod names
-pickaxe minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,DraconicEvolution,EnderIO,extrautilities,forbiddenmagic,galaxyspace,hardcoreenderexpansion,ic2,natura,projectred,railcraft,tconstruct,appliedenergistics2,harvestthenether,thaumicbases,witchery | pick botania,galacticraft,taintedmagic,thaumcraft,twilightforest,tinkerer | gt.metatool.01 2 | forestry:bronzePickaxe
+pickaxe minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,DraconicEvolution,EnderIO,extrautilities,forbiddenmagic,galaxyspace,hardcoreenderexpansion,ic2,natura,projectred,railcraft,tconstruct,appliedenergistics2,harvestthenether,thaumicbases,witchery,etfuturum | pick botania,galacticraft,taintedmagic,thaumcraft,twilightforest,tinkerer | gt.metatool.01 2 | forestry:bronzePickaxe
 #axe + list of mod names
-axe minecraft,awwayoftime,biomesoplenty,bloodarsenal,botania,DraconicEvolution,EnderIO,extrautilities,forbiddenmagic,galacticraft,galaxyspace,ic2,natura,railcraft,taintedmagic,thaumcraft,tinkerer,twilightforest,appliedenergistics2,harvestthenether,thaumicbases,avaritia,projectred | gt.metatool.01 6
+axe minecraft,awwayoftime,biomesoplenty,bloodarsenal,botania,DraconicEvolution,EnderIO,extrautilities,forbiddenmagic,galacticraft,galaxyspace,ic2,natura,railcraft,taintedmagic,thaumcraft,tinkerer,twilightforest,appliedenergistics2,harvestthenether,thaumicbases,avaritia,projectred,etfuturum | gt.metatool.01 6
 #sword + list of mod names
-sword minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,botania,DraconicEvolution,EnderIO,extrautilities,galacticraft,galaxyspace,ic2,natura,projectred,railcraft,randomthings,tconstruct,taintedmagic,thaumcraft,tinkerer,twilightforest,witchinggadgets,appliedenergistics2,harvestthenether,thaumicbases,witchery,forbiddenmagic | gt.metatool.01 0
+sword minecraft,awwayoftime,avaritia,biomesoplenty,bloodarsenal,botania,DraconicEvolution,EnderIO,extrautilities,galacticraft,galaxyspace,ic2,natura,projectred,railcraft,randomthings,tconstruct,taintedmagic,thaumcraft,tinkerer,twilightforest,witchinggadgets,appliedenergistics2,harvestthenether,thaumicbases,witchery,forbiddenmagic,etfuturum | gt.metatool.01 0
 #Clay Cast
 tconstruct:blankPattern 3 | tconstruct:clayPattern | r/^tconstruct:clay\scast$/
 #Wood Cast

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -786,6 +786,8 @@ dreamcraft:item.mold !moldForm | dreamcraft:item.marshmallowForm | :gt.ggfab.d1 
 :gt.metaitem.01 32300,32350-32377 | dreamcraft:item.ExtruderShapeBoat | miscutils:MU-metaitem.01 32040
 #pattern
 tconstruct:metalPattern | r/tconstruct:cast$/ | tconstruct:gearcast | tgregworks.shardcast
+#Beds
+r/minecraft:bed$/ | r/etfuturum:.*_bed$/ | CarpentersBlocks:itemCarpentersBed | harvestthenether:netherbedItem
 #Vanilla-like Signs
 sign minecraft,etfuturum
 #Boats

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -485,7 +485,7 @@ transport:pipelens 0-16
 transport:pipelens 16-31
 #doors
 malisisdoors:door_ !malisisdoors:door_factory | malisisdoors:wood_sliding_door | r/malisisdoors:item.*door/ | malisisdoors:iron_sliding_door | malisisdoors:jail_door | malisisdoors:laboratory_door | malisisdoors:factory_door | malisisdoors:shoji_door | witchery:ingredient 52-53
-extratrees:door | r/minecraft:.*_door/ | carpentersdoor | TwilightForest:item.door | r/natura:.*doorItem/ | ic2:itemdooralloy | galacticraftamunra:item.baseitem 25
+extratrees:door | r/minecraft:.*_door/ | carpentersdoor | TwilightForest:item.door | r/natura:.*doorItem/ | ic2:itemdooralloy | galacticraftamunra:item.baseitem 25 | r/etfuturum:.*copper_door/
 malisisdoors:item.curtain
 malisisdoors:curtain_
 #arrows

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -511,7 +511,7 @@ railcraft:lantern
 etfuturum:banner
 etfuturum:concrete_powder
 etfuturum:concrete
-r/etfuturum:.*_glazed_terracotta/
+r/etfuturum:.*glazed_terracotta/
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -776,6 +776,8 @@ dreamcraft:item.mold !moldForm | dreamcraft:item.marshmallowForm | :gt.ggfab.d1 
 :gt.metaitem.01 32300,32350-32377 | dreamcraft:item.ExtruderShapeBoat | miscutils:MU-metaitem.01 32040
 #pattern
 tconstruct:metalPattern | r/tconstruct:cast$/ | tconstruct:gearcast | tgregworks.shardcast
+#Vanilla-like Signs
+sign minecraft,etfuturum
 #Boats
 r/etfuturum:.*_chest_boat$/ | etfuturum:bamboo_chest_raft
 minecraft:boat | r/etfuturum:.*_boat$/ | etfuturum:bamboo_raft | IC2:itemBoat 0,1,3 | ThaumicHorizons:boat | adventurebackpack:backpackComponent 7,8

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -492,7 +492,7 @@ malisisdoors:curtain_
 gt.metaitem.02 25008-27000 | thaumcraft:primalArrow | gt.metaitem.01 32225-32258 | battlegear2:mb.arrow
 gt.metaitem.01 32200-32208
 #flower / plant
-minecraft:tallgrass | r/minecraft:.*_flower/ | minecraft:deadbush | minecraft:vine | minecraft:waterlily | minecraft:double_plant | biomesoplenty:plants | biomesoplenty:flower | biomesoplenty:willow !stairs | biomesoplenty:ivy | biomesoplenty:treeMoss | biomesoplenty:wisteria | :lilyBop | biomesoplenty:foliage | botany:itemflower | botany: plant | amunra:tile.basePlant | mars:tile.cavernvines | galaxyspace: dandelion | hardcoreender crossed_decoration | TFPlant | witchery:plantmine | witchery: bramble | harvestcraft:pam crop | harvestthenether: crop | taintFibres
+minecraft:tallgrass | r/minecraft:.*_flower/ | minecraft:deadbush | minecraft:vine | minecraft:waterlily | minecraft:double_plant | biomesoplenty:plants | biomesoplenty:flower | biomesoplenty:willow !stairs | biomesoplenty:ivy | biomesoplenty:treeMoss | biomesoplenty:wisteria | :lilyBop | biomesoplenty:foliage | botany:itemflower | botany: plant | amunra:tile.basePlant | mars:tile.cavernvines | galaxyspace: dandelion | hardcoreender crossed_decoration | TFPlant | witchery:plantmine | witchery: bramble | harvestcraft:pam crop | harvestthenether: crop | taintFibres | etfuturum:cornflower | etfuturum:lily_of_the_valley | etfuturum:wither_rose | etfuturum:pink_petals | etfuturum:glow_lichen | r/etfuturum:cave_vine/
 #thaumichorizons
 thaumichorizons:crystalTH
 thaumichorizons:cloudGlowingTH

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -708,7 +708,7 @@ botania:altar
 randomthings:spectreBlock
 botania:stone $stonegranite
 :honeydrop | magicbees:drop | gregtech:gt.drop | miscutils:gtpp.drop
-railcraft:wall | r/minecraft:.*_wall/ | botania:biomeStoneA0Wall | projectred.exploration.stonewalls | r/botania:.*Wall$/ | galacticraftcore:tile.wallGC
+railcraft:wall | r/minecraft:.*_wall/ | botania:biomeStoneA0Wall | projectred.exploration.stonewalls | r/botania:.*Wall$/ | galacticraftcore:tile.wallGC | r/etfuturum:.*_wall$/
 ic2:blockwall
 $logwood
 witchery:stockade

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -507,6 +507,8 @@ natura: bag
 railcraft:post.metal.platform | r/railcraft:post$/ 4-6
 railcraft:glass
 railcraft:lantern
+#IronChest
+r/IronChest:.*Upgrade$/
 #etfuturum
 etfuturum:banner
 etfuturum:concrete_powder
@@ -514,14 +516,16 @@ etfuturum:concrete
 etfuturum:lingering_potion
 r/etfuturum:.*glazed_terracotta/
 r/etfuturum:light$/
-r/etfuturum:shulker_box$/ tag.Type=1
-r/etfuturum:shulker_box$/ tag.Type=2
-r/etfuturum:shulker_box$/ tag.Type=3
-r/etfuturum:shulker_box$/ tag.Type=4
-r/etfuturum:shulker_box$/ tag.Type=5
-r/etfuturum:shulker_box$/ tag.Type=6
-r/etfuturum:shulker_box$/ tag.Type=7
-r/etfuturum:shulker_box$/
+etfuturum:barrel_upgrade
+etfuturum:shulker_box_upgrade
+etfuturum:shulker_box tag.Type=1
+etfuturum:shulker_box tag.Type=2
+etfuturum:shulker_box tag.Type=3
+etfuturum:shulker_box tag.Type=4
+etfuturum:shulker_box tag.Type=5
+etfuturum:shulker_box tag.Type=6
+etfuturum:shulker_box tag.Type=7
+etfuturum:shulker_box
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -507,6 +507,9 @@ natura: bag
 railcraft:post.metal.platform | r/railcraft:post$/ 4-6
 railcraft:glass
 railcraft:lantern
+#etfuturum
+etfuturum:concrete_powder
+etfuturum:concrete
 #chisel
 chisel:aluminumblock
 chisel:aluminum_stairs

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -489,7 +489,7 @@ extratrees:door | r/minecraft:.*_door/ | carpentersdoor | TwilightForest:item.do
 malisisdoors:item.curtain
 malisisdoors:curtain_
 #arrows
-gt.metaitem.02 25008-27000 | thaumcraft:primalArrow | gt.metaitem.01 32225-32258 | battlegear2:mb.arrow
+arrow minecraft,etfuturum,battlegear2 | gt.metaitem.02 25008-27000 | thaumcraft:primalArrow | gt.metaitem.01 32225-32258
 gt.metaitem.01 32200-32208
 #flower / plant
 minecraft:tallgrass | r/minecraft:.*_flower/ | minecraft:deadbush | minecraft:vine | minecraft:waterlily | minecraft:double_plant | biomesoplenty:plants | biomesoplenty:flower | biomesoplenty:willow !stairs | biomesoplenty:ivy | biomesoplenty:treeMoss | biomesoplenty:wisteria | :lilyBop | biomesoplenty:foliage | botany:itemflower | botany: plant | amunra:tile.basePlant | mars:tile.cavernvines | galaxyspace: dandelion | hardcoreender crossed_decoration | TFPlant | witchery:plantmine | witchery: bramble | harvestcraft:pam crop | harvestthenether: crop | taintFibres | etfuturum:rose | etfuturum:cornflower | etfuturum:lily_of_the_valley | etfuturum:wither_rose | etfuturum:pink_petals | etfuturum:glow_lichen | r/etfuturum:cave_vine/

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -24,7 +24,7 @@ minecraft:spawn_egg | EnderZoo:SpawnEggEnderZoo | EnderZoo:itemSpawnEggEnderZoo 
 # mob spawner
 minecraft:mob_spawner | DraconicEvolution:customSpawner | EnderIO:itemBrokenSpawner | HardcoreEnderExpansion:custom_spawner | TwilightForest:tile.TFBossSpawner
 # music disk
-minecraft:record_ | hardcoreenderexpansion:music_disk | biomesoplenty:record_ | botania:record
+minecraft:record_ | hardcoreenderexpansion:music_disk | biomesoplenty:record_ | botania:record | r/etfuturum:.*_record$/
 #minecraft dye
 minecraft:dye
 #splash potion

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -776,6 +776,9 @@ dreamcraft:item.mold !moldForm | dreamcraft:item.marshmallowForm | :gt.ggfab.d1 
 :gt.metaitem.01 32300,32350-32377 | dreamcraft:item.ExtruderShapeBoat | miscutils:MU-metaitem.01 32040
 #pattern
 tconstruct:metalPattern | r/tconstruct:cast$/ | tconstruct:gearcast | tgregworks.shardcast
+#Boats
+r/etfuturum:.*_chest_boat$/ | etfuturum:bamboo_chest_raft
+minecraft:boat | r/etfuturum:.*_boat$/ | etfuturum:bamboo_raft | IC2:itemBoat 0,1,3 | ThaumicHorizons:boat | adventurebackpack:backpackComponent 7,8
 
 # migrated from INpureProjects
 tinkersdefense:heater shield

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -511,6 +511,7 @@ railcraft:lantern
 etfuturum:banner
 etfuturum:concrete_powder
 etfuturum:concrete
+etfuturum:lingering_potion
 r/etfuturum:.*glazed_terracotta/
 #chisel
 chisel:aluminumblock

--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -508,6 +508,7 @@ railcraft:post.metal.platform | r/railcraft:post$/ 4-6
 railcraft:glass
 railcraft:lantern
 #etfuturum
+etfuturum:banner
 etfuturum:concrete_powder
 etfuturum:concrete
 #chisel


### PR DESCRIPTION
Creates groups (or adds to existing groups, when possible) for EFR.

This PR also includes three changes unrelated to EFR:
- `minecraft:arrow` is now part of the (non-tinkers) arrow group
- Grouped Iron Chest upgrades together (to be consistent with the Barrel and Shulker groups)
- Created a group for boats. Which includes, besides MC and EFR, boats from IC2, Adventure Backpack and Thaumic Horizons

EFR items in NEI:
<img width="981" height="607" alt="image" src="https://github.com/user-attachments/assets/f7a053a8-6d2f-4876-8059-d9edab9e67b2" />