### PR TITLE
Make the rarer themed rougelike dungeons more common by replacing the default dungeon in certain biomes.

### DIFF
--- a/config/roguelike_dungeons/settings/dungeon_mesa.json
+++ b/config/roguelike_dungeons/settings/dungeon_mesa.json
@@ -1,6 +1,6 @@
 {
 	"name": "dungeon_mesa",
-  	"criteria": {"biomeTypes": ["MESA"]},
+  	"criteria": {"biomeTypes": ["MESA", "OCEAN"]},
   	"inherit": [
 		"loot_all",
 		"loot_hot_food",

--- a/config/roguelike_dungeons/settings/dungeon_mountain.json
+++ b/config/roguelike_dungeons/settings/dungeon_mountain.json
@@ -1,6 +1,6 @@
 {
 	"name": "dungeon_mountain",
-  	"criteria": {"biomeTypes": ["MOUNTAIN"]},
+  	"criteria": {"biomeTypes": ["MOUNTAIN", "HILLS"]},
   	"inherit": [
 		"loot_all",
 		"loot_mountain",

--- a/config/roguelike_dungeons/settings/dungeon_swamp.json
+++ b/config/roguelike_dungeons/settings/dungeon_swamp.json
@@ -1,6 +1,6 @@
 {
 	"name": "dungeon_swamp",
-  	"criteria": {"biomeTypes": ["SWAMP"]},
+  	"criteria": {"biomeTypes": ["SWAMP", "RIVER"]},
   	"inherit": [
 		"loot_all",
 		"loot_swamp",


### PR DESCRIPTION
Currently, if a biome type isn't specified in the roguelike dungeon config, a default dungeon spawns in. Some biomes make more sense to have one of the themed dungeons spawn instead of the default dungeon.

Changes:
Wizard Tower:
Wizard tower can now spawn in hills instead of just biomes defined as mountain biomes. This maintains the theme of the dungeon spawning in elevated areas

Mesa Dungeon: There are no mesa biomes in the current worldgen, all the mesa-like biomes are defined as deserts, meaning this dungeon currently is bugged and does not spawn. Mesa is added to the Ocean biome biomes, which contains the Bayou and Shield biomes that look nothing like an ocean, and fits the mesa dungeon well.

Swamp dungeon:
The swamp dungeon was added to the river biome list, which fits the wet theme of the dungeon.

<img width="323" height="253" alt="image" src="https://github.com/user-attachments/assets/79bce89c-a967-4968-8970-c69b131bfe8f" />
