### PR TITLE
Use manualSlotSelection and slotTypeOverrides in Baubles.cfg

### DIFF
--- a/config/Baubles.cfg
+++ b/config/Baubles.cfg
@@ -1,0 +1,76 @@
+# Configuration file
+
+debug {
+    # Hides the Bauble debug item from the creative menu.
+    #  [default: true]
+    B:hideDebugItem=true
+}
+
+
+general {
+    # IDs of enchantments that should be treated as soul bound when on items in a bauble slot.
+    I:soulBoundEnchantments <
+     >
+}
+
+
+menu {
+    # Manually override slot assignments.
+    # !Bauble slot types must be configured manually with this option enabled!
+    #  [default: false]
+    B:manualSlotSelection=true
+
+    # Display unused Bauble slots.
+    #  [default: false]
+    B:showUnusedSlots=false
+}
+
+
+override {
+    # Baubles and its addons assigned the folowing types to the bauble slots.
+    # !This config option automatically changes to reflect what Baubles and its addons assigned each time the game is launched! [default: ]
+    S:defualtSlotTypes <
+        amulet
+        ring
+        ring
+        belt
+        Terminal
+        quiver
+        charm_pouch
+        wings
+        focus_pouch
+        cape
+        gauntlet
+        charm
+        title
+        unknown
+        unknown
+        unknown
+        unknown
+        unknown
+        unknown
+        unknown
+     >
+
+    # Slot assignments to use if manualSlotSelection is enabled.
+    # Any assignents after the first 20 will be ignored.
+    # !Adding, moving, or removing slots of the amulet, ring, or belt types will reduce compatibility with mods made for original Baubles versions!
+    #  [default: [amulet], [ring], [ring], [belt]]
+    S:slotTypeOverrides <
+        amulet
+        ring
+        ring
+        belt
+        Terminal
+        quiver
+        charm_pouch
+        wings
+        focus_pouch
+        cape
+        gauntlet
+        charm
+        title
+     >
+}
+
+


### PR DESCRIPTION
This will prevent slots from changing order when new slots are added, which led to items being in the wrong slot for their type.
This change will also require new slots to be added manually in this config, but that's simple enough.