### PR TITLE
fix: disable new anvils from EFR

### DIFF
--- a/config/etfuturum/blocksitems.cfg
+++ b/config/etfuturum/blocksitems.cfg
@@ -153,7 +153,7 @@ equipment {
     B:enableLoom=true
 
     # Enables new anvil behavior, such as less expensive item renaming [default: true]
-    B:enableNewAnvil=true
+    B:enableNewAnvil=false
 
     # Beacon beam can be colored using stained glass [default: true]
     B:enableNewBeacon=true


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21271

Following the discussion on Discord: https://discord.com/channels/181078474394566657/401118216228831252/1418190294410723389

I think we should disable the new anvils from EFR due to known and potentially more uncovered issues.
It might be a good idea to check other block replacements from EFR too, especially ones that are used in multiblocks for example.