### PR TITLE
Disable shulker spawns in end

### DIFF
--- a/config/etfuturum/tweaks.cfg
+++ b/config/etfuturum/tweaks.cfg
@@ -42,7 +42,7 @@
 
     # For compatibility reasons, you may want the Shulker to spawn anywhere in the End in random groups like Endermen. These are uncommon.
     # Shulkers spawned in this way will despawn naturally, unless seated, given armor through a dispenser, or name tagged. Right now Shulkers are otherwise inacessible. [default: false]
-    B:shulkersSpawnAnywhere=true
+    B:shulkersSpawnAnywhere=false
 
     # If spawn anywhere is enabled, spawn Shulkers matching the color of modded biome blocks. Currently supports Enderlicious and Hardcore Ender Expansion terrain blocks. [default: true]
     B:spawnAnywhereShulkerColors=true


### PR DESCRIPTION
Thaumcraft's dimension for whatever reason has the end tag in one of its biomes which is causing shulkers to spawn 1/3rd of the time due to the weights thaumcraft is using.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21325