### PR TITLE
Fix EV 64A Hatches quest

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/StoringandTransf-AAAAAAAAAAAAAAAAAAAAIQ==/EV64AHatches-M_HRDMb8Q2GnvpgfgsRnRw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/StoringandTransf-AAAAAAAAAAAAAAAAAAAAIQ==/EV64AHatches-M_HRDMb8Q2GnvpgfgsRnRw==.json
@@ -66,7 +66,7 @@
       "requiredItems:9": {
         "0:10": {
           "Count:3": 1,
-          "Damage:2": 15229,
+          "Damage:2": 15129,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockmachines"
         }


### PR DESCRIPTION
Instead of "Energy OR Dynamo" it was just "Dynamo OR Dynamo"
@HFPTetraUro