### PR TITLE
Add Java 25 to issue templates and drop non-LTS versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/000-report-crash.yml
+++ b/.github/ISSUE_TEMPLATE/000-report-crash.yml
@@ -38,12 +38,10 @@ body:
     description: What Java version are you using? It's worth mentioning that if you play on Java9+ you should try update to latest minor release (e.g. prefer Java 17.0.6 over 17.0.2) of that version.
     options:
     - Java 8
-    - Java 9
-    - Java 11
     - Java 17
-    - Java 19
-    - Java 20
     - Java 21
+    - Java 24
+    - Java 25
     - Other versions in between
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/001-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/001-report-bug.yml
@@ -38,12 +38,10 @@ body:
     description: What Java version are you using? It's worth mentioning that if you play on Java9+ you should try update to latest minor release (e.g. prefer Java 17.0.6 over 17.0.2) of that version.
     options:
     - Java 8
-    - Java 9
-    - Java 11
     - Java 17
-    - Java 19
-    - Java 20
     - Java 21
+    - Java 24
+    - Java 25
     - Other versions in between
   validations:
     required: true


### PR DESCRIPTION
We are officially enabling java 25 with 2.8, so add that to our issue templates. If not the lastest supported java, people should stay on LTS releases. Keep java 24 around as last non-LTS release as people might not have updated yet.