### PR TITLE
Change Big Backpacks to 90 slots again

### DIFF
--- a/config/Backpack.cfg
+++ b/config/Backpack.cfg
@@ -15,7 +15,7 @@ general {
     # Number of slots a large backpack has
     # valid: integers 1-128
     # ##############
-    I:backpackSlotsL=91
+    I:backpackSlotsL=90
 
     # ##############
     # Number of slots a medium backpack has

--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -24,9 +24,9 @@
 	<ToolTip ItemName="StevesCarts:CartModule:61" ToolTip="§dPerpetual Locomotion" NBT=""/>
 
 //Bags
-	<ToolTip ItemName="Backpack:backpack" ToolTip="4*9 Inventory - 36 Slots" NBT="" MetaStart="0" MetaEnd="16"/>
-	<ToolTip ItemName="Backpack:backpack" ToolTip="7*9 Inventory - 63 Slots" NBT="" MetaStart="100" MetaEnd="116"/>
-	<ToolTip ItemName="Backpack:backpack" ToolTip="10*9 Inventory - 90 Slots" NBT="" MetaStart="200" MetaEnd="216"/>
+	<ToolTip ItemName="Backpack:backpack" ToolTip="36 Slots" NBT="" MetaStart="0" MetaEnd="16"/>
+	<ToolTip ItemName="Backpack:backpack" ToolTip="63 Slots" NBT="" MetaStart="100" MetaEnd="116"/>
+	<ToolTip ItemName="Backpack:backpack" ToolTip="90 Slots" NBT="" MetaStart="200" MetaEnd="216"/>
 	<ToolTip ItemName="Backpack:backpack:17" ToolTip="Crafting Backpack with 9 Inventory Slots" NBT=""/>
 	<ToolTip ItemName="Backpack:backpack:217" ToolTip="Crafting Backpack with 18 Inventory Slots" NBT=""/>
 	<ToolTip ItemName="Backpack:backpack:31999" ToolTip="§4Disabled Item; No recipe" NBT=""/>

--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -26,7 +26,7 @@
 //Bags
 	<ToolTip ItemName="Backpack:backpack" ToolTip="4*9 Inventory - 36 Slots" NBT="" MetaStart="0" MetaEnd="16"/>
 	<ToolTip ItemName="Backpack:backpack" ToolTip="7*9 Inventory - 63 Slots" NBT="" MetaStart="100" MetaEnd="116"/>
-	<ToolTip ItemName="Backpack:backpack" ToolTip="10*9 Inventory - 91 Slots" NBT="" MetaStart="200" MetaEnd="216"/>
+	<ToolTip ItemName="Backpack:backpack" ToolTip="10*9 Inventory - 90 Slots" NBT="" MetaStart="200" MetaEnd="216"/>
 	<ToolTip ItemName="Backpack:backpack:17" ToolTip="Crafting Backpack with 9 Inventory Slots" NBT=""/>
 	<ToolTip ItemName="Backpack:backpack:217" ToolTip="Crafting Backpack with 18 Inventory Slots" NBT=""/>
 	<ToolTip ItemName="Backpack:backpack:31999" ToolTip="§4Disabled Item; No recipe" NBT=""/>


### PR DESCRIPTION
There are some changes ([1](https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/19), [2](https://github.com/GTNewHorizons/Minecraft-Backpack-Mod/pull/17)) in the pipeline to improve the inventory layout with the original 90 slots, so go back to that for now. That means, the last slot in the grid will be empty with the current algorithm, but that's acceptable.