### PR TITLE
Hide Various Unused Items from NEI

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -36,3 +36,78 @@ r/^Genetics:serumArray$/ !tag.genes.0.allele=forestry.speciesForest
 GraviSuite:itemPlasmaCell
 TConstruct:fluid.molten.
 tectech:item.em.debugContainer
+
+# IC2 Dusts
+IC2:itemDust  0 # Bronze
+IC2:itemDust  1 # Clay
+IC2:itemDust  2 # Coal
+IC2:itemDust  3 # Copper
+IC2:itemDust  4 # Gold
+IC2:itemDust  5 # Iron
+IC2:itemDust  6 # Silver
+IC2:itemDust  7 # Tin
+IC2:itemDust  9 # Stone
+IC2:itemDust 10 # Lead
+IC2:itemDust 11 # Obsidian
+IC2:itemDust 12 # Lapis Lazuli
+IC2:itemDust 13 # Sulfur
+IC2:itemDust 14 # Lithium
+
+# IC2 Dusts (2)
+IC2:itemDust2 0 # Silicon Dioxide
+IC2:itemDust2 1 # Diamond
+IC2:itemDust2 3 # Ashes
+
+# IC2 Plates
+IC2:itemPlates 0 # Copper
+IC2:itemPlates 1 # Tin
+IC2:itemPlates 2 # Bronze
+IC2:itemPlates 3 # Gold
+IC2:itemPlates 4 # Iron
+IC2:itemPlates 5 # Steel
+IC2:itemPlates 6 # Lead
+IC2:itemPlates 7 # Obsidian
+IC2:itemPlates 8 # Lapis Lazuli
+
+# IC2 Dense Plates
+IC2:itemDensePlates 0 # Copper
+IC2:itemDensePlates 1 # Tin
+IC2:itemDensePlates 2 # Bronze
+IC2:itemDensePlates 3 # Gold
+IC2:itemDensePlates 4 # Iron
+IC2:itemDensePlates 5 # Steel
+IC2:itemDensePlates 6 # Lead
+IC2:itemDensePlates 8 # Lapis Lazuli
+
+# IC2 Ingots
+IC2:itemIngot 0 # Copper
+IC2:itemIngot 1 # Tin
+IC2:itemIngot 2 # Bronze
+IC2:itemIngot 3 # Refined Iron
+IC2:itemIngot 5 # Lead
+IC2:itemIngot 6 # Silver
+
+# Project Red Ingots
+ProjRed|Core:projectred.core.part 10 # Red Alloy
+ProjRed|Core:projectred.core.part 52 # Copper
+ProjRed|Core:projectred.core.part 53 # Tin
+ProjRed|Core:projectred.core.part 54 # Silver
+
+# Tinker's Construct Ingots
+TConstruct:materials  9 # Copper
+TConstruct:materials 10 # Tin
+TConstruct:materials 11 # Aluminum
+TConstruct:materials 16 # Steel
+
+# EnderIO Powders
+EnderIO:itemPowderIngot 0 # Coal
+EnderIO:itemPowderIngot 1 # Iron
+EnderIO:itemPowderIngot 2 # Gold
+EnderIO:itemPowderIngot 3 # Copper
+EnderIO:itemPowderIngot 4 # Tin
+EnderIO:itemPowderIngot 7 # Obsidian
+EnderIO:itemPowderIngot 8 # Flour
+
+# Amun-Ra Ingots
+GalacticraftAmunRa:item.baseItem 10 # Lead
+GalacticraftAmunRa:item.baseItem 12 # Steel


### PR DESCRIPTION
This PR hides the following unused items from NEI to reduce clutter:

- IC2
  - Dusts
  - Special Dusts
  - Plates
  - Dense Plates
  - Ingots
- Project Red
  - Ingots
- Tinker's Construct
  - Ingots
- EnderIO
  - Powders
- Amun-Ra
  - Ingots

Requires [Support Inline Comments After `#` #734](https://github.com/GTNewHorizons/NotEnoughItems/pull/734) to be merged.