### PR TITLE
Hide Unused IC2 Item Casings

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -90,6 +90,15 @@ IC2:itemIngot 3 # Refined Iron
 IC2:itemIngot 5 # Lead
 IC2:itemIngot 6 # Silver
 
+# IC2 Item Casings
+IC2:itemCasing 0 # Copper
+IC2:itemCasing 1 # Tin
+IC2:itemCasing 2 # Bronze
+IC2:itemCasing 3 # Gold
+IC2:itemCasing 4 # Iron
+IC2:itemCasing 5 # Steel
+IC2:itemCasing 6 # Lead
+
 # Project Red Ingots
 ProjRed|Core:projectred.core.part 10 # Red Alloy
 ProjRed|Core:projectred.core.part 52 # Copper


### PR DESCRIPTION
Follow-up to [Hide Various Unused Items from NEI #21487](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/21487).