### PR TITLE
Update GT Client.cfg, up line thickness from 2.5 to 5

### DIFF
--- a/config/GregTech/Client.cfg
+++ b/config/GregTech/Client.cfg
@@ -17,30 +17,13 @@ client {
         ##########################################################################################################
 
         cableinsulation {
-            #  [range: -2147483648 ~ 2147483647, default: 64]
+            #  [range: 0 ~ 255, default: 64]
             I:blue=64
 
-            #  [range: -2147483648 ~ 2147483647, default: 64]
+            #  [range: 0 ~ 255, default: 64]
             I:green=64
 
-            #  [range: -2147483648 ~ 2147483647, default: 64]
-            I:red=64
-        }
-
-        ##########################################################################################################
-        # constructionfoam
-        #--------------------------------------------------------------------------------------------------------#
-        # RGB values for the construction foam color modulation.
-        ##########################################################################################################
-
-        constructionfoam {
-            #  [range: -2147483648 ~ 2147483647, default: 64]
-            I:blue=64
-
-            #  [range: -2147483648 ~ 2147483647, default: 64]
-            I:green=64
-
-            #  [range: -2147483648 ~ 2147483647, default: 64]
+            #  [range: 0 ~ 255, default: 64]
             I:red=64
         }
 
@@ -51,13 +34,13 @@ client {
         ##########################################################################################################
 
         machinemetal {
-            #  [range: -2147483648 ~ 2147483647, default: 255]
+            #  [range: 0 ~ 255, default: 255]
             I:blue=255
 
-            #  [range: -2147483648 ~ 2147483647, default: 220]
+            #  [range: 0 ~ 255, default: 220]
             I:green=220
 
-            #  [range: -2147483648 ~ 2147483647, default: 210]
+            #  [range: 0 ~ 255, default: 210]
             I:red=210
         }
 
@@ -102,6 +85,9 @@ client {
         # if true, input filter will initially be on when input buses are placed in the world. [default: false]
         B:inputBusInitialFilter=false
 
+        # if true, input filter will initially be on when input hatches are placed in the world. [default: false]
+        B:inputHatchInitialFilter=false
+
         # If true, scrolling up while hovering a ghost circuit in a machine UI will increment the circuit number. [default: false]
         B:invertCircuitScrollDirection=false
 
@@ -125,6 +111,15 @@ client {
     ##########################################################################################################
 
     render {
+        # When >0, powerfail notifications will stop rendering after this many seconds. [range: -2147483648 ~ 2147483647, default: 0]
+        I:"Powerfail Notification Timeout"=0
+
+        # Render lines to MagLev Pylons when tethering [default: true]
+        B:"Render MagLev Tethers"=true
+
+        #  [default: true]
+        B:"Render Powerfail Notifications"=true
+
         # Disables coil lighting. Requires world reload (f3 + a or relog). [default: false]
         B:"Use Old Coil Textures"=false
 
@@ -151,6 +146,9 @@ client {
 
         # if true, enables ambient-occlusion smooth lighting on tiles. [default: true]
         B:renderTileAmbientOcclusion=true
+
+        # Enables or disables Trans Metal rendering, also impacts motors, pistons etc with same rendering. Accessibility option. [default: true]
+        B:renderTransMetalFancy=true
 
         # enables BaseMetaTileEntity block updates handled by BlockUpdateHandler. [default: false]
         B:useBlockUpdateHandler=false
@@ -242,6 +240,43 @@ client {
             S:ticPartExtruding=ENABLE
         }
 
+    }
+
+    ##########################################################################################################
+    # blockoverlay
+    #--------------------------------------------------------------------------------------------------------#
+    # GT Tool Block Overlay section
+    ##########################################################################################################
+
+    blockoverlay {
+        # The alpha for the color of the block overlay [range: 0 ~ 255, default: 127]
+        I:alpha=127
+
+        # The blue color of the block overlay [range: 0 ~ 255, default: 0]
+        I:blue=0
+
+        # The green color of the block overlay [range: 0 ~ 255, default: 0]
+        I:green=0
+
+        # The line width of the block overlay [range: 0.0 ~ 30.0, default: 2.5]
+        S:lineWidth=5
+
+        # The red color of the block overlay [range: 0 ~ 255, default: 0]
+        I:red=0
+    }
+
+    ##########################################################################################################
+    # chat
+    #--------------------------------------------------------------------------------------------------------#
+    # Chat message section
+    ##########################################################################################################
+
+    chat {
+        # Prints the powerfail command help text when receiving a powerfail. The message is only printed once per game session. [default: true]
+        B:"Print Powerfail Help Text"=true
+
+        # Displays a chat message when a powerfail occurs. [default: true]
+        B:"Print Powerfail Notifications"=true
     }
 
 }


### PR DESCRIPTION
Noticed that the current repo's version of the file was fairly outdated.

Changes listed come from a clean 2.8.0 client instance, minus one adjustment (changing line thickness for the wrench/tool overlay from 2.5 to 5 for better visibility).