### PR TITLE
A few earlygame quest improvements

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SOTIREDMUSTSLEEP-AAAAAAAAAAAAAAAAAAAADQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/SOTIREDMUSTSLEEP-AAAAAAAAAAAAAAAAAAAADQ==.json
@@ -18,7 +18,7 @@
         "Count:3": 1,
         "Damage:2": 0,
         "OreDict:8": "",
-        "id:8": "minecraft:bed"
+        "id:8": "etfuturum:white_bed"
       },
       "isGlobal:1": 0,
       "isMain:1": 1,
@@ -91,7 +91,7 @@
           "Count:3": 1,
           "Damage:2": 0,
           "OreDict:8": "bedWood",
-          "id:8": "minecraft:bed"
+          "id:8": "etfuturum:white_bed"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WhatYouSow-AAAAAAAAAAAAAAAAAAAABw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/AndSoItBegins-AAAAAAAAAAAAAAAAAAAAAA==/WhatYouSow-AAAAAAAAAAAAAAAAAAAABw==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "If you, by chance, did read the previous quest and planted the carrots, then you\u0027re fine.\n\nMeanwhile, you should turn some more fruits and vegetables into seeds, and increase the size of your farm to get a steady supply of food.",
+      "desc:8": "If, by chance, you did read the previous quest and planted the carrots, then you\u0027re fine.\n\nMeanwhile, you should turn some more fruits and vegetables into seeds, and increase the size of your farm to get a steady supply of food.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MonsterHunter-AAAAAAAAAAAAAAAAAAAACw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultipleQuestLine/MonsterHunter-AAAAAAAAAAAAAAAAAAAACw==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "It\u0027s about time to craft something more useful: A sword!\n\nNow that you have a sword, you will get credit for monster kills in the Kill All the Things tab. Watch out, monsters in this world will chew you up and spit you out!\n\nYou can find additional weapon quests on the Getting Around tab.",
+      "desc:8": "It\u0027s about time to craft something more useful: A sword!\n\nNow that you have a sword, you will get credit for monster kills in the Kill All the Things tab. Watch out, monsters in this world will chew you up and spit you out!\n\nYou can find additional weapon quests on the ...Without Dying tab.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/OptionsForFindin-AAAAAAAAAAAAAAAAAAAHSg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/OptionsForFindin-AAAAAAAAAAAAAAAAAAAHSg==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "It can be hard to find Zinc Gravel Ore on old servers or unlucky world seeds.\n\nThe alternatives are:\n- Buy the zinc gravel in the Coins Coins coins tab,\n- Searching for small zinc ore in the overworld,\n- A recipe with XP buckets on a crafting table.\n\nOnce you reach LV, you can get zinc from processing various ores like antimony, sphalerite, tetrahedrite and tin.\nCheck NEI for more options.",
+      "desc:8": "It can be hard to find Zinc Gravel Ore on old servers or unlucky world seeds.\n\nThe alternatives are:\n- Buy the Zinc Gravel Ore in the Coins, Coins, Coins tab,\n- Search for Small Zinc Ore in the overworld,\n- Use the recipe with XP buckets in a crafting table.\n\nOnce you reach LV, you can get zinc from processing various ores like antimony, sphalerite, tetrahedrite and tin.\nCheck NEI for more options.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -20,7 +20,7 @@
       "isMain:1": 1,
       "isSilent:1": 0,
       "lockedProgress:1": 0,
-      "name:8": "§2§lOptions For Finding Zinc in This Tier",
+      "name:8": "§2§lOptions For Finding Zinc",
       "partySingleReward:1": 0,
       "questLogic:8": "AND",
       "repeatTime:3": -1,

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RareOres-AAAAAAAAAAAAAAAAAAAGCg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/RareOres-AAAAAAAAAAAAAAAAAAAGCg==.json
@@ -57,7 +57,7 @@
         },
         "3:10": {
           "Count:3": 1,
-          "Damage:2": 824,
+          "Damage:2": 57,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockores"
         }

--- a/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/ZincGravel-AAAAAAAAAAAAAAAAAAAAIg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier0StoneAge-AAAAAAAAAAAAAAAAAAAAAQ==/ZincGravel-AAAAAAAAAAAAAAAAAAAAIg==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "You can find it in chunks of gravel on the surface.\n\nUse as little as possible and save the rest for when you get a macerator in Steam age, you\u0027ll get twice as much.\n\nIf you can\u0027t find any, you can buy them in the Coins tab.\n\nIf you get enough and fully process it, you can also get gallium for gallium arsenide in LV age.",
+      "desc:8": "You can find it in chunks of gravel on the surface.\n\nUse as little as possible and save the rest for when you get a macerator in Steam age, you\u0027ll get twice as much.\n\nIf you can\u0027t find any, you can buy them in the Coins tab.\n\nIf you get enough and fully process it, you can also get Gallium for Gallium Arsenide in LV age.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,


### PR DESCRIPTION
- fixes the wood sword quest referencing the wrong tab
- changes the bed icons in the bed quest to the white one to be less confusing for new players. (but any color works and this is pointed out already)
- changes a new reward in stone age from cass ore to tin ore to not trivialize Mica. (was discussed and agreed with dream)
- some language and capitalization improvements
- removed 'in this tier' from the zinc quest title as that was really a thing about alu having multiple such quests, not zinc.