### PR TITLE
Update etfuturum config to keep parity of original 1.7.10 vanilla and modded items, blocks, and assets, but keep modern additions.

### DIFF
--- a/config/etfuturum/functions.cfg
+++ b/config/etfuturum/functions.cfg
@@ -65,13 +65,13 @@ changes {
 
 client {
     # Bows render pulling animation in inventory [default: true]
-    B:enableBowRendering=true
+    B:enableBowRendering=false
 
     # Enables NBT tag count and item namespace label on F3 + H debug item labels [default: true]
     B:enableExtraF3HTooltips=false
 
     # Skulls render 3D in inventory [default: true]
-    B:enableFancySkulls=true
+    B:enableFancySkulls=false
 
     # Enable the /fill command. [default: true]
     B:enableFillCommand=false
@@ -80,13 +80,13 @@ client {
     B:enableGamemodeSwitcher=true
 
     # Replaces some lang keys with a more modern version, such as calling some old wood items "oak", calling beds "Red Bed", and so on. Full list of replaced keys can be seen in the mod jar at resources/resourcepacks/vanilla_overrides/assets/minecraft/lang [default: true]
-    B:enableLangReplacements=true
+    B:enableLangReplacements=false
 
     # Make F3 only show/hide info on release, and not if another key is pressed [default: true]
     B:enableNewF3Behavior=true
 
     # Replace tall grass and sponge textures with modern version [default: true]
-    B:enableNewTextures=true
+    B:enableNewTextures=false
 
     # Allows use of 1.8 skin format, and Alex skins. Also includes some fixes from SkinPort. (Per SkinPort author's permission) Disable if skin is displaying oddly. Not compatible with OptiFine, use FastCraft instead. [default: false]
     B:enablePlayerSkinOverlay=false
@@ -98,7 +98,7 @@ client {
     B:enableTransparentAmour=true
 
     # Render beds with a 3D inventory model instead of a 2D sprite. [default: true]
-    B:inventoryBedModels=true
+    B:inventoryBedModels=false
 
     # The maximum amount of items a Shulker box can display on its tooltip. When the box has more stacks inside than this number, the rest of the stacks are displayed as "And x more...". Set to 0 to disable Shulker Box tooltips. [range: 0 ~ 127, default: 5]
     I:shulkerBoxTooltipLines=5

--- a/config/etfuturum/mixins.cfg
+++ b/config/etfuturum/mixins.cfg
@@ -26,7 +26,7 @@
 
     # Makes beds bouncy. Should work with most modded beds. For continuity disabling this also disables EFR beds being bouncy.
     # Modified Classes: net.minecraft.block.BlockBed [default: true]
-    B:bouncyBeds=true
+    B:bouncyBeds=false
 
     # In 1.14+, when breaking a block, the block break particles stay within the outline, instead of always occupying the whole block space.
     # Mofified Client Classes: net.minecraft.client.particle.EffectRenderer [default: true]
@@ -107,22 +107,22 @@
 
     # New sounds for throwing an eye of ender, and for them breaking or dropping.
     # Modified Classes: net.minecraft.entity.item.EntityEnderEye net.minecraft.item.ItemEnderEye [default: true]
-    B:newEnderEyeSounds=true
+    B:newEnderEyeSounds=false
 
     # New sounds for casting and reeling in fishing rods.
     # Modified Classes: net.minecraft.item.ItemFishingRod [default: true]
-    B:newFishingRodSounds=true
+    B:newFishingRodSounds=false
 
     # Damage sounds for walking into a berry bush, drowning or burning
     # Modified Classes: net.minecraft.entity.player.EntityPlayer net.minecraft.client.entity.EntityClientPlayerMP [default: true]
-    B:newHurtSounds=true
+    B:newHurtSounds=false
 
     # New sounds for the witch, snow golem, squid and wither skeleton. [default: true]
-    B:newMobSounds=true
+    B:newMobSounds=false
 
     # Fires an event after a tree generates, mainly for beehives to accurately know where most trees are. For now this option is disabled if bees are disabled.
     # Modified Classes: net.minecraft.world.gen.feature.WorldGenAbstractTree [default: true]
-    B:postTreeGenEvent=true
+    B:postTreeGenEvent=false
 
     # Is not a new block, but rather a mixin for fire. Allows fire to stay ignited on soul soil. Does double damage when standing in it, and does not spread to other blocks.
     # Even if this is off fire can still stay ignited on soul soil, but do be mindful that fire will spread from soul soil if this option is disabled.

--- a/config/etfuturum/sounds.cfg
+++ b/config/etfuturum/sounds.cfg
@@ -8,13 +8,13 @@
 
 ambient {
     # Add new cave ambience, adding more eerie cave sounds that occasionally play underground or in dark areas. [default: true]
-    B:caveAmbience=true
+    B:caveAmbience=false
 
     # Play new ambience in the Nether. [default: true]
-    B:netherAmbience=true
+    B:netherAmbience=false
 
     # Replace rain sounds with new, calm ones introduced in 1.11+ [default: true]
-    B:rainSounds=true
+    B:rainSounds=false
 }
 
 
@@ -26,34 +26,34 @@ ambient {
 
 "blocks and items" {
     # New sounds for closing wooden chests, and new sounds for opening and closing ender chests. Works with Ender Storage. [default: true]
-    B:chestOpenClose=true
+    B:chestOpenClose=false
 
     # New sounds for opening and closing doors, only affects doors with the wood or metal material type. [default: true]
-    B:doorOpenClose=true
+    B:doorOpenClose=false
 
     # Sounds for filling an end portal with eyes of ender, plays a sound to the whole server when fully lit. [default: true]
-    B:endPortalFillSounds=true
+    B:endPortalFillSounds=false
 
     # Add placing sounds for blocks that don't play one for some reason such as doors or restone dust. [default: true]
-    B:fixSilentPlacing=true
+    B:fixSilentPlacing=false
 
     # Play a sound when filling or emptying a bucket/bottle. Plays sounds for filling/emptying cauldrons too but works on vanilla cauldrons only. [default: true]
-    B:fluidInteract=true
+    B:fluidInteract=false
 
     # Adds furnace crackling to lit furnace blocks. [default: true]
-    B:furnaceCrackling=true
+    B:furnaceCrackling=false
 
     # Many blocks after 1.14 introduce a new step sound, if this is turned off most backported blocks will use the most suitable step sound present in vanilla 1.7.10. [default: true]
-    B:newBlockSounds=true
+    B:newBlockSounds=false
 
     # The new instruments from 1.12 and 1.14 for note blocks. [default: true]
     B:noteBlockNotes=true
 
     # Lower-pitched clicking sounds for buttons and pressure plates. Stone buttons are unaffected. [default: true]
-    B:pressurePlateButton=true
+    B:pressurePlateButton=false
 
     # Planting seeds or nether wart onto farmland/soulsand. [default: true]
-    B:seedPlanting=true
+    B:seedPlanting=false
 }
 
 
@@ -65,10 +65,10 @@ ambient {
 
 entities {
     # Play a more intense splash when the player lands in water at high speeds. [default: true]
-    B:heavyWaterSplashing=true
+    B:heavyWaterSplashing=false
 
     # Sounds for horses eating food and cows being milked. [default: true]
-    B:horseEatCowMilk=true
+    B:horseEatCowMilk=false
 
     # New sounds for being hurt by the Thorns enchantment. [default: true]
     B:thornsSounds=true
@@ -84,7 +84,7 @@ entities {
 
 misc {
     # Changes the click in the book GUI to have a page turn sound instead of the menu click. [default: true]
-    B:bookPageTurn=true
+    B:bookPageTurn=false
 }
 
 
@@ -152,19 +152,19 @@ players {
      >
 
     # New sounds for using bone meal. [default: true]
-    B:bonemealing=true
+    B:bonemealing=false
 
     # Damage threshold for attacks to play the "strong" hit sound. 1 = half heart, 2 = full heart. 4 (default) = 2 hearts [range: 0.0 ~ 3.4028235E38, default: 4.0]
     S:combatSoundStrongThreshold=4.0
 
     # New sounds for player attacking. [default: true]
-    B:combatSounds=true
+    B:combatSounds=false
 
     # New sounds for placing, interacting with, and destroying item frames or paintings. [default: true]
-    B:leashSounds=true
+    B:leashSounds=false
 
     # New sounds for placing, interacting with, and destroying item frames or paintings. [default: true]
-    B:paintingItemFramePlacing=true
+    B:paintingItemFramePlacing=false
 }
 
 

--- a/config/etfuturum/sounds.cfg
+++ b/config/etfuturum/sounds.cfg
@@ -11,7 +11,7 @@ ambient {
     B:caveAmbience=false
 
     # Play new ambience in the Nether. [default: true]
-    B:netherAmbience=false
+    B:netherAmbience=true
 
     # Replace rain sounds with new, calm ones introduced in 1.11+ [default: true]
     B:rainSounds=false
@@ -32,16 +32,16 @@ ambient {
     B:doorOpenClose=false
 
     # Sounds for filling an end portal with eyes of ender, plays a sound to the whole server when fully lit. [default: true]
-    B:endPortalFillSounds=false
+    B:endPortalFillSounds=true
 
     # Add placing sounds for blocks that don't play one for some reason such as doors or restone dust. [default: true]
-    B:fixSilentPlacing=false
+    B:fixSilentPlacing=true
 
     # Play a sound when filling or emptying a bucket/bottle. Plays sounds for filling/emptying cauldrons too but works on vanilla cauldrons only. [default: true]
-    B:fluidInteract=false
+    B:fluidInteract=true
 
     # Adds furnace crackling to lit furnace blocks. [default: true]
-    B:furnaceCrackling=false
+    B:furnaceCrackling=true
 
     # Many blocks after 1.14 introduce a new step sound, if this is turned off most backported blocks will use the most suitable step sound present in vanilla 1.7.10. [default: true]
     B:newBlockSounds=false
@@ -53,7 +53,7 @@ ambient {
     B:pressurePlateButton=false
 
     # Planting seeds or nether wart onto farmland/soulsand. [default: true]
-    B:seedPlanting=false
+    B:seedPlanting=true
 }
 
 
@@ -68,7 +68,7 @@ entities {
     B:heavyWaterSplashing=false
 
     # Sounds for horses eating food and cows being milked. [default: true]
-    B:horseEatCowMilk=false
+    B:horseEatCowMilk=true
 
     # New sounds for being hurt by the Thorns enchantment. [default: true]
     B:thornsSounds=true
@@ -152,7 +152,7 @@ players {
      >
 
     # New sounds for using bone meal. [default: true]
-    B:bonemealing=false
+    B:bonemealing=true
 
     # Damage threshold for attacks to play the "strong" hit sound. 1 = half heart, 2 = full heart. 4 (default) = 2 hearts [range: 0.0 ~ 3.4028235E38, default: 4.0]
     S:combatSoundStrongThreshold=4.0
@@ -161,10 +161,10 @@ players {
     B:combatSounds=false
 
     # New sounds for placing, interacting with, and destroying item frames or paintings. [default: true]
-    B:leashSounds=false
+    B:leashSounds=true
 
     # New sounds for placing, interacting with, and destroying item frames or paintings. [default: true]
-    B:paintingItemFramePlacing=false
+    B:paintingItemFramePlacing=true
 }
 
 


### PR DESCRIPTION
Keep the general spirit of 1.7.10 sounds. The ones I can see of a good argument of keeping is end portal sounds so the whole server can hear, but this is not normally present on 1.7.10 and maybe nether ambience with the new blocks.