### PR TITLE
remove incorrect shift-clicking dissuasion

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/WhatsintheBox-AAAAAAAAAAAAAAAAAAAHhQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier4EV-AAAAAAAAAAAAAAAAAAAABg==/WhatsintheBox-AAAAAAAAAAAAAAAAAAAHhQ==.json
@@ -8,7 +8,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "Tired of waiting around for hours with radium in your inventory, waiting for it to decay? With a §5Lead-Lined Box§r you can safely leave your radium in it and it\u0027ll decay while you do real work.\n\n[note]You may not be able to shift-click items in and out, but pipes still work. You can not use a WA.[/note]\n\nAdditionally, you can also choose to use the §5Decay Warehouse§r for this task; it\u0027s more efficient but comes at a much higher cost. (More info in Multiblock Goals tab)",
+      "desc:8": "Tired of waiting around for hours with radium in your inventory, waiting for it to decay? With a §5Lead-Lined Box§r you can safely leave your radium in it and it\u0027ll decay while you do real work.\n\n[note]Pipes work with it, but you can not use a WA.[/note]\n\nAdditionally, you can also choose to use the §5Decay Warehouse§r for this task; it\u0027s more efficient but comes at a much higher cost. (More info in Multiblock Goals tab)",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,


### PR DESCRIPTION
the questbook tells the reader that they are unable to shift-click into the lead lined box, which I am assuming is from an older version where this wasn't possible