### PR TITLE
Removed test trade

### DIFF
--- a/config/vendingmachine/tradeDatabase.json
+++ b/config/vendingmachine/tradeDatabase.json
@@ -6451,43 +6451,6 @@
 			},
 			"label:8": "Oblivion Hive"
 		},
-		"119:10": {
-			"trades:9": {
-				"0:10": {
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:dirt",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:stone",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {},
-			"category:8": "misc",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5818400732674949356,
-				"tradeGroupIDHigh:4": 3365699171666512004
-			},
-			"label:8": "test"
-		},
 		"120:10": {
 			"trades:9": {
 				"0:10": {


### PR DESCRIPTION
Removed test trade from the trade database json.

This causes the "array" sequence to not be continuous anymore (119 is missing now), but does not cause issues on load.

Side Note: In its current implementation, if we add new trades and write to the file, it will shuffle the trade sequence and create a huge number of changed lines. This makes it annoying to review new changes. I'm making a change to sort by tradegroup ID during write operations, to minimize this pain.