### PR TITLE
Updated file storage format to remove sequence indices for NBTTagLists.

### DIFF
--- a/config/vendingmachine/tradeDatabase.json
+++ b/config/vendingmachine/tradeDatabase.json
@@ -1,9501 +1,9501 @@
 {
-	"tradeGroups:9": {
-		"0:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30724,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1084,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5107817319724605576,
-				"tradeGroupIDHigh:4": 198378206351213307
-			},
-			"label:8": "Lubricant"
-		},
-		"1:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1467,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6233360669011173034,
-				"tradeGroupIDHigh:4": -3053195979660571002
-			},
-			"label:8": "Silver 2x Cables"
-		},
-		"2:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:blockOreUran",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5098,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1415,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8969502125118346443,
-				"tradeGroupIDHigh:4": -1117975299186472804
-			},
-			"label:8": "Uranium Ore exchange"
-		},
-		"3:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 70
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30718,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1021,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7789957616853306556,
-				"tradeGroupIDHigh:4": -996007330482665153
-			},
-			"label:8": "Sodium Persulfate"
-		},
-		"4:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "blood",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "AWWayofTime:reinforcedSlate",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 422,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8080821362402546667,
-				"tradeGroupIDHigh:4": 4616430484883131944
-			},
-			"label:8": "T2 BM Slates"
-		},
-		"5:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30712,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4892984339196323849,
-				"tradeGroupIDHigh:4": -3258833425462573495
-			},
-			"label:8": "Creosote"
-		},
-		"6:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32039,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8211821702759576697,
-				"tradeGroupIDHigh:4": 8559080038165139144
-			},
-			"label:8": "RAM"
-		},
-		"7:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 65
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:coal_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 8538,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 64
-						},
-						"1:10": {
-							"Damage:2": 2538,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 29,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 300,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5903948547600641774,
-				"tradeGroupIDHigh:4": -9093615307106008532
-			},
-			"label:8": "Who Would Use This Garbage??"
-		},
-		"8:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:beeDroneGE",
-							"OreDict:8": "",
-							"Count:3": 1,
-							"tag:10": {
-								"MaxH:3": 40,
-								"IsAnalyzed:1": 1,
-								"Genome:10": {
-									"Chromosomes:9": {
-										"0:10": {
-											"Slot:1": 0,
-											"UID0:8": "forestry.speciesSteadfast",
-											"UID1:8": "forestry.speciesSteadfast"
-										},
-										"1:10": {
-											"Slot:1": 1,
-											"UID0:8": "forestry.speedSlower",
-											"UID1:8": "forestry.speedSlower"
-										},
-										"2:10": {
-											"Slot:1": 2,
-											"UID0:8": "forestry.lifespanNormal",
-											"UID1:8": "forestry.lifespanNormal"
-										},
-										"3:10": {
-											"Slot:1": 3,
-											"UID0:8": "forestry.fertilityNormal",
-											"UID1:8": "forestry.fertilityNormal"
-										},
-										"4:10": {
-											"Slot:1": 4,
-											"UID0:8": "forestry.toleranceNone",
-											"UID1:8": "forestry.toleranceNone"
-										},
-										"5:10": {
-											"Slot:1": 5,
-											"UID0:8": "forestry.boolTrue",
-											"UID1:8": "forestry.boolTrue"
-										},
-										"6:10": {
-											"Slot:1": 7,
-											"UID0:8": "forestry.toleranceNone",
-											"UID1:8": "forestry.toleranceNone"
-										},
-										"7:10": {
-											"Slot:1": 8,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"8:10": {
-											"Slot:1": 9,
-											"UID0:8": "forestry.boolTrue",
-											"UID1:8": "forestry.boolTrue"
-										},
-										"9:10": {
-											"Slot:1": 10,
-											"UID0:8": "forestry.flowersVanilla",
-											"UID1:8": "forestry.flowersVanilla"
-										},
-										"10:10": {
-											"Slot:1": 11,
-											"UID0:8": "forestry.floweringSlowest",
-											"UID1:8": "forestry.floweringSlowest"
-										},
-										"11:10": {
-											"Slot:1": 12,
-											"UID0:8": "forestry.territoryAverage",
-											"UID1:8": "forestry.territoryAverage"
-										},
-										"12:10": {
-											"Slot:1": 13,
-											"UID0:8": "forestry.effectNone",
-											"UID1:8": "forestry.effectNone"
-										}
-									}
-								},
-								"Health:3": 40
-							}
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:emerald_block",
-							"OreDict:8": "",
-							"Count:3": 4
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:royalJelly",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1121,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8479936493771858344,
-				"tradeGroupIDHigh:4": -8917382112598276013
-			},
-			"label:8": "Steadfast Bees"
-		},
-		"9:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "space",
-							"value:3": 500
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "HardcoreEnderExpansion:essence",
-							"OreDict:8": "",
-							"Count:3": 320
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "DraconicEvolution:dragonHeart",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1297,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 43200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4678340994427474139,
-				"tradeGroupIDHigh:4": -6162812482555919455
-			},
-			"label:8": "Dragon Essence II"
-		},
-		"10:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 823,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:stone",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 53,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6986344121459865824,
-				"tradeGroupIDHigh:4": 801808094838409848
-			},
-			"label:8": "Calcite Getting you Down?"
-		},
-		"11:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1366,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+	"tradeGroups:9": [
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 1148,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6388473470953204394,
-				"tradeGroupIDHigh:4": -6592119183814015930
-			},
-			"label:8": "Copper Cables"
-		},
-		"12:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 200
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 5142,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8446138834706361365,
-				"tradeGroupIDHigh:4": 5630385190759056755
-			},
-			"label:8": "Stainless Steel Fluid Pipes"
-		},
-		"13:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5126966555949172973,
-				"tradeGroupIDHigh:4": -3086623031657675904
-			},
-			"label:8": "Curious Hive"
-		},
-		"14:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23303,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7178890099584910232,
-				"tradeGroupIDHigh:4": -728621510259358270
-			},
-			"label:8": "Electrum Rods"
-		},
-		"15:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 15
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 62,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7888449537290138317,
-				"tradeGroupIDHigh:4": -2649851937429697283
-			},
-			"label:8": "Magma Cube"
-		},
-		"16:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 240
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23030,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6703713838163902610,
-				"tradeGroupIDHigh:4": -5209402801621613815
-			},
-			"label:8": "Chrome Rods"
-		},
-		"17:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 1000
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2056,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 2311,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6185601626992205159,
-				"tradeGroupIDHigh:4": 3922838451961088362
-			},
-			"label:8": "Indium Dust"
-		},
-		"18:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 120
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 21305,
-							"id:8": "gregtech:gt.metaitem.02",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8508372527171231671,
-				"tradeGroupIDHigh:4": 1587593817887491926
-			},
-			"label:8": "Steel rotors"
-		},
-		"19:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 1000
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 500
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 231,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:item.alphaFur",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:tile.AuroraPillar",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 72000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8523383816479699814,
-				"tradeGroupIDHigh:4": -1310138638007384625
-			},
-			"label:8": "Snow Queen"
-		},
-		"20:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32100,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7509059139663921801,
-				"tradeGroupIDHigh:4": 608035471216231384
-			},
-			"label:8": "Basic Circuit Boards"
-		},
-		"21:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:ender_pearl",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6451452568670596108,
-				"tradeGroupIDHigh:4": 5902713242381009205
-			},
-			"label:8": "Ender Pearl"
-		},
-		"22:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32106,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6401729731510317256,
-				"tradeGroupIDHigh:4": -2994175566713893553
-			},
-			"label:8": "Plastic Circuit Boards"
-		},
-		"23:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 36,
-							"id:8": "enhancedlootbags:lootbag",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 440,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8378731789285706905,
-				"tradeGroupIDHigh:4": 4992445561253610254
-			},
-			"label:8": "Garden Bags"
-		},
-		"24:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:wool",
-							"OreDict:8": "",
-							"Count:3": 20
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 11,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4688583532486906793,
-				"tradeGroupIDHigh:4": 1831286921561784817
-			},
-			"label:8": "Need Some Wool?"
-		},
-		"25:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 937,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"1:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 35,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"2:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 870,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"3:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 834,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"4:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 500,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"5:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 810,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"6:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 526,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"7:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 530,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"8:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 523,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"9:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 535,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"10:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 57,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"11:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 936,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"12:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 935,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"13:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						},
-						"1:10": {
-							"type:8": "smith",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 838,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1504,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 7200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7940483957138509434,
-				"tradeGroupIDHigh:4": -131575629021035508
-			},
-			"label:8": "Can't Find Those Ores?"
-		},
-		"26:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30740,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 549,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9120817654110373902,
-				"tradeGroupIDHigh:4": 6687784599856825625
-			},
-			"label:8": "Light Fuel"
-		},
-		"27:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "ExtraBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6343112004592918270,
-				"tradeGroupIDHigh:4": -8183924001269004581
-			},
-			"label:8": "Rocky Hive"
-		},
-		"28:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "HardcoreEnderExpansion:enderman_head",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 2350,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 36000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8765542160574366250,
-				"tradeGroupIDHigh:4": 8068168097533346427
-			},
-			"label:8": "Enderman Head"
-		},
-		"29:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 8,
-							"id:8": "TwilightForest:tile.TFFireJet",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:tile.TFFireJet",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6211893698514779770,
-				"tradeGroupIDHigh:4": 2324870461010953277
-			},
-			"label:8": "Fire is Cool"
-		},
-		"30:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:beeDroneGE",
-							"OreDict:8": "",
-							"Count:3": 1,
-							"tag:10": {
-								"MaxH:3": 50,
-								"IsAnalyzed:1": 1,
-								"Genome:10": {
-									"Chromosomes:9": {
-										"0:10": {
-											"Slot:1": 0,
-											"UID0:8": "forestry.speciesMonastic",
-											"UID1:8": "forestry.speciesMonastic"
-										},
-										"1:10": {
-											"Slot:1": 1,
-											"UID0:8": "forestry.speedSlower",
-											"UID1:8": "forestry.speedSlower"
-										},
-										"2:10": {
-											"Slot:1": 2,
-											"UID0:8": "forestry.lifespanLong",
-											"UID1:8": "forestry.lifespanLong"
-										},
-										"3:10": {
-											"Slot:1": 3,
-											"UID0:8": "forestry.fertilityLow",
-											"UID1:8": "forestry.fertilityLow"
-										},
-										"4:10": {
-											"Slot:1": 4,
-											"UID0:8": "forestry.toleranceBoth1",
-											"UID1:8": "forestry.toleranceBoth1"
-										},
-										"5:10": {
-											"Slot:1": 5,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"6:10": {
-											"Slot:1": 7,
-											"UID0:8": "forestry.toleranceBoth1",
-											"UID1:8": "forestry.toleranceBoth1"
-										},
-										"7:10": {
-											"Slot:1": 8,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"8:10": {
-											"Slot:1": 9,
-											"UID0:8": "forestry.boolTrue",
-											"UID1:8": "forestry.boolTrue"
-										},
-										"9:10": {
-											"Slot:1": 10,
-											"UID0:8": "forestry.flowersWheat",
-											"UID1:8": "forestry.flowersWheat"
-										},
-										"10:10": {
-											"Slot:1": 11,
-											"UID0:8": "forestry.floweringFaster",
-											"UID1:8": "forestry.floweringFaster"
-										},
-										"11:10": {
-											"Slot:1": 12,
-											"UID0:8": "forestry.territoryAverage",
-											"UID1:8": "forestry.territoryAverage"
-										},
-										"12:10": {
-											"Slot:1": 13,
-											"UID0:8": "forestry.effectNone",
-											"UID1:8": "forestry.effectNone"
-										}
-									}
-								},
-								"Health:3": 50
-							}
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:emerald_block",
-							"OreDict:8": "",
-							"Count:3": 4
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:royalJelly",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1121,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6988983965900979722,
-				"tradeGroupIDHigh:4": 8750149870227900566
-			},
-			"label:8": "Monastic Bees"
-		},
-		"31:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2006,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9154976941603920863,
-				"tradeGroupIDHigh:4": -8031269670881050036
-			},
-			"label:8": "Red Alloy Cables"
-		},
-		"32:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:pammapleSapling",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 440,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6001886707592869699,
-				"tradeGroupIDHigh:4": -1161695127140415544
-			},
-			"label:8": "Maple Syrup?"
-		},
-		"33:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 200
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32182,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": -8693302957682373366,
-						"questIDHigh:4": -2567739677140758553
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 213,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8449791893976220856,
-				"tradeGroupIDHigh:4": 4275762369475792571
-			},
-			"label:8": "More SMD Inductors"
-		},
-		"34:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:frameImpregnated",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 507,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7514908793536764410,
-				"tradeGroupIDHigh:4": -7586385544549939517
-			},
-			"label:8": "Impregnated Frames"
-		},
-		"35:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30715,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 644,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6493983714776546357,
-				"tradeGroupIDHigh:4": 2767363482272514
-			},
-			"label:8": "Methane"
-		},
-		"36:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 3,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 76,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 21600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8617917877298316615,
-				"tradeGroupIDHigh:4": 5730324588730272059
-			},
-			"label:8": "Tin Berries"
-		},
-		"37:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "ExtraBees:hiveFrame.cocoa",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 507,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 43200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7862643245927830587,
-				"tradeGroupIDHigh:4": 1638503203244623249
-			},
-			"label:8": "Chocolate is Bad For You..."
-		},
-		"38:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2879,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 50
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 945,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7989253404725874083,
-				"tradeGroupIDHigh:4": -8382468326480066229
-			},
-			"label:8": "Tired of Grinding Reeds?"
-		},
-		"39:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 500
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2817,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 0,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8474466748179230466,
-				"tradeGroupIDHigh:4": -7651212176927670027
-			},
-			"label:8": "Salt for Your Salty Mouth"
-		},
-		"40:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "space",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "HardcoreEnderExpansion:essence",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:dragon_egg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 400,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 43200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7609014856225906144,
-				"tradeGroupIDHigh:4": -6831519265120301352
-			},
-			"label:8": "Dragon Essence"
-		},
-		"41:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 50
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 182,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:tile.TFNagastoneBody",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 36000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5576427176385441338,
-				"tradeGroupIDHigh:4": -1359955860059700412
-			},
-			"label:8": "Naga"
-		},
-		"42:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1341,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8752857805792840610,
-				"tradeGroupIDHigh:4": -1394589871759275576
-			},
-			"label:8": "Cupronickel 2x Wires"
-		},
-		"43:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 5,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 986,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6069872065390352622,
-				"tradeGroupIDHigh:4": -6749605871916531503
-			},
-			"label:8": "Ender Hive"
-		},
-		"44:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 6,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7898843875360998813,
-				"tradeGroupIDHigh:4": -1002121497548404556
-			},
-			"label:8": "Wintry Hive"
-		},
-		"45:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "cook",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "ExtraUtilities:defoliageAxe",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:delightedmealItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:heartybreakfastItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"2:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:rainbowcurryItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"3:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:supremepizzaItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"4:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:sausageinbreadItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"5:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:beefwellingtonItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"6:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:epicbaconItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"7:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:meatfeastpizzaItem",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 600,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 604800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8535848914293245286,
-				"tradeGroupIDHigh:4": 8249722080323585335
-			},
-			"label:8": "Healing Axe 2.0"
-		},
-		"46:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "darkWizard",
-							"value:3": 500
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Thaumcraft:ItemBathSalts",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1097,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 18000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8814568880806125484,
-				"tradeGroupIDHigh:4": -6895050813467177405
-			},
-			"label:8": "Bath Salt"
-		},
-		"47:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 3,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5877888774416027119,
-				"tradeGroupIDHigh:4": -3070428155345613988
-			},
-			"label:8": "Modest Hive"
-		},
-		"48:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 150
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11306,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
+			],
 			"category:8": "raw",
 			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8299580794907626861,
-				"tradeGroupIDHigh:4": -8605554061585461795
-			},
-			"label:8": "Stainless Steel Ingots"
-		},
-		"49:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 100
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 205,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "TwilightForest:item.trophy",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 6,
-							"id:8": "TwilightForest:tile.TFMazestone",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 48000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5199563096401156684,
-				"tradeGroupIDHigh:4": -2064889456646600207
-			},
-			"label:8": "Minoshroom"
-		},
-		"50:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:string",
-							"OreDict:8": "",
-							"Count:3": 30
-						},
-						"1:10": {
-							"Damage:3": 3,
-							"id:8": "Natura:barleyFood",
-							"OreDict:8": "",
-							"Count:3": 24
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 486,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6913100934010137265,
-				"tradeGroupIDHigh:4": -1849725078230381883
-			},
-			"label:8": "Cotton and String"
-		},
-		"51:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 31,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 103,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7831601698323567118,
-				"tradeGroupIDHigh:4": -7369202228715827960
-			},
-			"label:8": "Manganese Ore"
-		},
-		"52:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "holoinventory:Hologlasses",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 11305,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 65,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 12000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5103329954409932760,
-				"tradeGroupIDHigh:4": -4119083381545414768
-			},
-			"label:8": "Holo Glasses"
-		},
-		"53:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 200
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 224,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:item.trophy",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:tile.TFUnderBrick",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 60000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8710579738301169189,
-				"tradeGroupIDHigh:4": -4054227815665547780
-			},
-			"label:8": "Knight Phantom"
-		},
-		"54:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32101,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5974164531640371128,
-				"tradeGroupIDHigh:4": 6630841127279479696
-			},
-			"label:8": "Good Circuit Boards"
-		},
-		"55:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11305,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
 			"id:10": {
 				"tradeGroupIDLow:4": -8321622777038284087,
 				"tradeGroupIDHigh:4": -9178793868474562574
 			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11305,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
 			"label:8": "Steel Ingots"
 		},
-		"56:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32018,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1013,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7003650837158748943,
-				"tradeGroupIDHigh:4": -1569327059066273508
-			},
-			"label:8": "SMD Transistors"
-		},
-		"57:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 43200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5194676379114717901,
-				"tradeGroupIDHigh:4": 1483776143412711262
-			},
-			"label:8": "Gold Berries"
-		},
-		"58:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "miscutils:blockFishTrap",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:cooked_fished",
-							"OreDict:8": "",
-							"Count:3": 40
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1009,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 7200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6272246248059718701,
-				"tradeGroupIDHigh:4": -4479977775871604728
-			},
-			"label:8": "Shhh, Don't Tell 0lafe..."
-		},
-		"59:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 120
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23355,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6621110070263941947,
-				"tradeGroupIDHigh:4": 6956279470374472716
-			},
-			"label:8": "Magnetic Steel Rods"
-		},
-		"60:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 300
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 150
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 217,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "TwilightForest:tile.TFTowerStone",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:item.phantomHelm",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 60000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5940753176321417748,
-				"tradeGroupIDHigh:4": -5493634304718058938
-			},
-			"label:8": "Ur-Ghast"
-		},
-		"61:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 28880,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5204768688110740212,
-				"tradeGroupIDHigh:4": 7419429424489055752
-			},
-			"label:8": "Rubber Rings"
-		},
-		"62:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30720,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6286403260748772969,
-				"tradeGroupIDHigh:4": 1509543741206448578
-			},
-			"label:8": "Sulfuric Acid"
-		},
-		"63:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30013,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 846,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8589559165387387085,
-				"tradeGroupIDHigh:4": 3873137491768461295
-			},
-			"label:8": "Oxygen"
-		},
-		"64:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 64
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 538,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:coal",
-							"OreDict:8": "",
-							"Count:3": 64
-						},
-						"1:10": {
-							"Damage:2": 2,
-							"id:8": "IC2:itemDust",
-							"OreDict:8": "dustCoal",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 29,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 300,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8059561285075528868,
-				"tradeGroupIDHigh:4": -5636143048331017735
-			},
-			"label:8": "You Can't Spell Lignite Without Ignite"
-		},
-		"65:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:tnt",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"1:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:blockITNT",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8025661602294684606,
-				"tradeGroupIDHigh:4": 6516331556602793699
-			},
-			"label:8": "TNT and iTNT"
-		},
-		"66:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 3,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7295092635075644842,
-				"tradeGroupIDHigh:4": -7145228414530335426
-			},
-			"label:8": "Deep Hive"
-		},
-		"67:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32700,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7177894263341230175,
-				"tradeGroupIDHigh:4": 1054350691466628837
-			},
-			"label:8": "Vacuum Tubes"
-		},
-		"68:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"1:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"2:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"3:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 3,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"4:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 4,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"5:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 5,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"6:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 6,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"7:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 7,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"8:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 8,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"9:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 15,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"10:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 9,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"11:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 10,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"12:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 11,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"13:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 12,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"14:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 13,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"15:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "flower",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 14,
-							"id:8": "Botania:mushroom",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 3221,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4619349719529052517,
-				"tradeGroupIDHigh:4": 7584468753205841514
-			},
-			"label:8": "Having trouble finding Botania mushrooms?"
-		},
-		"69:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "blood",
-							"value:3": 1000
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "AWWayofTime:imbuedSlate",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 421,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 1800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8820720829680841348,
-				"tradeGroupIDHigh:4": 9073790976223889808
-			},
-			"label:8": "T3 BM Slates"
-		},
-		"70:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 7,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8679376729168452011,
-				"tradeGroupIDHigh:4": -2701240967370945209
-			},
-			"label:8": "Marshy Hive"
-		},
-		"71:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7798972233727803539,
-				"tradeGroupIDHigh:4": 554955742662315221
-			},
-			"label:8": "Unusual Hive"
-		},
-		"72:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 1000
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "DraconicEvolution:dragonHeart",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 986,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7220124082401255793,
-				"tradeGroupIDHigh:4": -4708319372406274295
-			},
-			"label:8": "Dragon Warrior"
-		},
-		"73:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "ExtraBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8940895640491756088,
-				"tradeGroupIDHigh:4": 6264043070516511452
-			},
-			"label:8": "Nether Hive"
-		},
-		"74:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23306,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6125592342325853572,
-				"tradeGroupIDHigh:4": 1620417935309295411
-			},
-			"label:8": "Stainless Steel Rods"
-		},
-		"75:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32717,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6056940048786587787,
-				"tradeGroupIDHigh:4": -8417223990231678012
-			},
-			"label:8": "Transistors"
-		},
-		"76:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1246,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8878380846779580496,
-				"tradeGroupIDHigh:4": 2106211961264687831
-			},
-			"label:8": "Tin Cables"
-		},
-		"77:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:apiculture",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 507,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 4800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8498417496281731719,
-				"tradeGroupIDHigh:4": -4892619657022648527
-			},
-			"label:8": "Apiary"
-		},
-		"78:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 59,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 3
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6494411469531869056,
-				"tradeGroupIDHigh:4": 3075548050690229060
-			},
-			"label:8": "Cave Spider"
-		},
-		"79:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23019,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9152068418958551657,
-				"tradeGroupIDHigh:4": 807129249512636498
-			},
-			"label:8": "Aluminium Rods"
-		},
-		"80:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32045,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 4800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8750511144673075718,
-				"tradeGroupIDHigh:4": 6052516535919657784
-			},
-			"label:8": "Central Processing Units"
-		},
-		"81:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 4,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5037157695275214349,
-				"tradeGroupIDHigh:4": -7589467650922823552
-			},
-			"label:8": "Tropical Hive"
-		},
-		"82:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:piston",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"1:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:sticky_piston",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 49,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 300,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4650295033948924895,
-				"tradeGroupIDHigh:4": 7961956447783177634
-			},
-			"label:8": "Piston"
-		},
-		"83:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 500
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 250
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 226,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 3,
-							"id:8": "TwilightForest:item.trophy",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:item.fieryTears",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 72000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6576396442260391736,
-				"tradeGroupIDHigh:4": -7366662857989666759
-			},
-			"label:8": "Yeti"
-		},
-		"84:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:blockOreCopper",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5035,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 825,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5125550796358846011,
-				"tradeGroupIDHigh:4": -3695049620202173633
-			},
-			"label:8": "Copper Ore exchange"
-		},
-		"85:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32716,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5979766207122424084,
-				"tradeGroupIDHigh:4": 2234969258349117744
-			},
-			"label:8": "Resistors"
-		},
-		"86:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 21300,
-							"id:8": "gregtech:gt.metaitem.02",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4615562487088085683,
-				"tradeGroupIDHigh:4": 9212520479894815118
-			},
-			"label:8": "Bronze Rotors"
-		},
-		"87:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 200
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23356,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8235850438672384275,
-				"tradeGroupIDHigh:4": 5929497451589618055
-			},
-			"label:8": "Magnetic Neodymium Rods"
-		},
-		"88:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 4,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 986,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6567362948613707111,
-				"tradeGroupIDHigh:4": 7994267434210969771
-			},
-			"label:8": "Infernal Hive"
-		},
-		"89:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:leather",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 11,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7475903403107465931,
-				"tradeGroupIDHigh:4": -5109685962067852121
-			},
-			"label:8": "Need Some Leather?"
-		},
-		"90:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 5122,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7895326952858249963,
-				"tradeGroupIDHigh:4": 7475415713971194555
-			},
-			"label:8": "Bronze Fluid Pipes"
-		},
-		"91:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 56,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7517425302332734491,
-				"tradeGroupIDHigh:4": 5159347170331348818
-			},
-			"label:8": "Ghast"
-		},
-		"92:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 20
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 505,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 230,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": -7973202373084553817,
-						"questIDHigh:4": 6327679129227052174
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5141609898475924178,
-				"tradeGroupIDHigh:4": 3098501365243202370
-			},
-			"label:8": "Shulker"
-		},
-		"93:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 60,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 3
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8151979855454705270,
-				"tradeGroupIDHigh:4": 2496347508437697028
-			},
-			"label:8": "Silverfish"
-		},
-		"94:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "darkWizard",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Thaumcraft:ItemSanitySoap",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1099,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 36000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5819792386440411040,
-				"tradeGroupIDHigh:4": -6512933849023690205
-			},
-			"label:8": "Bath Soap"
-		},
-		"95:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "harvestcraft:pamoliveSapling",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 440,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6397549567670417457,
-				"tradeGroupIDHigh:4": -1894222317107983964
-			},
-			"label:8": "Olive Saplings"
-		},
-		"96:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 70
-						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 4
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 190,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "TwilightForest:item.trophy",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "dreamcraft:item.LichBone",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 36000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7222248691732709394,
-				"tradeGroupIDHigh:4": -5864776777758128953
-			},
-			"label:8": "Lich"
-		},
-		"97:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 15
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 57,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5063205176464563964,
-				"tradeGroupIDHigh:4": -3872743183723835538
-			},
-			"label:8": "Pigmen"
-		},
-		"98:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23301,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8344874008329633178,
-				"tradeGroupIDHigh:4": 5470206081520975915
-			},
-			"label:8": "Brass Rods"
-		},
-		"99:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 29501,
-							"id:8": "gregtech:gt.metaitem.02",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9167501362109146863,
-				"tradeGroupIDHigh:4": 853329771106552056
-			},
-			"label:8": "Flawless Emeralds"
-		},
-		"100:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11880,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4878956512713250462,
-				"tradeGroupIDHigh:4": 2851399178580214429
-			},
-			"label:8": "Rubber Ingots"
-		},
-		"101:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "Forestry:apiculture",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 502,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4901138001202915576,
-				"tradeGroupIDHigh:4": -2596378106001404499
-			},
-			"label:8": "Bee Houses"
-		},
-		"102:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:coal_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5535,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 826,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7204870650604289528,
-				"tradeGroupIDHigh:4": -8246471351695160453
-			},
-			"label:8": "Coal Ore exchange"
-		},
-		"103:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 58,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8190606158079126071,
-				"tradeGroupIDHigh:4": -3205654040659935216
-			},
-			"label:8": "Enderman"
-		},
-		"104:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23,
-							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 183,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6098089596415734327,
-				"tradeGroupIDHigh:4": -5611710622322374349
-			},
-			"label:8": "Calculation Processors"
-		},
-		"105:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11019,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7859955698812297513,
-				"tradeGroupIDHigh:4": -1272808310886478837
-			},
-			"label:8": "Aluminium Ingots"
-		},
-		"106:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 61,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8311372216884165580,
-				"tradeGroupIDHigh:4": -7763654742908320046
-			},
-			"label:8": "Blaze"
-		},
-		"107:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:redstone_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5810,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 494,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8039330079242763919,
-				"tradeGroupIDHigh:4": -3000405660460038034
-			},
-			"label:8": "Redstone Ore exchange"
-		},
-		"108:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5146008665935241180,
-				"tradeGroupIDHigh:4": 4627047919204518623
-			},
-			"label:8": "Meadow Hive"
-		},
-		"109:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:clay_ball",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 21,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 300,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6398275613071624045,
-				"tradeGroupIDHigh:4": 3509451350714765269
-			},
-			"label:8": "Clay for Pennies"
-		},
-		"110:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11304,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8142161446435907338,
-				"tradeGroupIDHigh:4": -1136721260394561326
-			},
-			"label:8": "Wrought Iron Ingots"
-		},
-		"111:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32033,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6265385299162117070,
-				"tradeGroupIDHigh:4": 1318869882000067183
-			},
-			"label:8": "Wafers"
-		},
-		"112:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30741,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 552,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8007892794003452081,
-				"tradeGroupIDHigh:4": -7481994371413817247
-			},
-			"label:8": "Heavy Fuel"
-		},
-		"113:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32011,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 2736,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8494605400156751851,
-				"tradeGroupIDHigh:4": -7027288359462285445
-			},
-			"label:8": "SMD Resistors"
-		},
-		"114:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 160
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:blaze_rod",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7717715279482793706,
-				"tradeGroupIDHigh:4": 4225595787390042355
-			},
-			"label:8": "Blaze Rods"
-		},
-		"115:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30726,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 88,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 745,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8936809284440028363,
-				"tradeGroupIDHigh:4": -1951235289747340594
-			},
-			"label:8": "Glue"
-		},
-		"116:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 2,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8357917661111456593,
-				"tradeGroupIDHigh:4": -8655004027535473126
-			},
-			"label:8": "Resonating Hive"
-		},
-		"117:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 16,
-							"id:8": "appliedenergistics2:item.ItemMultiPart",
-							"OreDict:8": "",
-							"Count:3": 24
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 183,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8841304052891890194,
-				"tradeGroupIDHigh:4": -4560690988635766035
-			},
-			"label:8": "ME Glass Cables"
-		},
-		"118:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 5,
-							"id:8": "MagicBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 986,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6516365028778359962,
-				"tradeGroupIDHigh:4": -5214843363391681868
-			},
-			"label:8": "Oblivion Hive"
-		},
-		"120:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30014,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1812,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6364699589404929605,
-				"tradeGroupIDHigh:4": -1519213210561656680
-			},
-			"label:8": "Fluorine"
-		},
-		"121:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32715,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7769182733040394563,
-				"tradeGroupIDHigh:4": -3054782028430097122
-			},
-			"label:8": "Diodes"
-		},
-		"122:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:beePrincessGE",
-							"OreDict:8": "",
-							"Count:3": 4,
-							"tag:10": {
-								"MaxH:4": 20,
-								"IsAnalyzed:4": 1,
-								"Genome:10": {
-									"Chromosomes:9": {
-										"0:10": {
-											"Slot:4": 0,
-											"UID0:8": "extrabees.species.ocean",
-											"UID1:8": "extrabees.species.ocean"
-										},
-										"1:10": {
-											"Slot:4": 1,
-											"UID0:8": "forestry.speedSlowest",
-											"UID1:8": "forestry.speedSlowest"
-										},
-										"2:10": {
-											"Slot:4": 2,
-											"UID0:8": "forestry.lifespanShorter",
-											"UID1:8": "forestry.lifespanShorter"
-										},
-										"3:10": {
-											"Slot:4": 3,
-											"UID0:8": "forestry.fertilityNormal",
-											"UID1:8": "forestry.fertilityNormal"
-										},
-										"4:10": {
-											"Slot:4": 4,
-											"UID0:8": "forestry.toleranceNone",
-											"UID1:8": "forestry.toleranceNone"
-										},
-										"5:10": {
-											"Slot:4": 5,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"6:10": {
-											"Slot:4": 7,
-											"UID0:8": "forestry.toleranceBoth1",
-											"UID1:8": "forestry.toleranceBoth1"
-										},
-										"7:10": {
-											"Slot:4": 8,
-											"UID0:8": "forestry.boolTrue",
-											"UID1:8": "forestry.boolTrue"
-										},
-										"8:10": {
-											"Slot:4": 9,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"9:10": {
-											"Slot:4": 10,
-											"UID0:8": "extrabees.flower.water",
-											"UID1:8": "extrabees.flower.water"
-										},
-										"10:10": {
-											"Slot:4": 11,
-											"UID0:8": "forestry.floweringSlowest",
-											"UID1:8": "forestry.floweringSlowest"
-										},
-										"11:10": {
-											"Slot:4": 12,
-											"UID0:8": "forestry.territoryAverage",
-											"UID1:8": "forestry.territoryAverage"
-										},
-										"12:10": {
-											"Slot:4": 13,
-											"UID0:8": "extrabees.effect.water",
-											"UID1:8": "extrabees.effect.water"
-										}
-									}
-								},
-								"Health:4": 20
-							}
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "Forestry:beeDroneGE",
-							"OreDict:8": "",
-							"Count:3": 4,
-							"tag:10": {
-								"MaxH:4": 20,
-								"IsAnalyzed:4": 1,
-								"Genome:10": {
-									"Chromosomes:9": {
-										"0:10": {
-											"Slot:4": 0,
-											"UID0:8": "extrabees.species.ocean",
-											"UID1:8": "extrabees.species.ocean"
-										},
-										"1:10": {
-											"Slot:4": 1,
-											"UID0:8": "forestry.speedSlowest",
-											"UID1:8": "forestry.speedSlowest"
-										},
-										"2:10": {
-											"Slot:4": 2,
-											"UID0:8": "forestry.lifespanShorter",
-											"UID1:8": "forestry.lifespanShorter"
-										},
-										"3:10": {
-											"Slot:4": 3,
-											"UID0:8": "forestry.fertilityNormal",
-											"UID1:8": "forestry.fertilityNormal"
-										},
-										"4:10": {
-											"Slot:4": 4,
-											"UID0:8": "forestry.toleranceNone",
-											"UID1:8": "forestry.toleranceNone"
-										},
-										"5:10": {
-											"Slot:4": 5,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"6:10": {
-											"Slot:4": 7,
-											"UID0:8": "forestry.toleranceBoth1",
-											"UID1:8": "forestry.toleranceBoth1"
-										},
-										"7:10": {
-											"Slot:4": 8,
-											"UID0:8": "forestry.boolTrue",
-											"UID1:8": "forestry.boolTrue"
-										},
-										"8:10": {
-											"Slot:4": 9,
-											"UID0:8": "forestry.boolFalse",
-											"UID1:8": "forestry.boolFalse"
-										},
-										"9:10": {
-											"Slot:4": 10,
-											"UID0:8": "extrabees.flower.water",
-											"UID1:8": "extrabees.flower.water"
-										},
-										"10:10": {
-											"Slot:4": 11,
-											"UID0:8": "forestry.floweringSlowest",
-											"UID1:8": "forestry.floweringSlowest"
-										},
-										"11:10": {
-											"Slot:4": 12,
-											"UID0:8": "forestry.territoryAverage",
-											"UID1:8": "forestry.territoryAverage"
-										},
-										"12:10": {
-											"Slot:4": 13,
-											"UID0:8": "extrabees.effect.water",
-											"UID1:8": "extrabees.effect.water"
-										}
-									}
-								},
-								"Health:4": 20
-							}
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1121,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7485785662864231228,
-				"tradeGroupIDHigh:4": 2187396924325973295
-			},
-			"label:8": "Ocean Bees"
-		},
-		"123:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "darkWizard",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 5,
-							"id:8": "Thaumcraft:blockCustomPlant",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 241,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8373030686352213240,
-				"tradeGroupIDHigh:4": 6880768796930231095
-			},
-			"label:8": "Vishroom"
-		},
-		"124:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"1:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"2:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"3:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 3,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"4:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 4,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				},
-				"5:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "forestry",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 5,
-							"id:8": "minecraft:sapling",
-							"OreDict:8": "",
-							"Count:3": 5
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 4,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9092426022131304709,
-				"tradeGroupIDHigh:4": 4362636526341408413
-			},
-			"label:8": "Vanilla Saplings"
-		},
-		"125:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 66,
-							"id:8": "minecraft:spawn_egg",
-							"OreDict:8": "",
-							"Count:3": 3
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 44,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5022282330024590292,
-				"tradeGroupIDHigh:4": 5057974419326913552
-			},
-			"label:8": "Witch"
-		},
-		"126:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 60
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 5,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 172800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7800726402794054648,
-				"tradeGroupIDHigh:4": -7655625746504660045
-			},
-			"label:8": "XP Berries"
-		},
-		"127:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 30
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1360,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8543116577650432060,
-				"tradeGroupIDHigh:4": 7574593932850249871
-			},
-			"label:8": "Copper Wires"
-		},
-		"128:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:lapis_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5526,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 867,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8312859639004491960,
-				"tradeGroupIDHigh:4": 367939962177408043
-			},
-			"label:8": "Lapis Ore exchange"
-		},
-		"129:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30739,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 641,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4691957073449626538,
-				"tradeGroupIDHigh:4": -2612923544728679895
-			},
-			"label:8": "Naphtha"
-		},
-		"130:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "cook",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:egg",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 11,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6878126313705567722,
-				"tradeGroupIDHigh:4": -2788734869977674001
-			},
-			"label:8": "Buy Some Eggs"
-		},
-		"131:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32037,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 4800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8493135421258265699,
-				"tradeGroupIDHigh:4": -3690642540020809165
-			},
-			"label:8": "Integrated Logic Circuits"
-		},
-		"132:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30707,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 546,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5462780835002749274,
-				"tradeGroupIDHigh:4": 2665768948144164116
-			},
-			"label:8": "Oil"
-		},
-		"133:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1426,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6355741419395100015,
-				"tradeGroupIDHigh:4": -1978937296784896422
-			},
-			"label:8": "Gold Cables"
-		},
-		"134:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 8516,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9171496556203865558,
-				"tradeGroupIDHigh:4": -5026418203027225874
-			},
-			"label:8": "Certus Quartz"
-		},
-		"135:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30706,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8249127371271555509,
-				"tradeGroupIDHigh:4": -6251230119638712162
-			},
-			"label:8": "Ethanol"
-		},
-		"136:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 20
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 76,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 21600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4875887444083229413,
-				"tradeGroupIDHigh:4": -699433035426673334
-			},
-			"label:8": "Iron Berries"
-		},
-		"137:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 17880,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8868281201543702871,
-				"tradeGroupIDHigh:4": 2067926537080358072
-			},
-			"label:8": "Rubber Sheets"
-		},
-		"138:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1386,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 160,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1172,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7991294957602498369,
-				"tradeGroupIDHigh:4": -4956052114595820828
-			},
-			"label:8": "Annealed Copper Cables"
-		},
-		"139:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23354,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6787753830114031681,
-				"tradeGroupIDHigh:4": 1900754739404949578
-			},
-			"label:8": "Magnetic Iron Rods"
-		},
-		"140:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:gold_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5086,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 826,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -9061213087120535670,
-				"tradeGroupIDHigh:4": -4638244725637299738
-			},
-			"label:8": "Gold Ore exchange"
-		},
-		"141:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemHarz",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 37,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "misc",
 			"cooldown:3": 900,
-			"maxTrades:3": -1,
 			"id:10": {
 				"tradeGroupIDLow:4": -5914996230571043261,
 				"tradeGroupIDHigh:4": -9133737372445946123
 			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:itemHarz",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
 			"label:8": "Sticky Matter"
 		},
-		"142:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 25
-						},
-						"1:10": {
-							"type:8": "farmer",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemFertilizer",
-							"OreDict:8": "",
-							"Count:3": 128
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:spider_eye",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:rotten_flesh",
-							"OreDict:8": "",
-							"Count:3": 8
-						},
-						"2:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:dirt",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 718,
+						"questIDLow:4": 29,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 7200,
-			"maxTrades:3": -1,
+			],
+			"category:8": "raw",
+			"cooldown:3": 300,
 			"id:10": {
-				"tradeGroupIDLow:4": -6468828570032518602,
-				"tradeGroupIDHigh:4": -5783444801880699178
+				"tradeGroupIDLow:4": -5903948547600641774,
+				"tradeGroupIDHigh:4": -9093615307106008532
 			},
-			"label:8": "Manure for Fertilizer"
-		},
-		"143:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 11335,
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 8538,
+							"Count:3": 64,
 							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8321738503108510267,
-				"tradeGroupIDHigh:4": 7482077897818587995
-			},
-			"label:8": "Damascus Steel Ingots"
-		},
-		"144:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "survivor",
-							"value:3": 150
+							"OreDict:8": ""
 						},
-						"1:10": {
-							"type:8": "darkWizard",
-							"value:3": 70
+						{
+							"Damage:2": 2538,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 189,
-							"id:8": "TwilightForest:item.tfspawnegg",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:3": 8,
-							"id:8": "TwilightForest:tile.TFFireJet",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:tile.TFFireJet",
-							"OreDict:8": "",
-							"Count:3": 1
-						},
-						"2:10": {
-							"Damage:3": 0,
-							"id:8": "TwilightForest:item.minotaurAxe",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 225,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 48000,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5498839954666292430,
-				"tradeGroupIDHigh:4": 5450349837546703482
-			},
-			"label:8": "Hydra"
-		},
-		"145:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 40
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 21057,
-							"id:8": "gregtech:gt.metaitem.02",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -4917326387650827868,
-				"tradeGroupIDHigh:4": -4783446858259872532
-			},
-			"label:8": "Tin Rotors"
-		},
-		"146:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
+					],
+					"toItems:9": [
+						{
 							"Damage:2": 0,
-							"id:8": "IC2:blockOreLead",
-							"OreDict:8": "",
-							"Count:3": 64
+							"Count:3": 64,
+							"id:8": "minecraft:coal_ore",
+							"OreDict:8": ""
 						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5089,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 610,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6467302626849877005,
-				"tradeGroupIDHigh:4": 7092401461566918136
-			},
-			"label:8": "Lead Ore exchange"
-		},
-		"147:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:quartz_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5522,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 479,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7578005454057286907,
-				"tradeGroupIDHigh:4": 6570548978895114191
-			},
-			"label:8": "Netherquartz Ore exchange"
-		},
-		"148:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
+					],
+					"fromCurrency:9": [
+						{
 							"type:8": "adventure",
-							"value:3": 50
+							"value:3": 65
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:blockCrop",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:log",
-							"OreDict:8": "logWood",
-							"Count:3": 1
-						}
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
+			],
+			"label:8": "Who Would Use This Garbage??"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 718,
+						"questIDLow:4": 1121,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 7200,
-			"maxTrades:3": -1,
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
 			"id:10": {
-				"tradeGroupIDLow:4": -7796899935526309028,
-				"tradeGroupIDHigh:4": 5508599544875928445
+				"tradeGroupIDLow:4": -8479936493771858344,
+				"tradeGroupIDHigh:4": -8917382112598276013
 			},
-			"label:8": "Wood for Sheep?"
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "minecraft:emerald_block",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 32,
+							"id:8": "Forestry:royalJelly",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"tag:10": {
+								"MaxH:3": 40,
+								"Health:3": 40,
+								"IsAnalyzed:1": 1,
+								"Genome:10": {
+									"Chromosomes:9": [
+										{
+											"Slot:1": 0,
+											"UID0:8": "forestry.speciesSteadfast",
+											"UID1:8": "forestry.speciesSteadfast"
+										},
+										{
+											"Slot:1": 1,
+											"UID0:8": "forestry.speedSlower",
+											"UID1:8": "forestry.speedSlower"
+										},
+										{
+											"Slot:1": 2,
+											"UID0:8": "forestry.lifespanNormal",
+											"UID1:8": "forestry.lifespanNormal"
+										},
+										{
+											"Slot:1": 3,
+											"UID0:8": "forestry.fertilityNormal",
+											"UID1:8": "forestry.fertilityNormal"
+										},
+										{
+											"Slot:1": 4,
+											"UID0:8": "forestry.toleranceNone",
+											"UID1:8": "forestry.toleranceNone"
+										},
+										{
+											"Slot:1": 5,
+											"UID0:8": "forestry.boolTrue",
+											"UID1:8": "forestry.boolTrue"
+										},
+										{
+											"Slot:1": 7,
+											"UID0:8": "forestry.toleranceNone",
+											"UID1:8": "forestry.toleranceNone"
+										},
+										{
+											"Slot:1": 8,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:1": 9,
+											"UID0:8": "forestry.boolTrue",
+											"UID1:8": "forestry.boolTrue"
+										},
+										{
+											"Slot:1": 10,
+											"UID0:8": "forestry.flowersVanilla",
+											"UID1:8": "forestry.flowersVanilla"
+										},
+										{
+											"Slot:1": 11,
+											"UID0:8": "forestry.floweringSlowest",
+											"UID1:8": "forestry.floweringSlowest"
+										},
+										{
+											"Slot:1": 12,
+											"UID0:8": "forestry.territoryAverage",
+											"UID1:8": "forestry.territoryAverage"
+										},
+										{
+											"Slot:1": 13,
+											"UID0:8": "forestry.effectNone",
+											"UID1:8": "forestry.effectNone"
+										}
+									]
+								}
+							},
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "Forestry:beeDroneGE",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Steadfast Bees"
 		},
-		"149:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1013,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -8666641303671302370,
+				"tradeGroupIDHigh:4": -8739870649288146676
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32016,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
 							"value:3": 80
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 4,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
+			],
+			"label:8": "SMD Diodes"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 1148,
+						"questIDLow:4": 44,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 86400,
-			"maxTrades:3": -1,
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
 			"id:10": {
-				"tradeGroupIDLow:4": -6041842654134112569,
-				"tradeGroupIDHigh:4": -2497743160143098196
+				"tradeGroupIDLow:4": -8357917661111456593,
+				"tradeGroupIDHigh:4": -8655004027535473126
 			},
-			"label:8": "Aluminum Berries"
-		},
-		"150:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
 							"value:3": 10
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "appliedenergistics2:tile.BlockSkyStone",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
+			],
+			"label:8": "Resonating Hive"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 88,
+						"questIDLow:4": 176,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
+			"cooldown:3": 3600,
 			"id:10": {
-				"tradeGroupIDLow:4": -5451204044465762473,
-				"tradeGroupIDHigh:4": -8235694583613141612
+				"tradeGroupIDLow:4": -8299580794907626861,
+				"tradeGroupIDHigh:4": -8605554061585461795
 			},
-			"label:8": "Ironically, It's Not Used in AE2 Anymore"
-		},
-		"151:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11306,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
 							"type:8": "smith",
-							"value:3": 25
+							"value:3": 150
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "dreamcraft:ZincGravelOre",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 34,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5681067184501789008,
-				"tradeGroupIDHigh:4": 6805134868485587270
-			},
-			"label:8": "Zinc Gravel Ore"
+			],
+			"label:8": "Stainless Steel Ingots"
 		},
-		"152:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 120
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 5132,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 160,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
+			"cooldown:3": 3600,
 			"id:10": {
-				"tradeGroupIDLow:4": -4898654434465785694,
-				"tradeGroupIDHigh:4": 8274717392587211037
+				"tradeGroupIDLow:4": -6056940048786587787,
+				"tradeGroupIDHigh:4": -8417223990231678012
 			},
-			"label:8": "Steel Fluid Pipes"
-		},
-		"153:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32717,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:iron_ore",
-							"OreDict:8": "",
-							"Count:3": 64
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
 						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5032,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
+						"OreDict:8": ""
 					}
 				}
+			],
+			"label:8": "Transistors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 945,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7989253404725874083,
+				"tradeGroupIDHigh:4": -8382468326480066229
 			},
-			"requirements:9": {
-				"0:10": {
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2879,
+							"Count:3": 50,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tired of Grinding Reeds?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1013,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8633810402335966187,
+				"tradeGroupIDHigh:4": -8336662296209897510
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32020,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "SMD Capacitor"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 826,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "raw",
 			"cooldown:3": 1200,
-			"maxTrades:3": -1,
 			"id:10": {
-				"tradeGroupIDLow:4": -7233209231756456510,
-				"tradeGroupIDHigh:4": 2959425405873114832
+				"tradeGroupIDLow:4": -7204870650604289528,
+				"tradeGroupIDHigh:4": -8246471351695160453
 			},
-			"label:8": "Iron Ore exchange"
-		},
-		"154:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5535,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30012,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:coal_ore",
+							"OreDict:8": ""
 						}
-					},
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
+			],
+			"label:8": "Coal Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 555,
+						"questIDLow:4": 88,
 						"questIDHigh:4": 0
 					}
-				},
-				"1:10": {
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5451204044465762473,
+				"tradeGroupIDHigh:4": -8235694583613141612
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "appliedenergistics2:tile.BlockSkyStone",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ironically, It's Not Used in AE2 Anymore"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6343112004592918270,
+				"tradeGroupIDHigh:4": -8183924001269004581
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 1,
+							"id:8": "ExtraBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Rocky Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -9154976941603920863,
+				"tradeGroupIDHigh:4": -8031269670881050036
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2006,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Red Alloy Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8311372216884165580,
+				"tradeGroupIDHigh:4": -7763654742908320046
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 61,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Blaze"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6116557497129346802,
+				"tradeGroupIDHigh:4": -7744783041043413601
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Forest Hive"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 1148,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
+			],
+			"category:8": "farming",
+			"cooldown:3": 172800,
 			"id:10": {
-				"tradeGroupIDLow:4": -7336235052460510259,
-				"tradeGroupIDHigh:4": 3691062517631830681
+				"tradeGroupIDLow:4": -7800726402794054648,
+				"tradeGroupIDHigh:4": -7655625746504660045
 			},
-			"label:8": "Nitrogen"
-		},
-		"155:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 20
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 607,
-							"id:8": "gregtech:gt.blockores",
-							"OreDict:8": "",
-							"Count:3": 64
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 60
 						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
+			],
+			"label:8": "XP Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 0,
+			"id:10": {
+				"tradeGroupIDLow:4": -8474466748179230466,
+				"tradeGroupIDHigh:4": -7651212176927670027
 			},
-			"requirements:9": {
-				"0:10": {
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2817,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 500
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Salt for Your Salty Mouth"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5037157695275214349,
+				"tradeGroupIDHigh:4": -7589467650922823552
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 4,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tropical Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 507,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7514908793536764410,
+				"tradeGroupIDHigh:4": -7586385544549939517
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "Forestry:frameImpregnated",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Impregnated Frames"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 552,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8007892794003452081,
+				"tradeGroupIDHigh:4": -7481994371413817247
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30741,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Heavy Fuel"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 103,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7831601698323567118,
+				"tradeGroupIDHigh:4": -7369202228715827960
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 31,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Manganese Ore"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 72000,
+			"id:10": {
+				"tradeGroupIDLow:4": -6576396442260391736,
+				"tradeGroupIDHigh:4": -7366662857989666759
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.trophy",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.fieryTears",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 226,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 500
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 250
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Yeti"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7295092635075644842,
+				"tradeGroupIDHigh:4": -7145228414530335426
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Deep Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 2736,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -8494605400156751851,
+				"tradeGroupIDHigh:4": -7027288359462285445
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32011,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "SMD Resistors"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 586,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "raw",
 			"cooldown:3": 1200,
-			"maxTrades:3": -1,
 			"id:10": {
 				"tradeGroupIDLow:4": -5927645757187909495,
 				"tradeGroupIDHigh:4": -6974297349861850868
 			},
-			"label:8": "Pyrochlore Ore"
-		},
-		"156:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 24,
-							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 183,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
 			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8981702172980339533,
-				"tradeGroupIDHigh:4": 7104704104552417389
-			},
-			"label:8": "Engineering Processors"
-		},
-		"157:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 50
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 607,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 23032,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7778655195752207892,
-				"tradeGroupIDHigh:4": -5432004239910941845
-			},
-			"label:8": "Iron Rods"
-		},
-		"158:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32016,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1013,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8666641303671302370,
-				"tradeGroupIDHigh:4": -8739870649288146676
-			},
-			"label:8": "SMD Diodes"
-		},
-		"159:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
+					],
+					"fromCurrency:9": [
+						{
 							"type:8": "adventure",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2890,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 32
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 52,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 1800,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8627297198870911161,
-				"tradeGroupIDHigh:4": -2224824016237604941
-			},
-			"label:8": "Glassy Eyed"
-		},
-		"160:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "blood",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "AWWayofTime:blankSlate",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 407,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8339612917554702699,
-				"tradeGroupIDHigh:4": -5918325650662797765
-			},
-			"label:8": "T1 BM Slates"
-		},
-		"161:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:blockOreTin",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5057,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 31,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5462909668691926207,
-				"tradeGroupIDHigh:4": -1747356227010149517
-			},
-			"label:8": "Tin Ore exchange"
-		},
-		"162:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30001,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 550,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7162464133608694289,
-				"tradeGroupIDHigh:4": 2545802671257373786
-			},
-			"label:8": "Hydrogen"
-		},
-		"163:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 7,
-							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
-							"OreDict:8": "",
-							"Count:3": 24
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 183,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "raw",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6346221740992364432,
-				"tradeGroupIDHigh:4": -6105942178301984699
-			},
-			"label:8": "Fluix Crystals"
-		},
-		"164:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 25
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30023,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 2697,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6962383307413588605,
-				"tradeGroupIDHigh:4": 7319097299822396675
-			},
-			"label:8": "Chlorine"
-		},
-		"165:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "adventure",
-							"value:3": 10
-						},
-						"1:10": {
-							"type:8": "farmer",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "Thaumcraft:blockCustomPlant",
-							"OreDict:8": "",
-							"Count:3": 4
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "Thaumcraft:blockCustomPlant",
-							"OreDict:8": "",
-							"Count:3": 2
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 440,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8899945763906551753,
-				"tradeGroupIDHigh:4": 2759715337044443478
-			},
-			"label:8": "Magical Saplings"
-		},
-		"166:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 22,
-							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 183,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -6949394814874467634,
-				"tradeGroupIDHigh:4": 6406355225172919900
-			},
-			"label:8": "Logic Processors"
-		},
-		"167:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "chemist",
-							"value:3": 70
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 30693,
-							"id:8": "gregtech:gt.metaitem.01",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "IC2:itemCellEmpty",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1020,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1148,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "chemistry",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5111578174466659872,
-				"tradeGroupIDHigh:4": 702838174580426963
-			},
-			"label:8": "Iron (III) Chloride"
-		},
-		"168:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "witch",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "witchery:seedswormwood",
-							"OreDict:8": "",
-							"Count:3": 4
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:wheat",
-							"OreDict:8": "",
-							"Count:3": 16
-						},
-						"1:10": {
-							"Damage:3": 0,
-							"id:8": "witchery:somniancotton",
-							"OreDict:8": "",
-							"Count:3": 4
-						},
-						"2:10": {
-							"Damage:3": 0,
-							"id:8": "witchery:mutator",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 2387,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5736424960247910044,
-				"tradeGroupIDHigh:4": 4464894235924907266
-			},
-			"label:8": "Wormwood"
-		},
-		"169:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
 							"value:3": 20
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 2,
-							"id:8": "TConstruct:oreBerries",
-							"OreDict:8": "",
-							"Count:3": 10
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 76,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 21600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7036388173970555310,
-				"tradeGroupIDHigh:4": 4950570324848429471
-			},
-			"label:8": "Copper Berries"
+			],
+			"label:8": "Pyrochlore Ore"
 		},
-		"170:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 1,
-							"id:8": "Forestry:beehives",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
-						"questIDLow:4": 44,
+						"questIDLow:4": 1097,
 						"questIDHigh:4": 0
 					}
 				}
-			},
-			"category:8": "bees",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
+			],
+			"category:8": "magic",
+			"cooldown:3": 18000,
 			"id:10": {
-				"tradeGroupIDLow:4": -6116557497129346802,
-				"tradeGroupIDHigh:4": -7744783041043413601
+				"tradeGroupIDLow:4": -8814568880806125484,
+				"tradeGroupIDHigh:4": -6895050813467177405
 			},
-			"label:8": "Forest Hive"
-		},
-		"171:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "farmer",
-							"value:3": 5
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 35,
-							"id:8": "enhancedlootbags:lootbag",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 440,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "farming",
-			"cooldown:3": 600,
 			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8108032577987767414,
-				"tradeGroupIDHigh:4": 4012189831531220477
-			},
-			"label:8": "Seed Bags"
-		},
-		"172:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 80
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 1442,
-							"id:8": "gregtech:gt.blockmachines",
-							"OreDict:8": "",
-							"Count:3": 8
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 1200,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -7218866763117093484,
-				"tradeGroupIDHigh:4": -4659314094307127343
-			},
-			"label:8": "Electrum 4x Wires"
-		},
-		"173:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 100
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 32020,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 16
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1013,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "components",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -8633810402335966187,
-				"tradeGroupIDHigh:4": -8336662296209897510
-			},
-			"label:8": "SMD Capacitor"
-		},
-		"174:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "technician",
-							"value:3": 240
-						}
-					},
-					"toItems:9": {
-						"0:10": {
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
 							"Damage:2": 0,
-							"id:8": "minecraft:ender_eye",
-							"OreDict:8": "",
-							"Count:3": 16
+							"Count:3": 2,
+							"id:8": "Thaumcraft:ItemBathSalts",
+							"OreDict:8": ""
 						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 176,
-						"questIDHigh:4": 0
-					}
-				},
-				"1:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 1233,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "misc",
-			"cooldown:3": 3600,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5714822084909401354,
-				"tradeGroupIDHigh:4": 4054259974374772034
-			},
-			"label:8": "Ender Eyes"
-		},
-		"175:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
+					],
+					"fromCurrency:9": [
+						{
 							"type:8": "darkWizard",
 							"value:3": 500
-						},
-						"1:10": {
-							"type:8": "witch",
-							"value:3": 100
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "witchery:hornofthehunt",
-							"OreDict:8": "",
-							"Count:3": 1
-						}
-					},
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
-			},
-			"requirements:9": {
-				"0:10": {
-					"name:8": "betterquesting",
-					"quest:10": {
-						"questIDLow:4": 333,
-						"questIDHigh:4": 0
-					}
-				}
-			},
-			"category:8": "magic",
-			"cooldown:3": 2400,
-			"maxTrades:3": -1,
-			"id:10": {
-				"tradeGroupIDLow:4": -5966660704359452136,
-				"tradeGroupIDHigh:4": 8506617739585799672
-			},
-			"label:8": "Horn of the Hunt"
+			],
+			"label:8": "Bath Salt"
 		},
-		"176:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "smith",
-							"value:3": 50
-						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:2": 0,
-							"id:8": "minecraft:diamond_ore",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					},
-					"displayItem:10": {
-						"Damage:2": 0,
-						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
-					},
-					"fromItems:9": {
-						"0:10": {
-							"Damage:2": 5500,
-							"id:8": "gregtech:gt.metaitem.03",
-							"OreDict:8": "",
-							"Count:3": 64
-						}
-					}
-				}
-			},
-			"requirements:9": {
-				"0:10": {
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 495,
 						"questIDHigh:4": 0
 					}
 				}
-			},
+			],
 			"category:8": "raw",
 			"cooldown:3": 1200,
-			"maxTrades:3": -1,
 			"id:10": {
 				"tradeGroupIDLow:4": -8880804389705596904,
 				"tradeGroupIDHigh:4": -6868700644185456174
 			},
-			"label:8": "Diamond Ore exchange"
-		},
-		"177:10": {
-			"trades:9": {
-				"0:10": {
-					"fromCurrency:9": {
-						"0:10": {
-							"type:8": "bees",
-							"value:3": 10
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5500,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
 						}
-					},
-					"toItems:9": {
-						"0:10": {
-							"Damage:3": 0,
-							"id:8": "ExtraBees:hive",
-							"OreDict:8": "",
-							"Count:3": 1
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:diamond_ore",
+							"OreDict:8": ""
 						}
-					},
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
 					"displayItem:10": {
 						"Damage:2": 0,
+						"Count:3": 1,
 						"id:8": "vendingmachine:placeholder",
-						"OreDict:8": "",
-						"Count:3": 1
+						"OreDict:8": ""
 					}
 				}
+			],
+			"label:8": "Diamond Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 400,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 43200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7609014856225906144,
+				"tradeGroupIDHigh:4": -6831519265120301352
 			},
-			"requirements:9": {
-				"0:10": {
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "minecraft:dragon_egg",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "HardcoreEnderExpansion:essence",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "space",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Dragon Essence"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 986,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6069872065390352622,
+				"tradeGroupIDHigh:4": -6749605871916531503
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ender Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6388473470953204394,
+				"tradeGroupIDHigh:4": -6592119183814015930
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1366,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Copper Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1099,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 36000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5819792386440411040,
+				"tradeGroupIDHigh:4": -6512933849023690205
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "Thaumcraft:ItemSanitySoap",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "darkWizard",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Bath Soap"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8249127371271555509,
+				"tradeGroupIDHigh:4": -6251230119638712162
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30706,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ethanol"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1297,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 43200,
+			"id:10": {
+				"tradeGroupIDLow:4": -4678340994427474139,
+				"tradeGroupIDHigh:4": -6162812482555919455
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "DraconicEvolution:dragonHeart",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 320,
+							"id:8": "HardcoreEnderExpansion:essence",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "space",
+							"value:3": 500
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Dragon Essence II"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 183,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6346221740992364432,
+				"tradeGroupIDHigh:4": -6105942178301984699
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 7,
+							"Count:3": 24,
+							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Fluix Crystals"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 407,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8339612917554702699,
+				"tradeGroupIDHigh:4": -5918325650662797765
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "AWWayofTime:blankSlate",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "blood",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "T1 BM Slates"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 36000,
+			"id:10": {
+				"tradeGroupIDLow:4": -7222248691732709394,
+				"tradeGroupIDHigh:4": -5864776777758128953
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.trophy",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "dreamcraft:item.LichBone",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 190,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 70
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 4
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Lich"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 718,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 7200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6468828570032518602,
+				"tradeGroupIDHigh:4": -5783444801880699178
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "minecraft:spider_eye",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "minecraft:rotten_flesh",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:dirt",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 128,
+							"id:8": "IC2:itemFertilizer",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 25
+						},
+						{
+							"type:8": "farmer",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Manure for Fertilizer"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 29,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 300,
+			"id:10": {
+				"tradeGroupIDLow:4": -8059561285075528868,
+				"tradeGroupIDHigh:4": -5636143048331017735
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:coal",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 2,
+							"Count:3": 64,
+							"id:8": "IC2:itemDust",
+							"OreDict:8": "dustCoal"
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 538,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 64
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "You Can't Spell Lignite Without Ignite"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 183,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6098089596415734327,
+				"tradeGroupIDHigh:4": -5611710622322374349
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23,
+							"Count:3": 8,
+							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Calculation Processors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 60000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5940753176321417748,
+				"tradeGroupIDHigh:4": -5493634304718058938
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFTowerStone",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.phantomHelm",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 217,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 300
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 150
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ur-Ghast"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7778655195752207892,
+				"tradeGroupIDHigh:4": -5432004239910941845
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23032,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Iron Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 986,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6516365028778359962,
+				"tradeGroupIDHigh:4": -5214843363391681868
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Oblivion Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6703713838163902610,
+				"tradeGroupIDHigh:4": -5209402801621613815
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23030,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 240
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Chrome Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 11,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7475903403107465931,
+				"tradeGroupIDHigh:4": -5109685962067852121
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:leather",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Need Some Leather?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -9171496556203865558,
+				"tradeGroupIDHigh:4": -5026418203027225874
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 8516,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Certus Quartz"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1172,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7991294957602498369,
+				"tradeGroupIDHigh:4": -4956052114595820828
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1386,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Annealed Copper Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 507,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 4800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8498417496281731719,
+				"tradeGroupIDHigh:4": -4892619657022648527
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "Forestry:apiculture",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Apiary"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -4917326387650827868,
+				"tradeGroupIDHigh:4": -4783446858259872532
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 21057,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.02",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tin Rotors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 986,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7220124082401255793,
+				"tradeGroupIDHigh:4": -4708319372406274295
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "DraconicEvolution:dragonHeart",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 1000
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Dragon Warrior"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7218866763117093484,
+				"tradeGroupIDHigh:4": -4659314094307127343
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1442,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Electrum 4x Wires"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 826,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -9061213087120535670,
+				"tradeGroupIDHigh:4": -4638244725637299738
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5086,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:gold_ore",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Gold Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 183,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8841304052891890194,
+				"tradeGroupIDHigh:4": -4560690988635766035
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 16,
+							"Count:3": 24,
+							"id:8": "appliedenergistics2:item.ItemMultiPart",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "ME Glass Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1009,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 7200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6272246248059718701,
+				"tradeGroupIDHigh:4": -4479977775871604728
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 40,
+							"id:8": "minecraft:cooked_fished",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "miscutils:blockFishTrap",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Shhh, Don't Tell 0lafe..."
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 65,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 12000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5103329954409932760,
+				"tradeGroupIDHigh:4": -4119083381545414768
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 11305,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "holoinventory:Hologlasses",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Holo Glasses"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 60000,
+			"id:10": {
+				"tradeGroupIDLow:4": -8710579738301169189,
+				"tradeGroupIDHigh:4": -4054227815665547780
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.trophy",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFUnderBrick",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 224,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 200
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Knight Phantom"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -5063205176464563964,
+				"tradeGroupIDHigh:4": -3872743183723835538
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 57,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 15
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Pigmen"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 825,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5125550796358846011,
+				"tradeGroupIDHigh:4": -3695049620202173633
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5035,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:blockOreCopper",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Copper Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 4800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8493135421258265699,
+				"tradeGroupIDHigh:4": -3690642540020809165
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32037,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Integrated Logic Circuits"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -4892984339196323849,
+				"tradeGroupIDHigh:4": -3258833425462573495
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30712,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Creosote"
+		},
+		{
+			"requirements:9": [
+				{
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDLow:4": 44,
 						"questIDHigh:4": 0
 					}
 				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8190606158079126071,
+				"tradeGroupIDHigh:4": -3205654040659935216
 			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 58,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Enderman"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
 			"category:8": "bees",
 			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5126966555949172973,
+				"tradeGroupIDHigh:4": -3086623031657675904
+			},
 			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Curious Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5877888774416027119,
+				"tradeGroupIDHigh:4": -3070428155345613988
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Modest Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7769182733040394563,
+				"tradeGroupIDHigh:4": -3054782028430097122
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32715,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Diodes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6233360669011173034,
+				"tradeGroupIDHigh:4": -3053195979660571002
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1467,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Silver 2x Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 494,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8039330079242763919,
+				"tradeGroupIDHigh:4": -3000405660460038034
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5810,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:redstone_ore",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Redstone Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6401729731510317256,
+				"tradeGroupIDHigh:4": -2994175566713893553
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32106,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Plastic Circuit Boards"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 11,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6878126313705567722,
+				"tradeGroupIDHigh:4": -2788734869977674001
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "cook",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Buy Some Eggs"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8679376729168452011,
+				"tradeGroupIDHigh:4": -2701240967370945209
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 7,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Marshy Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7888449537290138317,
+				"tradeGroupIDHigh:4": -2649851937429697283
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 62,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 15
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Magma Cube"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 641,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -4691957073449626538,
+				"tradeGroupIDHigh:4": -2612923544728679895
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30739,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Naphtha"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 502,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -4901138001202915576,
+				"tradeGroupIDHigh:4": -2596378106001404499
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 1,
+							"id:8": "Forestry:apiculture",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Bee Houses"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 86400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6041842654134112569,
+				"tradeGroupIDHigh:4": -2497743160143098196
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 4,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Aluminum Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 52,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 1800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8627297198870911161,
+				"tradeGroupIDHigh:4": -2224824016237604941
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2890,
+							"Count:3": 32,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Glassy Eyed"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 48000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5199563096401156684,
+				"tradeGroupIDHigh:4": -2064889456646600207
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.trophy",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 6,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFMazestone",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 205,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 100
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Minoshroom"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6355741419395100015,
+				"tradeGroupIDHigh:4": -1978937296784896422
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1426,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Gold Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 745,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8936809284440028363,
+				"tradeGroupIDHigh:4": -1951235289747340594
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30726,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Glue"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 440,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6397549567670417457,
+				"tradeGroupIDHigh:4": -1894222317107983964
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "harvestcraft:pamoliveSapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Olive Saplings"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 486,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6913100934010137265,
+				"tradeGroupIDHigh:4": -1849725078230381883
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 30,
+							"id:8": "minecraft:string",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 3,
+							"Count:3": 24,
+							"id:8": "Natura:barleyFood",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Cotton and String"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 31,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5462909668691926207,
+				"tradeGroupIDHigh:4": -1747356227010149517
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5057,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:blockOreTin",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tin Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1013,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7003650837158748943,
+				"tradeGroupIDHigh:4": -1569327059066273508
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32018,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "SMD Transistors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1812,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6364699589404929605,
+				"tradeGroupIDHigh:4": -1519213210561656680
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30014,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Fluorine"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8752857805792840610,
+				"tradeGroupIDHigh:4": -1394589871759275576
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1341,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Cupronickel 2x Wires"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 36000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5576427176385441338,
+				"tradeGroupIDHigh:4": -1359955860059700412
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFNagastoneBody",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 182,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 50
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Naga"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 72000,
+			"id:10": {
+				"tradeGroupIDLow:4": -8523383816479699814,
+				"tradeGroupIDHigh:4": -1310138638007384625
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.alphaFur",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.AuroraPillar",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 231,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 1000
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 500
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Snow Queen"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7859955698812297513,
+				"tradeGroupIDHigh:4": -1272808310886478837
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11019,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Aluminium Ingots"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 440,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6001886707592869699,
+				"tradeGroupIDHigh:4": -1161695127140415544
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "harvestcraft:pammapleSapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Maple Syrup?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8142161446435907338,
+				"tradeGroupIDHigh:4": -1136721260394561326
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11304,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Wrought Iron Ingots"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1415,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8969502125118346443,
+				"tradeGroupIDHigh:4": -1117975299186472804
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5098,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:blockOreUran",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Uranium Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7898843875360998813,
+				"tradeGroupIDHigh:4": -1002121497548404556
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 6,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Wintry Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1021,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7789957616853306556,
+				"tradeGroupIDHigh:4": -996007330482665153
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30718,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 70
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Sodium Persulfate"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7178890099584910232,
+				"tradeGroupIDHigh:4": -728621510259358270
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23303,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Electrum Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 76,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 21600,
+			"id:10": {
+				"tradeGroupIDLow:4": -4875887444083229413,
+				"tradeGroupIDHigh:4": -699433035426673334
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Iron Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1504,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 7200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7940483957138509434,
+				"tradeGroupIDHigh:4": -131575629021035508
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 937,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 35,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 870,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 834,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 500,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 810,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 526,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 530,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 523,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 535,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 57,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 936,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 935,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 838,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						},
+						{
+							"type:8": "smith",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Can't Find Those Ores?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 644,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6493983714776546357,
+				"tradeGroupIDHigh:4": 2767363482272514
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30715,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Methane"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1084,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -5107817319724605576,
+				"tradeGroupIDHigh:4": 198378206351213307
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30724,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Lubricant"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 867,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8312859639004491960,
+				"tradeGroupIDHigh:4": 367939962177408043
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5526,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:lapis_ore",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Lapis Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7798972233727803539,
+				"tradeGroupIDHigh:4": 554955742662315221
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Unusual Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7509059139663921801,
+				"tradeGroupIDHigh:4": 608035471216231384
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32100,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Basic Circuit Boards"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1020,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -5111578174466659872,
+				"tradeGroupIDHigh:4": 702838174580426963
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30693,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 70
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Iron (III) Chloride"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 53,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6986344121459865824,
+				"tradeGroupIDHigh:4": 801808094838409848
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:stone",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 823,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.blockores",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Calcite Getting you Down?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -9152068418958551657,
+				"tradeGroupIDHigh:4": 807129249512636498
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23019,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Aluminium Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -9167501362109146863,
+				"tradeGroupIDHigh:4": 853329771106552056
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 29501,
+							"Count:3": 32,
+							"id:8": "gregtech:gt.metaitem.02",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Flawless Emeralds"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7177894263341230175,
+				"tradeGroupIDHigh:4": 1054350691466628837
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32700,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Vacuum Tubes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
 			"id:10": {
 				"tradeGroupIDLow:4": -6435473900000590860,
 				"tradeGroupIDHigh:4": 1132356927433819318
 			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "ExtraBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
 			"label:8": "Water Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6265385299162117070,
+				"tradeGroupIDHigh:4": 1318869882000067183
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32033,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Wafers"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 43200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5194676379114717901,
+				"tradeGroupIDHigh:4": 1483776143412711262
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Gold Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6286403260748772969,
+				"tradeGroupIDHigh:4": 1509543741206448578
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30720,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Sulfuric Acid"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8508372527171231671,
+				"tradeGroupIDHigh:4": 1587593817887491926
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 21305,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.02",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 120
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Steel rotors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6125592342325853572,
+				"tradeGroupIDHigh:4": 1620417935309295411
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23306,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Stainless Steel Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 507,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 43200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7862643245927830587,
+				"tradeGroupIDHigh:4": 1638503203244623249
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "ExtraBees:hiveFrame.cocoa",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Chocolate is Bad For You..."
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 11,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -4688583532486906793,
+				"tradeGroupIDHigh:4": 1831286921561784817
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 20,
+							"id:8": "minecraft:wool",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Need Some Wool?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6787753830114031681,
+				"tradeGroupIDHigh:4": 1900754739404949578
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23354,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Magnetic Iron Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8868281201543702871,
+				"tradeGroupIDHigh:4": 2067926537080358072
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 17880,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Rubber Sheets"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 88,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8878380846779580496,
+				"tradeGroupIDHigh:4": 2106211961264687831
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1246,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tin Cables"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1121,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7485785662864231228,
+				"tradeGroupIDHigh:4": 2187396924325973295
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"tag:10": {
+								"MaxH:4": 20,
+								"Health:4": 20,
+								"IsAnalyzed:4": 1,
+								"Genome:10": {
+									"Chromosomes:9": [
+										{
+											"Slot:4": 0,
+											"UID0:8": "extrabees.species.ocean",
+											"UID1:8": "extrabees.species.ocean"
+										},
+										{
+											"Slot:4": 1,
+											"UID0:8": "forestry.speedSlowest",
+											"UID1:8": "forestry.speedSlowest"
+										},
+										{
+											"Slot:4": 2,
+											"UID0:8": "forestry.lifespanShorter",
+											"UID1:8": "forestry.lifespanShorter"
+										},
+										{
+											"Slot:4": 3,
+											"UID0:8": "forestry.fertilityNormal",
+											"UID1:8": "forestry.fertilityNormal"
+										},
+										{
+											"Slot:4": 4,
+											"UID0:8": "forestry.toleranceNone",
+											"UID1:8": "forestry.toleranceNone"
+										},
+										{
+											"Slot:4": 5,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:4": 7,
+											"UID0:8": "forestry.toleranceBoth1",
+											"UID1:8": "forestry.toleranceBoth1"
+										},
+										{
+											"Slot:4": 8,
+											"UID0:8": "forestry.boolTrue",
+											"UID1:8": "forestry.boolTrue"
+										},
+										{
+											"Slot:4": 9,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:4": 10,
+											"UID0:8": "extrabees.flower.water",
+											"UID1:8": "extrabees.flower.water"
+										},
+										{
+											"Slot:4": 11,
+											"UID0:8": "forestry.floweringSlowest",
+											"UID1:8": "forestry.floweringSlowest"
+										},
+										{
+											"Slot:4": 12,
+											"UID0:8": "forestry.territoryAverage",
+											"UID1:8": "forestry.territoryAverage"
+										},
+										{
+											"Slot:4": 13,
+											"UID0:8": "extrabees.effect.water",
+											"UID1:8": "extrabees.effect.water"
+										}
+									]
+								}
+							},
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "Forestry:beePrincessGE",
+							"OreDict:8": ""
+						},
+						{
+							"tag:10": {
+								"MaxH:4": 20,
+								"Health:4": 20,
+								"IsAnalyzed:4": 1,
+								"Genome:10": {
+									"Chromosomes:9": [
+										{
+											"Slot:4": 0,
+											"UID0:8": "extrabees.species.ocean",
+											"UID1:8": "extrabees.species.ocean"
+										},
+										{
+											"Slot:4": 1,
+											"UID0:8": "forestry.speedSlowest",
+											"UID1:8": "forestry.speedSlowest"
+										},
+										{
+											"Slot:4": 2,
+											"UID0:8": "forestry.lifespanShorter",
+											"UID1:8": "forestry.lifespanShorter"
+										},
+										{
+											"Slot:4": 3,
+											"UID0:8": "forestry.fertilityNormal",
+											"UID1:8": "forestry.fertilityNormal"
+										},
+										{
+											"Slot:4": 4,
+											"UID0:8": "forestry.toleranceNone",
+											"UID1:8": "forestry.toleranceNone"
+										},
+										{
+											"Slot:4": 5,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:4": 7,
+											"UID0:8": "forestry.toleranceBoth1",
+											"UID1:8": "forestry.toleranceBoth1"
+										},
+										{
+											"Slot:4": 8,
+											"UID0:8": "forestry.boolTrue",
+											"UID1:8": "forestry.boolTrue"
+										},
+										{
+											"Slot:4": 9,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:4": 10,
+											"UID0:8": "extrabees.flower.water",
+											"UID1:8": "extrabees.flower.water"
+										},
+										{
+											"Slot:4": 11,
+											"UID0:8": "forestry.floweringSlowest",
+											"UID1:8": "forestry.floweringSlowest"
+										},
+										{
+											"Slot:4": 12,
+											"UID0:8": "forestry.territoryAverage",
+											"UID1:8": "forestry.territoryAverage"
+										},
+										{
+											"Slot:4": 13,
+											"UID0:8": "extrabees.effect.water",
+											"UID1:8": "extrabees.effect.water"
+										}
+									]
+								}
+							},
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "Forestry:beeDroneGE",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ocean Bees"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5979766207122424084,
+				"tradeGroupIDHigh:4": 2234969258349117744
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32716,
+							"Count:3": 8,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Resistors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6211893698514779770,
+				"tradeGroupIDHigh:4": 2324870461010953277
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 8,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFFireJet",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFFireJet",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Fire is Cool"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8151979855454705270,
+				"tradeGroupIDHigh:4": 2496347508437697028
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 60,
+							"Count:3": 3,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Silverfish"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 550,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7162464133608694289,
+				"tradeGroupIDHigh:4": 2545802671257373786
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30001,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Hydrogen"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 546,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5462780835002749274,
+				"tradeGroupIDHigh:4": 2665768948144164116
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30707,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Oil"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 440,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8899945763906551753,
+				"tradeGroupIDHigh:4": 2759715337044443478
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 4,
+							"id:8": "Thaumcraft:blockCustomPlant",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "Thaumcraft:blockCustomPlant",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 10
+						},
+						{
+							"type:8": "farmer",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Magical Saplings"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -4878956512713250462,
+				"tradeGroupIDHigh:4": 2851399178580214429
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11880,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 40
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Rubber Ingots"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 826,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7233209231756456510,
+				"tradeGroupIDHigh:4": 2959425405873114832
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5032,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:iron_ore",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Iron Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6494411469531869056,
+				"tradeGroupIDHigh:4": 3075548050690229060
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 59,
+							"Count:3": 3,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Cave Spider"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 230,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": -7973202373084553817,
+						"questIDHigh:4": 6327679129227052174
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -5141609898475924178,
+				"tradeGroupIDHigh:4": 3098501365243202370
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 505,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 20
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Shulker"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 21,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 300,
+			"id:10": {
+				"tradeGroupIDLow:4": -6398275613071624045,
+				"tradeGroupIDHigh:4": 3509451350714765269
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:clay_ball",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Clay for Pennies"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 555,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7336235052460510259,
+				"tradeGroupIDHigh:4": 3691062517631830681
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30012,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Nitrogen"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 846,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8589559165387387085,
+				"tradeGroupIDHigh:4": 3873137491768461295
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30013,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Oxygen"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 2311,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6185601626992205159,
+				"tradeGroupIDHigh:4": 3922838451961088362
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2056,
+							"Count:3": 1,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 1000
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Indium Dust"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 440,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8108032577987767414,
+				"tradeGroupIDHigh:4": 4012189831531220477
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 35,
+							"Count:3": 1,
+							"id:8": "enhancedlootbags:lootbag",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Seed Bags"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1233,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -5714822084909401354,
+				"tradeGroupIDHigh:4": 4054259974374772034
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:ender_eye",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 240
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ender Eyes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -7717715279482793706,
+				"tradeGroupIDHigh:4": 4225595787390042355
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:blaze_rod",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Blaze Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": -8693302957682373366,
+						"questIDHigh:4": -2567739677140758553
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 213,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8449791893976220856,
+				"tradeGroupIDHigh:4": 4275762369475792571
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32182,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 200
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "More SMD Inductors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 4,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -9092426022131304709,
+				"tradeGroupIDHigh:4": 4362636526341408413
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 4,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 5,
+							"id:8": "minecraft:sapling",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "forestry",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Vanilla Saplings"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 2387,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5736424960247910044,
+				"tradeGroupIDHigh:4": 4464894235924907266
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:wheat",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "witchery:somniancotton",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "witchery:mutator",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "witchery:seedswormwood",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "witch",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Wormwood"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 422,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8080821362402546667,
+				"tradeGroupIDHigh:4": 4616430484883131944
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "AWWayofTime:reinforcedSlate",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "blood",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "T2 BM Slates"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5146008665935241180,
+				"tradeGroupIDHigh:4": 4627047919204518623
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 1,
+							"id:8": "Forestry:beehives",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Meadow Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 76,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 21600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7036388173970555310,
+				"tradeGroupIDHigh:4": 4950570324848429471
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Copper Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 440,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8378731789285706905,
+				"tradeGroupIDHigh:4": 4992445561253610254
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 36,
+							"Count:3": 1,
+							"id:8": "enhancedlootbags:lootbag",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 5
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Garden Bags"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 44,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -5022282330024590292,
+				"tradeGroupIDHigh:4": 5057974419326913552
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 66,
+							"Count:3": 3,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Witch"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -7517425302332734491,
+				"tradeGroupIDHigh:4": 5159347170331348818
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 56,
+							"Count:3": 2,
+							"id:8": "minecraft:spawn_egg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ghast"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 225,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 48000,
+			"id:10": {
+				"tradeGroupIDLow:4": -5498839954666292430,
+				"tradeGroupIDHigh:4": 5450349837546703482
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 8,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFFireJet",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:tile.TFFireJet",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.minotaurAxe",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 189,
+							"Count:3": 1,
+							"id:8": "TwilightForest:item.tfspawnegg",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 150
+						},
+						{
+							"type:8": "darkWizard",
+							"value:3": 70
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Hydra"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8344874008329633178,
+				"tradeGroupIDHigh:4": 5470206081520975915
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23301,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Brass Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 718,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 7200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7796899935526309028,
+				"tradeGroupIDHigh:4": 5508599544875928445
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "minecraft:log",
+							"OreDict:8": "logWood"
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:blockCrop",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "adventure",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Wood for Sheep?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8446138834706361365,
+				"tradeGroupIDHigh:4": 5630385190759056755
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5142,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 200
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Stainless Steel Fluid Pipes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 76,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 21600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8617917877298316615,
+				"tradeGroupIDHigh:4": 5730324588730272059
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 10,
+							"id:8": "TConstruct:oreBerries",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "farmer",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Tin Berries"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6451452568670596108,
+				"tradeGroupIDHigh:4": 5902713242381009205
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:ender_pearl",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Ender Pearl"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8235850438672384275,
+				"tradeGroupIDHigh:4": 5929497451589618055
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23356,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 200
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Magnetic Neodymium Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 4800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8750511144673075718,
+				"tradeGroupIDHigh:4": 6052516535919657784
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32045,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Central Processing Units"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -8940895640491756088,
+				"tradeGroupIDHigh:4": 6264043070516511452
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 1,
+							"id:8": "ExtraBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Nether Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 183,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6949394814874467634,
+				"tradeGroupIDHigh:4": 6406355225172919900
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 22,
+							"Count:3": 8,
+							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Logic Processors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8025661602294684606,
+				"tradeGroupIDHigh:4": 6516331556602793699
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "minecraft:tnt",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:blockITNT",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 160
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "TNT and iTNT"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 479,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7578005454057286907,
+				"tradeGroupIDHigh:4": 6570548978895114191
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5522,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "minecraft:quartz_ore",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Netherquartz Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -5974164531640371128,
+				"tradeGroupIDHigh:4": 6630841127279479696
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32101,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Good Circuit Boards"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 549,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -9120817654110373902,
+				"tradeGroupIDHigh:4": 6687784599856825625
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30740,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Light Fuel"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 34,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5681067184501789008,
+				"tradeGroupIDHigh:4": 6805134868485587270
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 32,
+							"id:8": "dreamcraft:ZincGravelOre",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Zinc Gravel Ore"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 241,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8373030686352213240,
+				"tradeGroupIDHigh:4": 6880768796930231095
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 5,
+							"id:8": "Thaumcraft:blockCustomPlant",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "darkWizard",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Vishroom"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6621110070263941947,
+				"tradeGroupIDHigh:4": 6956279470374472716
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 23355,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 120
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Magnetic Steel Rods"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 610,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -6467302626849877005,
+				"tradeGroupIDHigh:4": 7092401461566918136
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 5089,
+							"Count:3": 64,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 64,
+							"id:8": "IC2:blockOreLead",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Lead Ore exchange"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 183,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8981702172980339533,
+				"tradeGroupIDHigh:4": 7104704104552417389
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 24,
+							"Count:3": 8,
+							"id:8": "appliedenergistics2:item.ItemMultiMaterial",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Engineering Processors"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 2697,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "chemistry",
+			"cooldown:3": 600,
+			"id:10": {
+				"tradeGroupIDLow:4": -6962383307413588605,
+				"tradeGroupIDHigh:4": 7319097299822396675
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "IC2:itemCellEmpty",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 30023,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "chemist",
+							"value:3": 25
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Chlorine"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -5204768688110740212,
+				"tradeGroupIDHigh:4": 7419429424489055752
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 28880,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 10
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Rubber Rings"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -7895326952858249963,
+				"tradeGroupIDHigh:4": 7475415713971194555
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5122,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Bronze Fluid Pipes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "raw",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8321738503108510267,
+				"tradeGroupIDHigh:4": 7482077897818587995
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11335,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.01",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "smith",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Damascus Steel Ingots"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1148,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -8543116577650432060,
+				"tradeGroupIDHigh:4": 7574593932850249871
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1360,
+							"Count:3": 32,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 30
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Copper Wires"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 3221,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "farming",
+			"cooldown:3": 1200,
+			"id:10": {
+				"tradeGroupIDLow:4": -4619349719529052517,
+				"tradeGroupIDHigh:4": 7584468753205841514
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 1,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 2,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 3,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 4,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 6,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 7,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 8,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 15,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 9,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 10,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 11,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 12,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 13,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 14,
+							"Count:3": 2,
+							"id:8": "Botania:mushroom",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "flower",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Having trouble finding Botania mushrooms?"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 49,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 300,
+			"id:10": {
+				"tradeGroupIDLow:4": -4650295033948924895,
+				"tradeGroupIDHigh:4": 7961956447783177634
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "minecraft:piston",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				},
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "minecraft:sticky_piston",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 20
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Piston"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 986,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6567362948613707111,
+				"tradeGroupIDHigh:4": 7994267434210969771
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 4,
+							"Count:3": 1,
+							"id:8": "MagicBees:hive",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 50
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Infernal Hive"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 176,
+						"questIDHigh:4": 0
+					}
+				},
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 2350,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 36000,
+			"id:10": {
+				"tradeGroupIDLow:4": -8765542160574366250,
+				"tradeGroupIDHigh:4": 8068168097533346427
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 2,
+							"id:8": "HardcoreEnderExpansion:enderman_head",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "survivor",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Enderman Head"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 600,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "misc",
+			"cooldown:3": 604800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8535848914293245286,
+				"tradeGroupIDHigh:4": 8249722080323585335
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:delightedmealItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:heartybreakfastItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:rainbowcurryItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:supremepizzaItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:sausageinbreadItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:beefwellingtonItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:epicbaconItem",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 16,
+							"id:8": "harvestcraft:meatfeastpizzaItem",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "ExtraUtilities:defoliageAxe",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "cook",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Healing Axe 2.0"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -4898654434465785694,
+				"tradeGroupIDHigh:4": 8274717392587211037
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 5132,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.blockmachines",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 120
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Steel Fluid Pipes"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 333,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -5966660704359452136,
+				"tradeGroupIDHigh:4": 8506617739585799672
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "witchery:hornofthehunt",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "darkWizard",
+							"value:3": 500
+						},
+						{
+							"type:8": "witch",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Horn of the Hunt"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 3600,
+			"id:10": {
+				"tradeGroupIDLow:4": -8211821702759576697,
+				"tradeGroupIDHigh:4": 8559080038165139144
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 32039,
+							"Count:3": 16,
+							"id:8": "gregtech:gt.metaitem.03",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 60
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "RAM"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 1121,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "bees",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -6988983965900979722,
+				"tradeGroupIDHigh:4": 8750149870227900566
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"fromItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 4,
+							"id:8": "minecraft:emerald_block",
+							"OreDict:8": ""
+						},
+						{
+							"Damage:2": 0,
+							"Count:3": 32,
+							"id:8": "Forestry:royalJelly",
+							"OreDict:8": ""
+						}
+					],
+					"toItems:9": [
+						{
+							"tag:10": {
+								"MaxH:3": 50,
+								"Health:3": 50,
+								"IsAnalyzed:1": 1,
+								"Genome:10": {
+									"Chromosomes:9": [
+										{
+											"Slot:1": 0,
+											"UID0:8": "forestry.speciesMonastic",
+											"UID1:8": "forestry.speciesMonastic"
+										},
+										{
+											"Slot:1": 1,
+											"UID0:8": "forestry.speedSlower",
+											"UID1:8": "forestry.speedSlower"
+										},
+										{
+											"Slot:1": 2,
+											"UID0:8": "forestry.lifespanLong",
+											"UID1:8": "forestry.lifespanLong"
+										},
+										{
+											"Slot:1": 3,
+											"UID0:8": "forestry.fertilityLow",
+											"UID1:8": "forestry.fertilityLow"
+										},
+										{
+											"Slot:1": 4,
+											"UID0:8": "forestry.toleranceBoth1",
+											"UID1:8": "forestry.toleranceBoth1"
+										},
+										{
+											"Slot:1": 5,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:1": 7,
+											"UID0:8": "forestry.toleranceBoth1",
+											"UID1:8": "forestry.toleranceBoth1"
+										},
+										{
+											"Slot:1": 8,
+											"UID0:8": "forestry.boolFalse",
+											"UID1:8": "forestry.boolFalse"
+										},
+										{
+											"Slot:1": 9,
+											"UID0:8": "forestry.boolTrue",
+											"UID1:8": "forestry.boolTrue"
+										},
+										{
+											"Slot:1": 10,
+											"UID0:8": "forestry.flowersWheat",
+											"UID1:8": "forestry.flowersWheat"
+										},
+										{
+											"Slot:1": 11,
+											"UID0:8": "forestry.floweringFaster",
+											"UID1:8": "forestry.floweringFaster"
+										},
+										{
+											"Slot:1": 12,
+											"UID0:8": "forestry.territoryAverage",
+											"UID1:8": "forestry.territoryAverage"
+										},
+										{
+											"Slot:1": 13,
+											"UID0:8": "forestry.effectNone",
+											"UID1:8": "forestry.effectNone"
+										}
+									]
+								}
+							},
+							"Damage:2": 0,
+							"Count:3": 1,
+							"id:8": "Forestry:beeDroneGE",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "bees",
+							"value:3": 100
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Monastic Bees"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 421,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "magic",
+			"cooldown:3": 1800,
+			"id:10": {
+				"tradeGroupIDLow:4": -8820720829680841348,
+				"tradeGroupIDHigh:4": 9073790976223889808
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 0,
+							"Count:3": 8,
+							"id:8": "AWWayofTime:imbuedSlate",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "blood",
+							"value:3": 1000
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "T3 BM Slates"
+		},
+		{
+			"requirements:9": [
+				{
+					"name:8": "betterquesting",
+					"quest:10": {
+						"questIDLow:4": 160,
+						"questIDHigh:4": 0
+					}
+				}
+			],
+			"category:8": "components",
+			"cooldown:3": 2400,
+			"id:10": {
+				"tradeGroupIDLow:4": -4615562487088085683,
+				"tradeGroupIDHigh:4": 9212520479894815118
+			},
+			"maxTrades:3": -1,
+			"trades:9": [
+				{
+					"toItems:9": [
+						{
+							"Damage:2": 21300,
+							"Count:3": 4,
+							"id:8": "gregtech:gt.metaitem.02",
+							"OreDict:8": ""
+						}
+					],
+					"fromCurrency:9": [
+						{
+							"type:8": "technician",
+							"value:3": 80
+						}
+					],
+					"displayItem:10": {
+						"Damage:2": 0,
+						"Count:3": 1,
+						"id:8": "vendingmachine:placeholder",
+						"OreDict:8": ""
+					}
+				}
+			],
+			"label:8": "Bronze Rotors"
 		}
-	},
+	],
 	"version:3": 1
 }


### PR DESCRIPTION
Please do not panic at the large number of changed lines. 
This PR is purely a formatting update, and does not modify the trades nor their IDs.

Sister PR: https://github.com/GTNewHorizons/VendingMachine/pull/9
The change in the trade database format only affects newly written files, and does not break reading legacy files.

We now sorts by tradegroup id before writing to file, and won't add indices for NBTTagLists.

This change ensures that changelogs won't be massive every time a trade is changed or added (like what is happening right now), from all the tradegroups and their indices getting shuffled around
