### PR TITLE
Bee Meteor adjustments (Add missing hives and remove marble one)

### DIFF
--- a/config/BloodMagic/meteors/BeeHive.json
+++ b/config/BloodMagic/meteors/BeeHive.json
@@ -1,5 +1,7 @@
 {
   "ores": [
+    "etfuturum:honey_block:0:100",
+    "BiomesOPlenty:hive:1:95",
     "Forestry:beehives:1:40",
     "Forestry:beehives:2:40",
     "Forestry:beehives:3:40",
@@ -15,9 +17,7 @@
     "MagicBees:hive:3:20",
     "Forestry:beehives:5:8",
     "MagicBees:hive:4:8",
-    "MagicBees:hive:5:8",
-    "BiomesOPlenty:hive:1:95",
-    "etfuturum:honey_block:0:100"
+    "MagicBees:hive:5:8"
   ],
   "filler": [
     "harvestcraft:beehive:0:80"


### PR DESCRIPTION
<img width="784" height="74" alt="image" src="https://github.com/user-attachments/assets/2f17fd55-df86-4563-ac2b-b7a670fa5dee" />

My OCD compelled me to clean up the ordering in config.

<img width="433" height="131" alt="javaw_fPalQlfBtY" src="https://github.com/user-attachments/assets/a94ecf4d-e04d-4352-9359-e4db03db0350" />

Adjusted a few hives based on their coins cost and reduced pam's hives chance (not by much, but they are practically useless and can't be used anywhere with Pam's Apiary and Queen recipes disabled).

Removed Marble Hive due to not having Marble Bees to drop from them.

A few after and before screenshots: https://discord.com/channels/181078474394566657/522098956491030558/1426526725801775247