### PR TITLE
Add Cooking for Blockheads drop-off support (yummers)

### DIFF
--- a/config/bogosorter.cfg
+++ b/config/bogosorter.cfg
@@ -59,6 +59,9 @@ general {
             Barrel
             Drawer
             Crate
+            Fridge
+            Cabinet
+            Counter
          >
 
         # Enable the drop-off button in the player inventory. [default: true]


### PR DESCRIPTION
I think it would be lovely to just get back to your kitchen and drop off all the crops you harvested for cleaner management (if anyone even tries that)

<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/c3579f43-d71a-40f2-87ff-0d321cdbf9c5" />

Because of substring matching it tries to interact with Nuclear Control's counters and Open File Cabinet, but first two only accept IC2 Transformer upgrades and the last is not craftable.
Some screenshots from testing:

<details>
  <summary>Big images</summary>
  
<img width="1920" height="1017" alt="javaw_3pmffHVzk1" src="https://github.com/user-attachments/assets/9a7120ec-13ec-41b5-9522-adafd298f363" />
<img width="1920" height="1017" alt="javaw_2XjJ25n4d6" src="https://github.com/user-attachments/assets/20fb0f9b-1193-4ea5-bacf-4a979a49cc6a" />
  
</details>

