### PR TITLE
fix gt diesel pollution config

### DIFF
--- a/config/GregTech/Pollution.cfg
+++ b/config/GregTech/Pollution.cfg
@@ -56,12 +56,14 @@ pollution {
     I:pollutionCharcoalPitPerSecond=100
 
     # Pollution released by tier, with the following formula: PollutionBaseDieselGeneratorPerSecond * PollutionDieselGeneratorReleasedByTier[Tier]
-    # The first entry has meaning as it is here to since machine tier with array index: LV is 1, etc. [default: [0.1, 1.0, 0.9, 0.8]]
+    # The first entry has meaning as it is here to since machine tier with array index: LV is 1, etc. [default: [0.1, 1.0, 0.9, 0.8, 0.7, 0.6]]
     D:pollutionDieselGeneratorReleasedByTier <
         0.1
         1.0
         0.9
         0.8
+        0.7
+        0.6
      >
 
     # Controls the pollution released per second by the EBF. [range: -2147483648 ~ 2147483647, default: 400]


### PR DESCRIPTION
add missing ev/iv numbers, the incorrect length actually throws an error in the log and makes the config non-functional.

Goes together with a PR in the GT repo for defaults: https://github.com/GTNewHorizons/GT5-Unofficial/pull/5115