### PR TITLE
Fix branch specification for questbook i18n workflow

### DIFF
--- a/.github/workflows/questbook-i18n.yml
+++ b/.github/workflows/questbook-i18n.yml
@@ -2,8 +2,7 @@ name: Quest Book I18N
 
 on:
   push:
-    branches:
-      - [ master, release/** ]
+    branches: [ master, release/** ]
     paths:
       - config/betterquesting/DefaultQuests/QuestLinesOrder.txt
       - config/betterquesting/DefaultQuests/QuestLines/*.json


### PR DESCRIPTION
I made an oopsie. GitHub is complaining: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/actions/runs/18722324879/workflow

follow-up for #22168