### PR TITLE
Adjusted value in AE2 config to reflect changes made in AE2 [#725](https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/725)

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -395,7 +395,7 @@ tickrates {
     I:AnnihilationPlane.min=2
     I:ExportBus.max=60
     I:ExportBus.min=5
-    I:IOPort.max=5
+    I:IOPort.max=1
     I:IOPort.min=1
     I:ImportBus.max=40
     I:ImportBus.min=5


### PR DESCRIPTION
Title. Changed `IOPort.max` key in `tickrates` to `1`.