### PR TITLE
Netherrack Froth Count Modification

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier6LuV-AAAAAAAAAAAAAAAAAAAACA==/NetherrackFroth-WNC6mX67QGG5gpjX0YkvDw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier6LuV-AAAAAAAAAAAAAAAAAAAACA==/NetherrackFroth-WNC6mX67QGG5gpjX0YkvDw==.json
@@ -84,7 +84,7 @@
       "partialMatch:1": 1,
       "requiredItems:9": {
         "0:10": {
-          "Count:3": 1,
+          "Count:3": 8,
           "Damage:2": 0,
           "OreDict:8": "",
           "id:8": "miscutils:FrothNetherrackflotation"


### PR DESCRIPTION
### Changes:
- Changes quest to reflect the output change 1 -> 8 Netherrack Froth found in https://github.com/GTNewHorizons/GT5-Unofficial/pull/5246

Doing this change standalone just in case it gets ported to 2.8 so it's an easy cherry.
(Also, I'm an S tier PR farmer how can I resist)