### PR TITLE
bring the altar down to earth

### DIFF
--- a/config/amazingtrophies/trophies/magic/bloodmagic/03_blood_altar.json
+++ b/config/amazingtrophies/trophies/magic/bloodmagic/03_blood_altar.json
@@ -6,6 +6,7 @@
   },
   "model": {
     "type": "item",
-    "registryName": "AWWayofTime:Altar"
+    "registryName": "AWWayofTime:Altar",
+    "yOffset": -0.3
   }
 }


### PR DESCRIPTION
followup to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/22420
offsets where fixed in https://github.com/GTNewHorizons/Amazing-Trophies/pull/18, so now we can use them to bring floating blocks down to the ground. 