### PR TITLE
Fix BloodMagic Meteor warnings

### DIFF
--- a/config/BloodMagic/meteors/SkyStoneMeteor.json
+++ b/config/BloodMagic/meteors/SkyStoneMeteor.json
@@ -5,7 +5,7 @@
     "ExtraUtilities:color_lightgem:15:80",
     "ExtraUtilities:color_obsidian:15:80",
     "chisel:grimstone:14:40",
-    "appliedenergistics2:tile.OreQuart:0:20",
+    "appliedenergistics2:tile.OreQuartz:0:20",
     "appliedenergistics2:tile.OreQuartzCharged:0:25",
     "GalacticraftAmunRa:tile.baseBlockRock:0:10"
   ],

--- a/config/BloodMagic/meteors/TnTMeteor.json
+++ b/config/BloodMagic/meteors/TnTMeteor.json
@@ -3,7 +3,7 @@
     "IC2:blockITNT:0:90",
     "BloodArsenal:blood_tnt:0:80",
     "minecraft:tnt:0:80",
-    "minecraft:redstone_lamp:0:30:"
+    "minecraft:redstone_lamp:0:30"
   ],
   "filler": [
     "chisel:redstone_block:14:10"


### PR DESCRIPTION
Fixes a few spelling errors in recently added BloodMagic meteors, causing some warnings in the log