### PR TITLE
Place the vending machine nei tab next to quests

### DIFF
--- a/config/NEI/handlerordering.csv
+++ b/config/NEI/handlerordering.csv
@@ -272,8 +272,9 @@ extreme,50
 ic2.neiIntegration.core.recipehandler.ScrapboxRecipeHandler,75
 enhancedlootbags,99
 bq_quest,100
-gt.recipe.fluidcanner,100
-forestry.factory.recipes.nei.NEIHandlerBottler,100
+com.cubefury.vendingmachine.integration.nei.NeiRecipeHandler,101
+gt.recipe.fluidcanner,110
+forestry.factory.recipes.nei.NEIHandlerBottler,110
 gt.recipe.scanner,500
 gt.recipe.researchStation,500
 gt.recipe.spaceResearch,500


### PR DESCRIPTION
The tab position for the new vending NEI tab had not been adjusted yet.

with this it will be directly after lootbags and questbook towards the end.

<img width="311" height="104" alt="image" src="https://github.com/user-attachments/assets/b3224662-3d52-4997-bc3d-b866be218355" />
