### PR TITLE
Coke Oven Quest Fixes

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/BiodieselAlterna-AAAAAAAAAAAAAAAAAAAMGw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/BiodieselAlterna-AAAAAAAAAAAAAAAAAAAMGw==.json
@@ -24,7 +24,7 @@
       "isSilent:1": 0,
       "lockedProgress:1": 0,
       "name:8": "Biodiesel Alternative",
-      "questLogic:8": "AND",
+      "questLogic:8": "OR",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,
       "simultaneous:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/FasterCharcoal-AAAAAAAAAAAAAAAAAAAMGA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/FasterCharcoal-AAAAAAAAAAAAAAAAAAAMGA==.json
@@ -8,13 +8,13 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "Even if you have more wood, this won\u0027t help your power issues that much. Using it directly as fuel isn\u0027t going to do much for you as you move forward, and turning it into Charcoal will be very important. You have already built a Coke Oven, maybe more than one, but each one takes 90 seconds to produce one Charcoal, an abysmal rate. Unfortunately, there isn\u0027t any faster option in this tier, so you will have to build more of these ovens. How many, exactly?\n\nThere are many different goals you might want to go for, but a good metric for your power needs is a setup with 19 Coke Ovens. This number will create both Charcoal and Creosote Oil at a rate that will run two max-sized LP (Low Pressure) Railcraft Boilers, one solid and one liquid, with the quest for those coming right after this one. If you automate this entire setup, it will produce around 2 amps of MV, which are equivalent to 8 amps of LV, plenty of power for this tier and enough to advance you to the next one.\n\nAfter building these Coke Ovens, you will need to automate them. There are a few ways to do this, but one of the cheapest ones is to use Item Pipes, made with Tin for example, with a Conveyor Module in the wood chest/drawer to put the wood in the ovens, and then one Hopper below each oven, into more Item Pipes, to gather the Charcoal. The Creosote is a bit harder to extract, but you can do it with Tinkers\u0027 Faucets on the side of each Coke Oven, with a Wooden Fluid Pipe directly under the faucet. You will need to keep reactivating them with redstone, which means you\u0027ll also need a redstone clock (there\u0027s a block dedicated to this purpose, named Redstone Clock, from Extra Utilities).",
+      "desc:8": "Even if you have more wood, this won\u0027t help your power issues that much. Using it directly as fuel isn\u0027t going to do much for you as you move forward, and turning it into Charcoal will be very important. You have already built a Coke Oven, maybe more than one, but each one takes 90 seconds to produce one Charcoal, an abysmal rate. Unfortunately, there isn\u0027t any faster option in this tier, so you will have to build more of these ovens. How many, exactly?\n\nThere are many different goals you might want to go for, but a good metric for your power needs is a setup with 19 Coke Ovens. This number will create both Charcoal and Creosote Oil at a rate that will run two max-sized LP (Low Pressure) Railcraft Boilers, one solid and one liquid, with the quest for those coming right after this one. If you automate this entire setup, it will produce around 2 amps of MV, which are equivalent to 8 amps of LV, plenty of power for this tier and enough to advance you to the next one.\n\nAfter building these Coke Ovens, you will want to automate them. You can do this using a Coke Oven Hatch. A screwdriver will change the modes between input, output, and fluid output. You can use hoppers and item pipes to push and pull items from the hatches. Additionally. the hatch itself will automatically dispense fluid so you can simply hook that directly to a pipeline, no faucets or pumps required.",
       "globalShare:1": 0,
       "icon:10": {
         "Count:3": 1,
-        "Damage:2": 7,
+        "Damage:2": 236,
         "OreDict:8": "",
-        "id:8": "Railcraft:machine.alpha"
+        "id:8": "gregtech:gt.blockmachines"
       },
       "isMain:1": 0,
       "isSilent:1": 0,
@@ -75,10 +75,16 @@
       "partialMatch:1": 1,
       "requiredItems:9": {
         "0:10": {
-          "Count:3": 494,
-          "Damage:2": 7,
+          "Count:3": 19,
+          "Damage:2": 236,
           "OreDict:8": "",
-          "id:8": "Railcraft:machine.alpha"
+          "id:8": "gregtech:gt.blockmachines"
+        },
+        "1:10": {
+          "Count:3": 265,
+          "Damage:2": 0,
+          "OreDict:8": "",
+          "id:8": "gregtech:gt.blockcasings12"
         }
       },
       "taskID:8": "bq_standard:retrieval"

--- a/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/TheBenzeneTier-AAAAAAAAAAAAAAAAAAAMGg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/TheBenzeneTier-AAAAAAAAAAAAAAAAAAAMGg==.json
@@ -24,7 +24,7 @@
       "isSilent:1": 0,
       "lockedProgress:1": 0,
       "name:8": "The Benzene Tier",
-      "questLogic:8": "AND",
+      "questLogic:8": "OR",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,
       "simultaneous:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/WhyOneCokeOvenWh-AAAAAAAAAAAAAAAAAAACuw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/MultiblockGoals-AAAAAAAAAAAAAAAAAAAADA==/WhyOneCokeOvenWh-AAAAAAAAAAAAAAAAAAACuw==.json
@@ -12,7 +12,7 @@
   "properties:10": {
     "betterquesting:10": {
       "autoClaim:1": 0,
-      "desc:8": "Your bricked blast furnace uses coal like hell and your steam boilers do too? Well it\u0027s time to make more coke ovens and automate them a bit. The Coke Oven Hatch, Wooden Fluid Pipes, and Tin Item Pipes will help you reach your goal.\n\nSince this is a GT multiblock, it can wallshare bricks and hatches. The amount of bricks required for this quest is the minimum for creating 10 wallshared Coke Ovens.\n\nRemember that tin item pipes require a steel wrench to dismantle them.\n\n[note]Search NEI for a more efficient way to make coke oven bricks.[/note]\n\n[warn]The whole coke-oven process generates a lot of pollution, so consider putting it further away.[/warn]",
+      "desc:8": "Your Bricked Blast Furnace uses coal like hell and your steam boilers do too? Well it\u0027s time to make more coke ovens and automate them a bit. The Coke Oven Hatch, Wooden Fluid Pipes, and Tin Item Pipes will help you reach your goal.\n\nSince this is a GT multiblock, it can wallshare bricks and hatches. The amount of bricks required for this quest is the minimum for creating 10 wallshared Coke Ovens.\n\nRemember that tin item pipes require a steel wrench to dismantle them.\n\n[note]Search NEI for a more efficient way to make coke oven bricks.[/note]\n\n[warn]The whole coke-oven process generates a lot of pollution, so consider putting it further away.[/warn]",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,
@@ -113,7 +113,7 @@
           "id:8": "gregtech:gt.blockmachines"
         },
         "1:10": {
-          "Count:3": 135,
+          "Count:3": 136,
           "Damage:2": 0,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockcasings12"
@@ -130,7 +130,7 @@
       "partialMatch:1": 1,
       "requiredItems:9": {
         "0:10": {
-          "Count:3": 11,
+          "Count:3": 9,
           "Damage:2": 237,
           "OreDict:8": "",
           "id:8": "gregtech:gt.blockmachines"


### PR DESCRIPTION
### Changes:
- Fixes amount in 10x Coke Oven quest (turns out I was wrong)
- Fixes amount, description & item in "Faster Charcoal"
- Makes "Benzene Tier" and "Biodiesel Alternative" OR unlock with MV again