### PR TITLE
Quest Patches 12.9 (2.8.3)

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/BiodieselAlterna-AAAAAAAAAAAAAAAAAAAMGw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/BiodieselAlterna-AAAAAAAAAAAAAAAAAAAMGw==.json
@@ -24,7 +24,7 @@
       "isSilent:1": 0,
       "lockedProgress:1": 0,
       "name:8": "Biodiesel Alternative",
-      "questLogic:8": "AND",
+      "questLogic:8": "OR",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,
       "simultaneous:1": 0,

--- a/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/TheBenzeneTier-AAAAAAAAAAAAAAAAAAAMGg==.json
+++ b/config/betterquesting/DefaultQuests/Quests/BiofortheMasses-AAAAAAAAAAAAAAAAAAAAFQ==/TheBenzeneTier-AAAAAAAAAAAAAAAAAAAMGg==.json
@@ -24,7 +24,7 @@
       "isSilent:1": 0,
       "lockedProgress:1": 0,
       "name:8": "The Benzene Tier",
-      "questLogic:8": "AND",
+      "questLogic:8": "OR",
       "repeatTime:3": -1,
       "repeat_relative:1": 1,
       "simultaneous:1": 0,


### PR DESCRIPTION
Switches two AND conditional to OR to allow MV players to skip the 19x coke oven quest like before.