### PR TITLE
Increase item loading timeout

### DIFF
--- a/config/NEI/client.cfg
+++ b/config/NEI/client.cfg
@@ -147,7 +147,7 @@ inventory.subsets
 	#Subsets Widget Position
 	widgetPosition=true
 }
-itemLoadingTimeout=500
+itemLoadingTimeout=5000
 keys.gui.back=14
 keys.gui.bookmark=30
 keys.gui.bookmark_pull_items=47


### PR DESCRIPTION
Seems like there's still the issue of the timeout triggering before every item gets loaded, which requires a game restart. The overall reward of a higher item loading timeout seem to heavily outweigh the risks, so this is just a simple change to make it more consistent.

Should probably be added for 2.8.3