### PR TITLE
add compressed chest to shulker blacklist

### DIFF
--- a/config/etfuturum/functions.cfg
+++ b/config/etfuturum/functions.cfg
@@ -170,6 +170,7 @@ settings {
         DQMIIINext:ItemOokinaFukuroG
         DQMIIINext:ItemOokinaFukuroR
         DQMIIINext:ItemOokinaFukuroY
+        DraconicEvolution:draconiumChest
         ExtraSimple:bedrockium
         ExtraSimple:bedrockiumBlock
         ExtraSimple:goldenBag


### PR DESCRIPTION
backpack/dolly/etc are all there, but this one was missed.

(was tested)