### PR TITLE
prevent adventure backpacks overlapping effects

### DIFF
--- a/config/adventurebackpack.cfg
+++ b/config/adventurebackpack.cfg
@@ -66,7 +66,7 @@ graphics {
         B:"Enable Overlay"=true
 
         # Horizontal indent from the window border [range: 0 ~ 1000, default: 2]
-        I:"Indent Horizontal"=2
+        I:"Indent Horizontal"=36
 
         # Vertical indent from the window border [range: 0 ~ 500, default: 2]
         I:"Indent Vertical"=2
@@ -86,7 +86,7 @@ graphics {
         B:"Enable Overlay"=true
 
         # Horizontal indent from the window border [range: 0 ~ 1000, default: 2]
-        I:"Indent Horizontal"=2
+        I:"Indent Horizontal"=36
 
         # Vertical indent from the window border [range: 0 ~ 500, default: 1]
         I:"Indent Vertical"=1


### PR DESCRIPTION
If adventure backpack is equipped, tanks will overlap with effects on the bottom right corner of the screen. This moves them to the left so the effect times are visible. Seems to work fine across GUI scales.