### PR TITLE
Fix Zinc Gravel Exchange VM Quest Unlock

### DIFF
--- a/config/vendingmachine/tradeDatabase.json
+++ b/config/vendingmachine/tradeDatabase.json
@@ -7891,7 +7891,7 @@
 					"name:8": "betterquesting",
 					"quest:10": {
 						"questIDHigh:4": 0,
-						"questIDLow:4": 34
+						"questIDLow:4": 1866
 					}
 				}
 			],


### PR DESCRIPTION
Old quest was deleted, moved to real quest:

<img width="2461" height="1214" alt="image" src="https://github.com/user-attachments/assets/5b3ef988-35b6-42c1-b0be-d886fea9de66" />
