### PR TITLE
Remove Useless Loot

### DIFF
--- a/config/TooMuchLoot/loot/mineshaftCorridor.xml
+++ b/config/TooMuchLoot/loot/mineshaftCorridor.xml
@@ -34,7 +34,6 @@
     <loot item="minecraft:hopper_minecart" damage="0" weight="5" count_min="1" count_max="1"/>
     <loot item="Railcraft:part.tie" damage="0" weight="20" count_min="4" count_max="16"/>
     <loot item="Railcraft:fuel.coke" damage="0" weight="20" count_min="4" count_max="16"/>
-    <loot item="Railcraft:part.gear" damage="3" weight="5" count_min="1" count_max="8"/>
     <loot item="Railcraft:cube" damage="2" weight="5" count_min="1" count_max="1"/>
     <loot item="Railcraft:cart.tnt.wood" damage="0" weight="5" count_min="1" count_max="3"/>
     <loot item="Railcraft:cart.work" damage="0" weight="8" count_min="1" count_max="1"/>

--- a/config/TooMuchLoot/loot/railcraft_workshop.xml
+++ b/config/TooMuchLoot/loot/railcraft_workshop.xml
@@ -21,7 +21,6 @@
     <loot item="Railcraft:part.rail" damage="3" weight="20" count_min="6" count_max="18"/>
     <loot item="Railcraft:part.rail" damage="4" weight="20" count_min="6" count_max="18"/>
     <loot item="Railcraft:fuel.coke" damage="0" weight="20" count_min="4" count_max="16"/>
-    <loot item="Railcraft:part.gear" damage="3" weight="5" count_min="1" count_max="8"/>
     <loot item="Railcraft:cart.tnt.wood" damage="0" weight="5" count_min="1" count_max="3"/>
     <loot item="Railcraft:cart.work" damage="0" weight="8" count_min="1" count_max="1"/>
     <loot item="Railcraft:tool.surveyor" damage="0" weight="5" count_min="1" count_max="1"/>


### PR DESCRIPTION
Removes "Tin Gear Bushing" from loot table, it has no purpose in this modpack. If it gets one later we can add it back. 

Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23297