### PR TITLE
Reduce Fusewood Rarity

### DIFF
--- a/config/Natura.cfg
+++ b/config/Natura.cfg
@@ -124,7 +124,7 @@ worldgen {
     I:"Darkwood Tree Spawn Rarity"=10
     I:"Duskberry Spawn Range"=100
     I:"Duskberry Spawn Rarity"=18
-    I:"Fusewood Tree Spawn Rarity"=50
+    I:"Fusewood Tree Spawn Rarity"=30
     I:"Ghostwood Tree Spawn Rarity"=10
     I:"Maloberry Spawn Range"=64
     I:"Maloberry Spawn Rarity"=40


### PR DESCRIPTION
These "need" to be gathered for an early game quest and rarity 50 makes the goal quite obscene. After some testing 30 is still rare and offers 2x the exploration challenge as the other trees in that quest, without being a needlessly difficult task.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23385