### PR TITLE
Remove AE2FC custom tooltips and storage bus priorities

### DIFF
--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -314,29 +314,5 @@
     <ToolTip ItemName="appliedenergistics2:item.ItemMultiPart:220" ToolTip="Preconfigured storage priority: 22" NBT='{priority: 22}'/>
     <ToolTip ItemName="appliedenergistics2:item.ItemMultiPart:220" ToolTip="Preconfigured storage priority: 23" NBT='{priority: 23}'/>
     <ToolTip ItemName="appliedenergistics2:item.ItemMultiPart:220" ToolTip="Preconfigured storage priority: 24" NBT='{priority: 24}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 1" NBT='{priority: 1}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 2" NBT='{priority: 2}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 3" NBT='{priority: 3}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 4" NBT='{priority: 4}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 5" NBT='{priority: 5}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 6" NBT='{priority: 6}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 7" NBT='{priority: 7}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 8" NBT='{priority: 8}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 9" NBT='{priority: 9}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 10" NBT='{priority: 10}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 11" NBT='{priority: 11}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 12" NBT='{priority: 12}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 13" NBT='{priority: 13}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 14" NBT='{priority: 14}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 15" NBT='{priority: 15}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 16" NBT='{priority: 16}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 17" NBT='{priority: 17}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 18" NBT='{priority: 18}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 19" NBT='{priority: 19}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 20" NBT='{priority: 20}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 21" NBT='{priority: 21}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 22" NBT='{priority: 22}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 23" NBT='{priority: 23}'/>
-    <ToolTip ItemName="ae2fc:part_fluid_storage_bus" ToolTip="Preconfigured storage priority: 24" NBT='{priority: 24}'/>
 
 </CustomToolTips>


### PR DESCRIPTION
Deleted preconfigured storage priority tooltips for 'ae2fc:part_fluid_storage_bus' items.

Obsolete because the text has been moved to [AE2FluidCraft-Rework](https://github.com/GTNewHorizons/AE2FluidCraft-Rework) mod itself https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/398