### PR TITLE
Decrease Dream weaver buff Sleep % requirement from 100% to 25%

### DIFF
--- a/config/witchery.cfg
+++ b/config/witchery.cfg
@@ -61,7 +61,7 @@ general {
         mycelium
      >
     D:NewFairestOfThemAllSpawnChance=0.01
-    I:PercentageOfPlayersSleepingForBuff=100
+    I:PercentageOfPlayersSleepingForBuff=25
     I:PotionStartID=32
     B:Render3dGlintEffect=true
     B:RenderHuntsmanGlintEffect=true


### PR DESCRIPTION
Given that most servers set the sleepvote to 25%, leaving  this at a default of 100% makes crafting any dream weavers, aside from the nightmares one, on a server with any real player base almost entirely pointless.