### PR TITLE
replacements for API.hideitem calls from NEIGTNewHorizonsConfig.java

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -14,6 +14,61 @@
 #
 # example: minecraft:potion 16384-16462,!16386 | $oreiron | tag.color=red
 #
+Avaritia:Neutronium_Compressor
+BiblioCraft:BiblioClipboard
+EnderZoo:enderZooIcon
+ExtraBees:misc 19-25
+ExtraTrees:multifence
+ForgeRelocation:relocation.blockmovingrow
+GraviSuite:BlockRelocatorPortal
+HardcoreEnderExpansion:death_flower_pot
+HardcoreEnderExpansion:corrupted_energy_high
+HardcoreEnderExpansion:corrupted_energy_low
+HardcoreEnderExpansion:biome_core
+HardcoreEnderExpansion:enhanced_brewing_stand_block
+HardcoreEnderExpansion:temple_end_portal
+HardcoreEnderExpansion:laser_beam
+HardcoreEnderExpansion:item_special_effects
+IC2:itemCellEmpty 8
+Mantle:mantleBook
+Thaumcraft:blockWarded
+Thaumcraft:blockEldritchNothing
+ThaumicHorizons:vatInterior
+ThaumicHorizons:evanescent
+ThaumicHorizons:portalTH
+ThaumicHorizons:syringeInjection 1
+ThaumicHorizons:syringeInjection 15
+ThaumicHorizons:dummyVat
+ThaumicMachina:metaphysicalBrick
+ThaumicMachina:metaphysicalRose
+ThaumicMachina:wandCore
+ThaumicTinkerer:gaseousLight
+ThaumicTinkerer:gaseousShadow
+ThaumicTinkerer:infusedGrainBlock
+ThaumicTinkerer:nitorGas
+TwilightForest:tile.TFBossSpawner 5-15
+TwilightForest:tile.TFTowerTranslucent 5-15
+TwilightForest:tile.TFTrophy
+TwilightForest:tile.TFUncraftingTable
+WarpTheory:blockVanish
+appliedenergistics2:tile.BlockPaint
+chisel:amber
+chisel:bloodBrick
+harvestcraft:oven
+harvestcraft:churn
+harvestcraft:quern
+malisisdoors:null
+opensecurity:SecurityDoor
+opensecurity:SecurityDoorPrivate
+sleepingbag:sleepingBagBlock
+BiomesOPlenty:misc 6-9
+MagicBees:capsule.magic
+MagicBees:capsule.void
+ForbiddenMagic:FMResource 1
+Natura:barleyFood 8
+tectech:ForgeOfGodsRenderBlock
+tectech:Eye of Harmony Renderer
+
 minecraft:portal
 minecraft:end_portal
 r/minecraft:fire$/
@@ -54,6 +109,11 @@ r/^Genetics:serumArray$/ !tag.genes.0.allele=forestry.speciesForest
 GraviSuite:itemPlasmaCell
 TConstruct:fluid.molten.
 tectech:item.em.debugContainer
+gregtech:gt.nanoforgerenderer
+gregtech:gt.blackholerenderer
+gregtech:gt.wormholerenderer
+gregtech:gt.dronerenderer
+GoodGenerator:antimatterRenderBlock
 
 # IC2 Dusts
 IC2:itemDust  0 # Bronze


### PR DESCRIPTION
Added items to hiddenitems.cfg as described in [this](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23680) issue

harvestcraft:ovenon, churnon and quernon do not show up in NEI and their normal versions are unused anyway so I disabled harvestcraft:oven, churn and quern instead

also removed the aroma1997 entry since its not in the pack