### PR TITLE
Hide IC2 Toolbox From NEI

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -238,6 +238,7 @@ IC2:blockHarz
 IC2:itemIronBlockCuttingBlade
 IC2:itemAdvIronBlockCuttingBlade
 IC2:itemDiamondBlockCuttingBlade
+IC2:itemToolbox
 
 # Project Red Ingots
 projectred.core.part 10 # Red Alloy


### PR DESCRIPTION
Decommissioned now in favor of new toolbox