### PR TITLE
Changes Gaia Meteor To Shard of Laputa T1 instead of T20

### DIFF
--- a/config/BloodMagic/meteors/BotGaia.json
+++ b/config/BloodMagic/meteors/BotGaia.json
@@ -17,6 +17,6 @@
   ],
   "radius": 7,
   "cost": 1000000001,
-  "focusItem": "Botania:laputaShard:19",
+  "focusItem": "Botania:laputaShard:0",
   "fillerChance": 50
 }


### PR DESCRIPTION
As title states. This was discussed in [metadev](https://discord.com/channels/181078474394566657/939305179524792340/1485694148395798591) (long convo). The conclusion reached was essentially that gating the meteor behind 20 infusion recipes was arbitrary since it doesn't add a challenge or relative cost. Using a T1 maintains the same cost gate (Blood Orb of Armok & Gaia Ingot) and makes the automation appealing to use without disrupting balance or changing the Laputa recipes.

I will adjust the questbook to account for the change in the patches