### PR TITLE
Add tinkersdefense unused/broken blocks into hiddenitems.cfg

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -323,6 +323,11 @@ TConstruct:materials 10 # Tin
 TConstruct:materials 11 # Aluminum
 TConstruct:materials 16 # Steel
 
+# Tinker's Defense
+tinkersdefense:Block_CrestMount
+tinkersdefense:Block_ArmorAnvil
+tinkersdefense:Block_JewelersBench
+
 # Amun-Ra Ingots
 GalacticraftAmunRa:item.baseItem 10 # Lead
 GalacticraftAmunRa:item.baseItem 12 # Steel


### PR DESCRIPTION
No crafting recipe uses for these. Broken textures. No point of having them bloating the NEI

<img width="949" height="721" alt="Screenshot 2026-04-05 214121" src="https://github.com/user-attachments/assets/1e3c2ce5-2204-4d8e-b0e0-50d9219adf53" />
