### PR TITLE
Change default position of ESM button

### DIFF
--- a/config/extremesoundmuffler.cfg
+++ b/config/extremesoundmuffler.cfg
@@ -1,0 +1,41 @@
+# Configuration file
+
+anchors {
+    # Disable the Anchors? [default: false]
+    B:disableAnchors=false
+}
+
+
+general {
+    # Volume set when pressed the mute button by default
+    D:defaultMuteVolume=0.0
+
+    # Blacklisted Sounds - add the name of the sounds to blacklist, separated with comma [default: [ui.], [music.], [ambient.]]
+    S:forbiddenSounds <
+        ui.
+        music.
+        ambient.
+     >
+
+    # Allow the "ALL" sounds list to include the blacklisted sounds? [default: false]
+    B:lawfulAllList=false
+
+    # Set to true to move the muffle and play buttons to the left side of the GUI [default: false]
+    B:leftButtons=false
+
+    # Show tips in the Muffler screen? [default: true]
+    B:showTip=true
+
+    # Whether or not use the dark theme [default: false]
+    B:useDarkTheme=false
+}
+
+
+inventory_button {
+    # Disable the Muffle button in the player inventory? [default: false]
+    B:disableInventoryButton=false
+    I:invButtonX=67
+    I:invButtonY=8
+}
+
+


### PR DESCRIPTION
The current default position overlaps with some stuff in gtnh

Before:
<img width="201" height="159" alt="esm_btn_before" src="https://github.com/user-attachments/assets/9ac6ad68-908e-45e1-892b-fba3226e3b6b" />
After:
<img width="198" height="167" alt="esm_btn_new" src="https://github.com/user-attachments/assets/706078a2-1908-432c-b6df-5cb9b7e28fe5" />

