### PR TITLE
Fix soldering iron quest task NBT

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/ForestryandMulti-AAAAAAAAAAAAAAAAAAAAEg==/ChangingYourFore-AAAAAAAAAAAAAAAAAAACSA==.json
+++ b/config/betterquesting/DefaultQuests/Quests/ForestryandMulti-AAAAAAAAAAAAAAAAAAAAEg==/ChangingYourFore-AAAAAAAAAAAAAAAAAAACSA==.json
@@ -130,10 +130,8 @@
           "OreDict:8": "",
           "id:8": "Forestry:solderingIron",
           "tag:10": {
-            "Slots:10": {
-              "1:8": ""
-            },
-            "UID:4": 109547956
+            "Slots:10": {},
+            "UID:3": -165950514
           }
         }
       },


### PR DESCRIPTION
The NBT for the soldering iron is incorrect and causes a crash if you attempt to use it after cheating in the quest task item. I confirmed the crafted soldering iron is still detected after this change.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23872