### PR TITLE
Removes Project From QB Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/003-propose-questbook-change.yml
+++ b/.github/ISSUE_TEMPLATE/003-propose-questbook-change.yml
@@ -3,8 +3,6 @@ description: Suggest an addition, amendment, or removal of a quest.
 labels:
   - "Status: Triage"
   - "Type: Quest"
-projects:
-  - "GTNewHorizons/18"
 
 body:
   - type: markdown


### PR DESCRIPTION
Unfortunately only works if user has write access. Found another way around it though using the project workflows