### PR TITLE
Change potion IDs of ThaumicHorizons

### DIFF
--- a/config/ThaumicHorizons.cfg
+++ b/config/ThaumicHorizons.cfg
@@ -13,3 +13,21 @@ general {
 }
 
 
+potions {
+    # Potion ID for the Shock Potion
+    I:shockPotionID=135
+
+    # Potion ID for the Sythesis Potion
+    I:synthesisPotionID=136
+
+    # Potion ID for the Vacuum
+    I:vacuumPotionID=137
+
+    # Potion ID for the VisBoost Potion
+    I:visboostPotionID=138
+
+    # Potion ID for the VisRegen Potion
+    I:visregenPotionID=139
+}
+
+


### PR DESCRIPTION
GTNewHorizons/ThaumicHorizons/pull/99 changed the timing of effect loading. 
This altered the default ID assignment for effects, causing some effects to be overridden by mods that load later. 
I have modified the potion IDs in ThaumicHorizons, which should resolve the issue described in Fixes #23616