### PR TITLE
add mudballs to digger backpack (Forestry)

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -12236,6 +12236,7 @@ backpacks {
             BiomesOPlenty:longGrass:0
             BiomesOPlenty:mud
             BiomesOPlenty:mud:0
+            BiomesOPlenty:mudball
             BiomesOPlenty:newBopDirt
             BiomesOPlenty:newBopGrass
             BiomesOPlenty:originGrass


### PR DESCRIPTION
just added BiomesOPlenty:mudball to backpack.cfg, specifically digger backpacks for consistency with "minecraft:clay"'s placement