### PR TITLE
update minimum amount of ram required to boot the pack

### DIFF
--- a/config/CodeChickenCore.cfg
+++ b/config/CodeChickenCore.cfg
@@ -15,7 +15,7 @@ checks
 	#If set to true, check RAM available for Minecraft before continuing to load
 	checkRAM=true
 	#Amount of RAM minimum this modpack needs to load
-	minRAM=3GB
+	minRAM=2GB
 	#Name of the modpack
 	modPack=GTNH
 	#Lower bound of recommended RAM
@@ -23,7 +23,7 @@ checks
 	#Upper bound of recommended RAM
 	recRAMUpper=6GB
 	#Webpage describing RAM settings
-	wiki=See <a href="https://gtnh.miraheze.org/m/3S2">the Wiki</a> for details.
+	wiki=See <a href="https://wiki.gtnewhorizons.com/wiki/Low_End_PCs">the Wiki</a> for details.
 }
 
 #Various tweaks that can be applied to game mechanics.


### PR DESCRIPTION
- Updated the minimum amount of RAM from 3GBs to 2GBs (the recommanded min amount of RAM is still 4GBs, we need more testing in solo, MP for sure runs fine with 3 GBs now)
- Updated the link to the wiki (the page is severely outdated tho, we'll need to revamp it later)