### PR TITLE
Allowed Bone Binding to be craftable

### DIFF
--- a/config/IguanaTinkerTweaks/restrictions.cfg
+++ b/config/IguanaTinkerTweaks/restrictions.cfg
@@ -33,6 +33,7 @@ toolparts {
         Bone:axe
         Bone:largeguard
         Bone:crossbar
+        Bone:binding
         Bone:knifeblade
         Bone:arrowhead
         Bone:bowlimb


### PR DESCRIPTION
The Bone Binding is uncraftable within the Part Builder, which didn't seem intentional.
So I've updated the allowed list.

If this was an intentional design choice, my mistake