### PR TITLE
Remove harvest info from WAWLA

### DIFF
--- a/config/Waila.cfg
+++ b/config/Waila.cfg
@@ -135,10 +135,10 @@ modules {
     B:wawla.furnace.fuel=true
     B:wawla.furnace.input=true
     B:wawla.furnace.output=true
-    B:wawla.harvest.showHarvest=true
+    B:wawla.harvest.showHarvest=false
     B:wawla.harvest.showProgress=true
-    B:wawla.harvest.showTier=true
-    B:wawla.harvest.showTool=true
+    B:wawla.harvest.showTier=false
+    B:wawla.harvest.showTool=false
     B:wawla.horse.showJump=true
     B:wawla.horse.showSpeed=true
     B:wawla.info.showHardness=false


### PR DESCRIPTION
The information is duplicated as WAILA Harvestability already shows the exact same information.

Before:
<img width="550" height="323" alt="image" src="https://github.com/user-attachments/assets/2a6bc036-54a0-4524-8d2f-2e09b713a107" />
After:
<img width="550" height="201" alt="image" src="https://github.com/user-attachments/assets/06421165-53e1-47f9-bea5-a4f5f40fc1b1" />

Note: The info from WAILA Harvestability is incorrect in the screenshot. https://github.com/GTNewHorizons/WailaHarvestability/pull/11 fixes this.