### PR TITLE
Add deepslateDust to miners backpack whitelist

### DIFF
--- a/config/forestry/backpacks.cfg
+++ b/config/forestry/backpacks.cfg
@@ -2594,6 +2594,7 @@ backpacks {
             dustData
             dustDecayedRadium226
             dustDeepIron
+            dustDeepslate
             dustDeimos
             dustDeimosStone
             dustDelutedXenoxene


### PR DESCRIPTION
The miners backpack holds normal stone dust, but not the deepslate dust added by GTNH. The dust can be mined naturally when mining deepslate so it makes sense it would act like normal stone dust. Added as oredict incase a dirty deepslate dust is added later. 