### PR TITLE
Increase village spacing in village names

### DIFF
--- a/config/VillageNames4/newvillages/village_gen.cfg
+++ b/config/VillageNames4/newvillages/village_gen.cfg
@@ -1215,10 +1215,10 @@
     I:"Village Size: Normal Order"=1
 
     # Median distance between villages. Vanilla is 20. [range: 1 ~ 100, default: 20]
-    I:"Village Spacing: Median"=20
+    I:"Village Spacing: Median"=40
 
     # Variation in distances between villages. Must be lower than Median value. Vanilla is 12. [range: 1 ~ 100, default: 12]
-    I:"Village Spacing: Range"=12
+    I:"Village Spacing: Range"=10
 
     # No villages will spawn less than this many chunks from world origin (0, 0). [range: 0 ~ 100000, default: 0]
     I:"Village Spacing: Village-Free Radius"=0


### PR DESCRIPTION
Village names makes villages spawn way too often. This PR attempts to bring it closer to how it is without the mod.

Normal village names spacing: Village spawns every 8 - 32 chunks (128 - 512 blocks)
This PR spacing: Village spawns every 30 - 50 chunks (480 - 800 blocks)

<details>
  <summary>Image comparisons on the same seed</summary>

Default village names config:
<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/3bb882c4-45e5-48fd-8aed-31c51c917a4f" />
With this PR:
<img width="800" height="700" alt="image" src="https://github.com/user-attachments/assets/a7187949-d3ae-4878-80ff-c7cbdacbe79e" />
Without village names:
<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/4d60aa42-00cc-4f5b-aa7d-5882ada5f585" />
</details>