### PR TITLE
Fix Cleanroom Glass w New Borosilicates

### DIFF
--- a/config/GregTech/MachineStats.cfg
+++ b/config/GregTech/MachineStats.cfg
@@ -128,9 +128,10 @@ machine_stats {
     ##########################################################################################################
 
     cleanroom {
-        # List of other blocks allowed as a part of the cleanroom. Format: <block name> or <block name>:<meta>. [default: [BW_GlasBlocks], [tile.openblocks.elevator], [tile.openblocks.elevator_rotating], [tile.blockTravelAnchor], [tile.blockCosmeticOpaque:2], [tile.extrautils:etherealglass]]
+        # List of other blocks allowed as a part of the cleanroom. Format: <block name> or <block name>:<meta>. [default: [BW_TieredGlass], [BW_ExtraGlass], [tile.openblocks.elevator], [tile.openblocks.elevator_rotating], [tile.blockTravelAnchor], [tile.blockCosmeticOpaque:2], [tile.extrautils:etherealglass]]
         S:allowedBlocks <
-            BW_GlasBlocks
+            BW_TieredGlass
+            BW_ExtraGlass
             tile.openblocks.elevator
             tile.openblocks.elevator_rotating
             tile.blockTravelAnchor


### PR DESCRIPTION
this pr changes the default cleanroom config to replace the deprecated BW_GlasBlocks


Do not merge without coremod and gt5u prs :)
https://github.com/GTNewHorizons/GT5-Unofficial/pull/7025
https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1801