### PR TITLE
Replace IC2 crop mentions with NH crops

### DIFF
--- a/config/txloader/forceload/____gtnhoverridenames/lang/en_US.lang
+++ b/config/txloader/forceload/____gtnhoverridenames/lang/en_US.lang
@@ -671,3 +671,9 @@ fluid.alumite.molten=Molten Obzinite
 material.alumite=Obzinite
 item.universalSingularities.tinkersConstruct.alumite.name=Obzinite Singularity
 item.iguana.tcon.clayBucket.Alumite.name=Molten Obzinite Clay Bucket
+
+
+# IC2 Crops -> Crops NH since CropsNH is GTNH-only and the target mods are on passive support
+item.gendustry.GeneSample.forestry.effectFertile.tooltip=Add random ticks to plants in range\n(does not work on CropsNH crops)
+# Crops NH hijacks the circuit logic instead of adding it's own.
+for.circuit.manualIC2Crop=CropsNH Farm


### PR DESCRIPTION
Adds lang key overrides for forestry's IC2 farm mode and gendustry's fertile effect description to replace IC2 crops mentions with mentions of cropsNH whenever applicable.

- Gendustry is on passive support and therefore can theoretically run with IC2 out of pack, so the lang key should only be overwritten in pack as CropsNH is only supported within the pack as of right now.
- The forestry farm mode for IC2 is hijacked by CropsNH to only function with CropsNH crops and therefore needs to be renamed, as forestry farms will no longer process IC2 crops when CropsNH is installed.