### PR TITLE
Fix regex issues and expand item groups in NEI collapsible items

### DIFF
--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -96,7 +96,7 @@ $r/^frame/ | dreamcraft:DiamondFrameBox
 $r/^ring/
 $itemcasing
 :gt. $sticklong | miscutils:item.itemrodlong | miscutils:itemrodlong | r/dreamcraft:long.*rod/
-:gt. $r/^stick/ | miscutils:item.itemrod | miscutils:itemrod | r/dreamcraft:*rod/ !shapeRod
+:gt. $r/^stick/ | miscutils:item.itemrod | miscutils:itemrod | r/dreamcraft:.*Rod/ !shapeRod
 $springsmall
 $r/^spring/ !$springsmall !harvestcraft
 $r/^cell/ !$cellempty | ic2:itemfluidcell | ic2:itemcellempty !0 | metaitem.98
@@ -109,7 +109,7 @@ miscutils:crushedcentrifuged
 miscutils:crushed | IC2:itemCrushedOre
 miscutils:dustimpure
 miscutils:dustpure
-:gt. $dust | r/dreamcraft:*dust$/ | miscutils:itemdust | ic2:itemdust
+:gt. $dust | r/dreamcraft:.*Dust$/ | miscutils:itemdust | ic2:itemdust
 :gt. $nugget | miscutils:itemnugget
 $r/^round/
 $r/^screw/
@@ -162,9 +162,9 @@ $ingothot
 #gregtech Solidifier Hatch
 :gt.blockmachines 31781-31784
 #gregtech Extrusion Bus
-:gt:blockmachines 31785-31788
+:gt.blockmachines 31785-31788
 #gregtech Chisel Bus
-:gt:blockmachines 31778-31780
+:gt.blockmachines 31778-31780
 #gregtech Super Tank
 :gt.blockmachines 130-134
 #gregtech Quantum Tank
@@ -500,7 +500,7 @@ transport:pipelens 0-16
 transport:pipelens 16-31
 #doors
 malisisdoors:door_ !malisisdoors:door_factory | malisisdoors:wood_sliding_door | r/malisisdoors:item.*door/ | malisisdoors:iron_sliding_door | malisisdoors:jail_door | malisisdoors:laboratory_door | malisisdoors:factory_door | malisisdoors:shoji_door | witchery:ingredient 52-53
-extratrees:door | r/minecraft:.*_door/ | carpentersdoor | TwilightForest:item.door | r/natura:.*doorItem/ | ic2:itemdooralloy | galacticraftamunra:item.baseitem 25 | r/etfuturum:.*copper_door/
+extratrees:door | r/minecraft:.*_door/ | carpentersdoor | TwilightForest:item.door | r/natura:.*doorItem/ | ic2:itemdooralloy | galacticraftamunra:item.baseitem 25 | r/etfuturum:.*copper_door/ | Thaumcraft:ItemArcaneDoor | witchery:ingredient 152
 malisisdoors:item.curtain
 malisisdoors:curtain_
 #arrows
@@ -781,8 +781,8 @@ ztones:tile.zaneBlock
 ztones:tile.zythBlock
 ztones:tile.ztylBlock
 #other
-extratrees:gate | minecraft:fence_gate | natura:fencegate | r/malisisdoors:.*fencegate/ | r/witchery:.*fencegate/ | r/biomesoplenty:.*fencegate$/
-extratrees:fence | minecraft:fence | natura.fence | witchery:icefence | forestry:fences | extratrees:multifence | minecraft:nether_brick_fence | hardcoreenderexpansionraveged_brick_fence | ic2:blockfenceiron | r/railcraft:post.metal$/ | r/railcraft:post$/ 0-2 | r/biomesoplenty:.*fence$/
+extratrees:gate | minecraft:fence_gate | natura:fencegate | r/malisisdoors:.*fencegate/ | r/witchery:.*fencegate/ | r/biomesoplenty:.*fencegate$/ | CarpentersBlocks:blockCarpentersGate
+extratrees:fence | minecraft:fence | natura.fence | witchery:icefence | forestry:fences | extratrees:multifence | minecraft:nether_brick_fence | HardcoreEnderExpansion:ravaged_brick_fence | ic2:blockfenceiron | r/railcraft:post.metal$/ | r/railcraft:post$/ 0-2 | r/biomesoplenty:.*fence$/
 botany:soil !soilmeter | r/botany:flower\w/ | botany:loam | botania: altGrass | r/biomesoplenty:.*grass/ | biomesoplenty:newBopDirt | biomesoplenty:newBopFarmland | hardcoreenderexpansion:end_stone_terrain
 natura:button | r/minecraft:.*_button/ | natura:netherbutton | r/etfuturum:.*button/
 extratrees:carpentry
@@ -801,8 +801,7 @@ botania:stone $stonegranite
 :honeydrop | magicbees:drop | gregtech:gt.drop | miscutils:gtpp.drop
 railcraft:wall | r/minecraft:.*_wall/ | botania:biomeStoneA0Wall | projectred.exploration.stonewalls | r/botania:.*Wall$/ | galacticraftcore:tile.wallGC | r/etfuturum:.*_wall$/
 ic2:blockwall
-r/etfuturum:.*stripped*/ | etfuturum:cherry_log 2-3 |fether:nether_log 2-3
-$logwood
+$logwood | r/etfuturum:.*stripped.*/ | etfuturum:cherry_log 2-3 | fether:nether_log 2-3
 witchery:stockade
 witchery:shadedglass
 r/cookingforblockheads:.*floor/


### PR DESCRIPTION
Small improvements to NEI collapsible item groups:

## Fixes
- Fixed regex for GregTech extrusion and chisel buses
- Fixed regex for DreamCraft dusts and rods
- Fixed regex for Et Futurum stripped wood logs

## Additions
- Added GoodGenerator and Tinkers Defense ingots to ingots group
- Added Carpenter's Gate to gates group
- Added Ice Door and Arcane Door to doors group
- Added Ravaged Brick Fence to fences group