### PR TITLE
Hide ic2 rubber pad

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -299,6 +299,7 @@ IC2:itemSlag
 
 # IC2 Blocks
 IC2:blockHarz # ic2.blockHarz
+IC2:blockRubber
 IC2:blockDoorAlloy # Reinforced Door
 IC2:blockReinforcedFoam # Reinforced Construction Foam
 IC2:blockFoam # Construction Foam


### PR DESCRIPTION
nothing to swap from it, so just hide ig

depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/7212