### PR TITLE
Hide IC2 reinforced stone

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -300,6 +300,7 @@ IC2:itemSlag
 # IC2 Blocks
 IC2:blockHarz # ic2.blockHarz
 IC2:blockDoorAlloy # Reinforced Door
+IC2:blockAlloy
 IC2:blockReinforcedFoam # Reinforced Construction Foam
 IC2:blockFoam # Construction Foam
 IC2:blockWall # ic2.blockWall


### PR DESCRIPTION
depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/7228