### PR TITLE
Remove Thermal Boiler Pollution Config

### DIFF
--- a/config/GregTech/Pollution.cfg
+++ b/config/GregTech/Pollution.cfg
@@ -242,9 +242,6 @@ pollution {
     # pollution rate in gibbl/s for the Reactor fuel processing plant [range: -2147483648 ~ 2147483647, default: 4000]
     I:pollutionPerSecondMultiRefinery=4000
 
-    # pollution rate in gibbl/s for the Thermal boiler [range: -2147483648 ~ 2147483647, default: 700]
-    I:pollutionPerSecondMultiThermalBoiler=700
-
     # pollution rate in gibbl/s for the Tree growth simulator [range: -2147483648 ~ 2147483647, default: 100]
     I:pollutionPerSecondMultiTreeFarm=100
 


### PR DESCRIPTION
The muffler hatch is already removed from the Thermal Boiler because it's a heat exchanger and should not be producing any pollution. This is to remove any last traces of such heresay.

Tied to https://github.com/GTNewHorizons/GT5-Unofficial/pull/7232