### PR TITLE
ci: bundle GTNH-Guide-Pack into nightly releases

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -23,6 +23,36 @@ jobs:
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
+      - name: Bundle matching GTNH-Guide-Pack release
+        if: contains(github.ref_name, '-nightly-')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GUIDE_REPO: GTNewHorizons/GTNH-Guide-Pack
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_VERSION}" == *-pre ]]; then
+            # Experimental modpack release: newest guide release of any tag.
+            GUIDE_TAG=$(gh release list --repo "$GUIDE_REPO" --limit 100 \
+              --json tagName,createdAt,isDraft \
+              --jq '[.[] | select(.isDraft | not)]
+                    | sort_by(.createdAt) | reverse | .[0].tagName // empty')
+          else
+            # Daily modpack release: newest guide release whose tag is not -pre.
+            GUIDE_TAG=$(gh release list --repo "$GUIDE_REPO" --limit 100 \
+              --json tagName,createdAt,isDraft \
+              --jq '[.[] | select(.isDraft | not)
+                          | select(.tagName | endswith("-pre") | not)]
+                    | sort_by(.createdAt) | reverse | .[0].tagName // empty')
+          fi
+          if [[ -z "$GUIDE_TAG" ]]; then
+            echo "No matching GTNH-Guide-Pack release found" >&2
+            exit 1
+          fi
+          echo "Selected GTNH-Guide-Pack release: $GUIDE_TAG"
+          gh release download "$GUIDE_TAG" --repo "$GUIDE_REPO" \
+            --pattern '*.zip' \
+            --output resourcepacks/GTNH-Guide-Pack.zip
+
       - name: Prepare release folder
         run: |
           mkdir -p release

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -49,9 +49,10 @@ jobs:
             exit 1
           fi
           echo "Selected GTNH-Guide-Pack release: $GUIDE_TAG"
+          # --dir keeps the asset's versioned name (GTNH-Guide-Pack-<version>.zip).
           gh release download "$GUIDE_TAG" --repo "$GUIDE_REPO" \
             --pattern '*.zip' \
-            --output resourcepacks/GTNH-Guide-Pack.zip
+            --dir resourcepacks
 
       - name: Prepare release folder
         run: |


### PR DESCRIPTION
Auto pulls the latest GTNH-Guide-Pack release into the release zip (not in the repo itself)
Skips if the config repo tag does not have "nightly" in it (stable/beta configs are handled manually)
If the config repo tag is -pre, it pulls the latest release, even if its -pre.
If the config repo tag is not -pre, it pulls the latest non-pre release