### PR TITLE
Keep questbook config on pack upgrade

### DIFF
--- a/config/localconfig.txt
+++ b/config/localconfig.txt
@@ -39,6 +39,8 @@ beebetteratbees.cfg/*/*
 
 BetterAchievements.cfg/*/*
 
+betterquesting.cfg/general/*
+
 Botania.cfg/general/baubleRender.enabled
 Botania.cfg/general/blockBreakingParticles.enabled
 Botania.cfg/general/blockBreakingParticlesTool.enabled


### PR DESCRIPTION
I have to reconfigure my questbook on every pack update (most notably the theme for me). This change tries to preserve the questbook settings.

Additionally, GTNH 2.9 will add many new config options for quest notifications and I think it's appropriate to keep these on update, so it's a good time to add this to `localconfig.cfg`.