### PR TITLE
Enable SU sleep voting over Morpheus

### DIFF
--- a/serverutilities/serverutilities.cfg
+++ b/serverutilities/serverutilities.cfg
@@ -337,7 +337,7 @@ world {
     S:enable_explosions=TRUE
 
     # Enabled Player Sleeping Percentage to skip night. Use the gamerule playersSleepingPercentage to set the percentage. [default: false]
-    B:enable_player_sleeping_percentage=false
+    B:enable_player_sleeping_percentage=true
 
     # Allowed values:
     # DEFAULT = Players can choose their own PVP status.


### PR DESCRIPTION
## Summary
Enable SU's sleep voting 

EFR's sleep voting is already disabled (full conflicts with SU's)


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
	None used
- [X] This PR requires another PR in order to merge
	REQUIRES Morpheus to be removed (server only mod) in DAXXL
