### PR TITLE
Fix Unbreakable Coke Oven Bricks

### DIFF
--- a/config/IguanaTinkerTweaks/BlockDefaults.cfg
+++ b/config/IguanaTinkerTweaks/BlockDefaults.cfg
@@ -5531,6 +5531,7 @@ blocks_pickaxe {
     I:"GalaxySpace:venustin:7"=2
     I:"GalaxySpace:venustin:8"=2
     I:"GalaxySpace:venustin:9"=2
+    I:"gregtech:gt.blockcasings12:0"=0
     I:"HardcoreEnderExpansion:cinder:0"=2
     I:"HardcoreEnderExpansion:cinder:1"=2
     I:"HardcoreEnderExpansion:cinder:10"=2


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25741 by allowing Coke Oven Bricks to be breakable by pickaxe in the Tinker Tweaks config.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
