### PR TITLE
increase lens mining levels

### DIFF
--- a/config/Botania.cfg
+++ b/config/Botania.cfg
@@ -72,7 +72,7 @@ general {
     I:harvestLevel.boreLens=5
 
     # The harvest level of the Mana Lens: Weight. 3 is diamond level. Defaults to 2 (iron level)
-    I:harvestLevel.weightLens=4
+    I:harvestLevel.weightLens=5
 
     # Set this to true to enable justified text in the Lexica Botania's text pages.
     B:lexicon.enable.justifiedText=false

--- a/config/Botania.cfg
+++ b/config/Botania.cfg
@@ -69,10 +69,10 @@ general {
     B:flowerTextures.alt=false
 
     # The harvest level of the Mana Lens: Bore. 3 is diamond level. Defaults to 3
-    I:harvestLevel.boreLens=3
+    I:harvestLevel.boreLens=5
 
     # The harvest level of the Mana Lens: Weight. 3 is diamond level. Defaults to 2 (iron level)
-    I:harvestLevel.weightLens=2
+    I:harvestLevel.weightLens=4
 
     # Set this to true to enable justified text in the Lexica Botania's text pages.
     B:lexicon.enable.justifiedText=false


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

The botania entry for the bore and weight lenses mention their mining levels as diamond and iron.  With iguana tweaks installed, these levels are 2 off than what diamond and iron mine respectively, being obsidian (5) and redstone (4).*

*After it was pointed out exactly how much more expensive the weight lens was compared to the bore lens, I felt it fine to make both minign level 5. While ordinarily the special mechanics of the weight lens would make sense for it to have a lower mining level, the cost in gtnh is quite a bit higher compared to the bore lens, and that disparity makes the nerf to its mining level make less sense. 

I think this would be a beneficial change for the pack, as it offers another way to automate mining with magic. The cost compared to making arcane bores is negligible, as you'll need many times more for the same effect, and they still won't be able to mine the toughest of ores, such as draconium, and that's with the more expensive lens of the two. 

There's also a mana cost associated, which would require all spreaders access to a mana pool or other source.

While this means they won't be able to mine all the meteors that Blood Magic can spawn (or even any, effectively), they will be able to mine the ores produce by the orechid with little issue, and other smaller, more niche setups like ender/nether tree leaves, or just an exotic looking cobblestone generator.

Opens player options, little balance issue imo, and more uses for magic.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20507


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
