### PR TITLE
chore(glue): fix green slime count

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Glue-AAAAAAAAAAAAAAAAAAAC6Q==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier1LV-AAAAAAAAAAAAAAAAAAAAAw==/Glue-AAAAAAAAAAAAAAAAAAAC6Q==.json
@@ -138,7 +138,7 @@
       "requireOnlyOneItem:1": 0,
       "requiredItems:9": {
         "0:10": {
-          "Count:3": 11,
+          "Count:3": 15,
           "Damage:2": 1,
           "OreDict:8": "",
           "id:8": "TConstruct:slime.gel"


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
change the requirement of the congealed green slime to 15 (still optional)
the reason for this change is that the congealed green slime can only give 200L glue per block now
<img width="412" height="462" alt="Screenshot 2026-07-21 at 13 27 22" src="https://github.com/user-attachments/assets/5c7f77b0-4c40-4e0f-9ef1-60bba103b33b" />


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
