### PR TITLE
Add InventoryBogoSorter config to localconfig.txt

### DIFF
--- a/config/localconfig.txt
+++ b/config/localconfig.txt
@@ -41,6 +41,24 @@ BetterAchievements.cfg/*/*
 
 betterquesting.cfg/general/*
 
+bogosorter.cfg/general.ae2integration/*
+!bogosorter.cfg/general.ae2integration/B:enableIntegrationDebugLogging
+bogosorter.cfg/general.usageticker/*
+!bogosorter.cfg/general.usageticker.arrow/*
+bogosorter.cfg/general.dropoff/*
+!bogosorter.cfg/general.dropoff/S:dropoffTargetNames
+!bogosorter.cfg/general.dropoff/S:dropoffRenderStyle
+!bogosorter.cfg/general.dropoff/B:dropoffRenderFadeOut
+!bogosorter.cfg/general.dropoff/I:dropoffQuotaInMS
+!bogosorter.cfg/general.dropoff/I:dropoffRadius
+!bogosorter.cfg/general.dropoff/I:dropoffPacketThrottleInMS
+bogosorter.cfg/general/*
+!bogosorter.cfg/general/I:buttonColor
+!bogosorter.cfg/general/B:enableAutoRefill
+!bogosorter.cfg/general/B:enableAutoRefill_server
+!bogosorter.cfg/general/B:enableDebugTools
+!bogosorter.cfg/general/S:sortSound
+
 Botania.cfg/general/baubleRender.enabled
 Botania.cfg/general/blockBreakingParticles.enabled
 Botania.cfg/general/blockBreakingParticlesTool.enabled


### PR DESCRIPTION
## Summary

Add bogosorter.cfg to localconfig.txt so that some InventoryBogoSorter configs are kept during GTNH upgrades. I went through these with a fine-toothed comb.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
