### PR TITLE
Disable StackWatcher by default

### DIFF
--- a/config/GregTech/MachineStats.cfg
+++ b/config/GregTech/MachineStats.cfg
@@ -65,6 +65,17 @@ machine_stats {
 
         # If true, requires at least a free face to open a machine gui. [default: false]
         B:forceFreeFace=false
+
+        # Minimum ticks an idle multiblock waits after a failed recipe check before a throttleable push may run another one.
+        # Only throttleable sources are affected (ME stocking inputs restocking, power trickling into a buffer); new inputs,
+        # drained outputs and user actions are immediate and ignore this entirely.
+        # 0 (default) keeps every check instant. Raise this only if a heavily loaded ME network makes recipe checks expensive
+        # (for reference, the legacy behaviour was roughly equivalent to 100 ticks). [range: -2147483648 ~ 2147483647, default: 0]
+        I:recipeCheckFailCooldown=0
+
+        # Use StackWatcher for Stocking Inputs (ME).
+        # If this option is off, periodic recipe check will be enabled if stocking input is attached. [default: true]
+        B:useStackWatcher=false
     }
 
     ##########################################################################################################


### PR DESCRIPTION
## Summary
Follow-up on https://github.com/GTNewHorizons/GT5-Unofficial/pull/7511

Current AE2 does not have a very efficient postChanges implementation. Disable StackWatcher by default allow AE2 to completely skip postChanges if nothing on the network is watching for changes.

Relevant spark showing the issue:
https://spark.lucko.me/a2APP1M6uJ (in the original PR, tps back to 20 with the config)
https://spark.lucko.me/CwUSsggQdc
https://spark.lucko.me/UwWohFcLwX

In flat view, postChanges is often taking over 50% of the total tick time in serious cases. In cases like LNR, there will be a lot of stocking inputs on the same network that generate and receive StackWatcher updates which exaggerates the issue a lot.

Advanced stocking input keep the ability to trigger recipe check instantly, no functionality is lost.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
