### PR TITLE
Whitelist lootgame blocks

### DIFF
--- a/config/ifu.cfg
+++ b/config/ifu.cfg
@@ -6,6 +6,8 @@ general {
         etfuturum:amethyst_block
         etfuturum:amethyst_cluster_1
         etfuturum:amethyst_cluster_2
+        lootgames:LootGamesDungeonWall
+        lootgames:LootGamesDungeonLight
      >
 
     # Blocks the Ore Finder must never search for, that it would otherwise match on its own. Use the block Item ID, same rules as Allowlist [default: ]


### PR DESCRIPTION
## Summary
I'm pretty sure it's supposed to be possible since the wiki mention it: https://wiki.gtnewhorizons.com/wiki/Lootgames#Locating_Dungeons

But the recent changes make it need to be whitelisted now, oopsie

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
