### PR TITLE
Update electric boots of the comet/meteor to correct charging voltage

### DIFF
--- a/config/GTNewHorizons/CustomToolTips.xml
+++ b/config/GTNewHorizons/CustomToolTips.xml
@@ -168,10 +168,10 @@
 	<ToolTip ItemName="thaumicboots:item.ItemElectricVoid" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemNanoVoid" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemQuantumVoid" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§8EV" NBT="" MetaStart="1" MetaEnd="325"/>
-	<ToolTip ItemName="thaumicboots:item.ItemElectricMeteor" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
+	<ToolTip ItemName="thaumicboots:item.ItemElectricMeteor" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§6MV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemNanoMeteor" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemQuantumMeteor" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§8EV" NBT="" MetaStart="1" MetaEnd="325"/>
-	<ToolTip ItemName="thaumicboots:item.ItemElectricComet" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
+	<ToolTip ItemName="thaumicboots:item.ItemElectricComet" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§6MV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemNanoComet" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§eHV" NBT="" MetaStart="1" MetaEnd="325"/>
 	<ToolTip ItemName="thaumicboots:item.ItemQuantumComet" ToolTip="customtooltip.recharge_tier_machine" FormatArgs="§8EV" NBT="" MetaStart="1" MetaEnd="325"/>
 


### PR DESCRIPTION
## Summary
Update Electric Boots of the Meteor and Electric Boots of the Comet to display correct charging voltage tier (MV)

<img width="839" height="430" alt="image" src="https://github.com/user-attachments/assets/c70acd34-b547-43d0-9fe7-af1e67c063ca" />

<img width="858" height="409" alt="image" src="https://github.com/user-attachments/assets/5d1af3d3-f7ce-4ed1-ab4e-1f437eda8d93" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge


#26221 