### PR TITLE
Remove Tinkers Construct tooltips from en_US.lang

### DIFF
--- a/config/txloader/load/customtooltips/lang/en_US.lang
+++ b/config/txloader/load/customtooltips/lang/en_US.lang
@@ -52,10 +52,6 @@ customtooltip.battery_tier=%s-tier
 ## OMT
 customtooltip.omt_hardness_resistance=Hardness: %s - Blast Resistance: %s
 
-## Tinkers Construct
-customtooltip.smeltery_purity_warning=§3Some metals processed in smeltery don't meet the purity requirement for GregTech processing.
-customtooltip.crops_nh_oreberries=Can be placed on empty Crop Sticks. See their growth requirements in NEI.
-
 ## GG
 customtooltip.check_ebf_recipe=§3Check Flawed Crystal recipe in EBF
 customtooltip.check_press_recipe=§3Check Plate recipe in Forming Press


### PR DESCRIPTION
## Summary
Removed tooltips related to Tinkers Construct from the language file.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [X] This PR requires another PR in order to merge https://github.com/GTNewHorizons/TinkersConstruct/pull/308
