### PR TITLE
Fix hiding too many IC2:blockGenerator

### DIFF
--- a/config/NEI/hiddenitems.cfg
+++ b/config/NEI/hiddenitems.cfg
@@ -184,9 +184,11 @@ IC2:itemCasing 6 # Lead
 
 # IC2 Generator
 IC2:blockKineticGenerator 3 # Manual Kinetic Generator
-IC2:blockGenerator # RTG POWARZ
+IC2:blockGenerator 0 # RTG POWARZ
 IC2:blockGenerator 1 # Geothermal Generator
 IC2:blockGenerator 2 # Water Mill
+IC2:blockGenerator 3 # Solar Panel
+IC2:blockGenerator 4 # Wind Mill
 IC2:blockGenerator 7 # Semifluid Generator
 
 # IC2 Machines


### PR DESCRIPTION
## Summary
Accidental wildcard was hiding Reactor Chamber and a few other still in use IC2 blocks

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
