### PR TITLE
disable silly inductive furnace recipe map generation

### DIFF
--- a/config/ProjectRed.cfg
+++ b/config/ProjectRed.cfg
@@ -48,6 +48,9 @@ Compatibility {
 "Machine Settings" {
     # Allow the Diamond Block Breaker to be crafted.
     B:"Enable the Diamond Block Breaker"=false
+
+    # Allow the Inductive Furnace to be crafted and load its smelting recipes.
+    B:"Enable the Inductive Furnace"=false
 }
 
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Will have no effect until https://github.com/GTNewHorizons/ProjectRed/pull/89 is merged.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
