### PR TITLE
Add QuestPR Build Workflow

### DIFF
--- a/.github/workflows/build-and-quest.yml
+++ b/.github/workflows/build-and-quest.yml
@@ -1,0 +1,29 @@
+name: build-and-quest
+
+on:
+  pull_request:
+    paths:
+      - config/betterquesting/DefaultQuests/**
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-quest:
+    name: Build DefaultQuests artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v5
+
+      - name: Stage DefaultQuests
+        run: |
+          mkdir -p artifact
+          cp -a config/betterquesting/DefaultQuests artifact/DefaultQuests
+
+      - name: Upload DefaultQuests
+        uses: actions/upload-artifact@v7
+        with:
+          name: DefaultQuests-PR-${{ github.event.pull_request.number }}
+          path: artifact
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Creates a downloadable DefaultQuests folder artifact on quest PRs so I (umm, I mean other people) can just download and slot right into my instance instead of checking out a fork branch and doing it that way. 

## Checklist
- [x] I have tested this PR
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
