### PR TITLE
Replace Ice Cream reward

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/FeedingYourself-AAAAAAAAAAAAAAAAAAAACg==/IceIceBaby-uPmgcTcIR6OcAYqLCD7IkQ==.json
+++ b/config/betterquesting/DefaultQuests/Quests/FeedingYourself-AAAAAAAAAAAAAAAAAAAACg==/IceIceBaby-uPmgcTcIR6OcAYqLCD7IkQ==.json
@@ -95,7 +95,7 @@
       "rewards:9": {
         "0:10": {
           "Count:3": 1,
-          "Damage:2": 32622,
+          "Damage:2": 32602,
           "OreDict:8": "",
           "id:8": "gregtech:gt.metaitem.02"
         }


### PR DESCRIPTION
## Summary
Change the reward from Magnetohydrodynamically Constrained Star Matter Ice Cream to Choco-Vanilla Ice Cream.
(so it's normal at start, these ice cream should be suprise)


Food_IceCream_MHDCSM(622) - > Food_IceCream_ChocoVanilla(602) 

## Checklist
- [X] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
