### PR TITLE
Expand the collapsible NEI ice cream group

### DIFF
--- a/config/NEI/collapsibleitems.cfg
+++ b/config/NEI/collapsibleitems.cfg
@@ -288,7 +288,7 @@ gt.metaitem.02 32414-32429
 # gregtech coin
 gt.metaitem.01 32000-32016
 # gregtech ice creams
-:gt.metaitem.02 32589-32640
+:gt.metaitem.02 32589-32764
 # gregtech Sheetmetal
 gregtech:gt.sheetmetal | gregtech:bw.sheetmetal
 # plate superdense


### PR DESCRIPTION
## Summary
Expand the group up to max I can go. This is for future when we were to add more Ice Creams, they will automatically get collabsed.

<img width="844" height="282" alt="image" src="https://github.com/user-attachments/assets/dd3721e3-6be2-4d05-9590-872b2661366f" />
<img width="437" height="94" alt="image" src="https://github.com/user-attachments/assets/f82c858c-ab0e-445b-a983-b9b3c5e26e9e" />

- no it won't show blank items, see picture from Daily above


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
