### PR TITLE
update hodgepodge config and turn on removeExtraIconLoad

### DIFF
--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -1,14 +1,29 @@
 # Configuration file
 
 asm {
+    # Disable BoP fog modifications [default: false]
+    B:bopFogDisable=false
+
     # Disable CoFH TileEntity cache (and patch MineFactory Reloaded and Thermal Expansion with a workaround) [default: true]
     B:cofhWorldTransformer=true
+
+    # Disable CoFH Access Transformer and use Forge AT instead to improve transforming performance [default: true]
+    B:disableCoFHAccessTransformer=true
+
+    # Remove various vararg method calls, to make profiling easier. [default: true]
+    B:dissectVarargs=true
 
     # Speedup LongInt HashMap [default: true]
     B:speedupLongIntHashMap=true
 
     # Speedup NBTTagCompound copy [default: true]
     B:speedupNBTTagCompoundCopy=true
+
+    # Speedup OreDictionary [default: true]
+    B:speedupOreDictionary=true
+
+    # Speedup PlayerManager [default: true]
+    B:speedupPlayerManager=true
 
     # Speedup progressbar [default: true]
     B:speedupProgressBar=true
@@ -30,18 +45,36 @@ debug {
 
     # Default GL state debug mode. 0 - off, 1 - reduced, 2 - full [range: 0 ~ 2, default: 0]
     I:renderDebugMode=0
+
+    # Show chunk generation stats on the F3 debug screen (left side). Singleplayer only. [default: false]
+    B:showChunkGenDebug=false
 }
 
 
 fixes {
+    # [Experimental] Add option to separate simulation distance from rendering distance (Incompatible with optifine, will automatically be disabled). WARNING: May lead to TPS issues [default: false]
+    B:addSimulationDistance_WIP=false
+
+    # Adds the thrower tag to all dropped EntityItems [default: true]
+    B:addThrowerTagToDroppedItems=true
+
     # Maximum hp for BetterHUD to render as hearts [range: 1 ~ 100000, default: 5000]
     I:betterHUDHPRenderLimit=5000
 
     # Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes [default: true]
     B:changeMaxNetworkNbtSizeLimit=true
 
+    # Clear stale clicks made on the loading screen and prevent them from firing in the main menu [default: true]
+    B:clearStaleLoadingScreenInput=true
+
+    # Prevents the entity rendered in the player inventory GUI and the horse GUI from overflowing their boxes. [default: true]
+    B:clipPlayerRenderInGuis=true
+
     # Removes duplicate Fermenter and Squeezer recipes and flower registration [default: true]
     B:deduplicateForestryCompatInBOP=true
+
+    # Make a deep copy when sending objects from the data watcher to the client in SinglePlayer [default: true]
+    B:deepCopyDataWatcherInSP=true
 
     # Prevents Sacred Rubber Tree Generation [default: false]
     B:disableMassiveSacredTreeGeneration=false
@@ -55,11 +88,17 @@ fixes {
     # Destroy and log TileEntities failing the safe coordinate instead of crashing the game (can cause loss of data) [default: false]
     B:earlyChunkTileCoordinateCheckDestructive=false
 
-    # Enable multiple fixes to reduce RAM usage [default: true]
-    B:enableMemoryFixes=true
-
     # Safely enlarge the potion array before other mods [default: true]
     B:enlargePotionArray=true
+
+    # Fix death messages containing English-localized entity names even on non-English clients. [default: true]
+    B:entityNameLocalization=true
+
+    # Fixes cascading worldgen caused by Biomes O' Plenty Kelp. [default: true]
+    B:fixBOPCascadingKelp=true
+
+    # Fix BOP sapling icon showing the wrong type when the growth stage bit is set in meta [default: true]
+    B:fixBOPSaplingIcon=true
 
     # Fix BetterHUD armor bar rendering breaking with skulls [default: true]
     B:fixBetterHUDArmorDisplay=true
@@ -70,17 +109,38 @@ fixes {
     # Fix Bibliocraft packet exploits [default: true]
     B:fixBibliocraftPackets=true
 
+    # Fix Bibliocraft PaintingUtil getting it's own jar path [default: true]
+    B:fixBibliocraftPaintingUtilPath=true
+
     # Fix Bibliocraft path sanitization [default: true]
     B:fixBibliocraftPathSanitization=true
 
+    # Fix Bibliowoods Forestry recipes [default: true]
+    B:fixBibliowoodsForestryRecipes=true
+
+    # Fix EndlessIds incompatibility with BoP [default: true]
+    B:fixBoPEid=true
+
     # Fix bogus FMLProxyPacket NPEs on integrated server crashes. [default: true]
     B:fixBogusIntegratedServerNPEs=true
+
+    # Do not flip bottom face textures (1.8+ behavior, see MC-47811) [default: false]
+    B:fixBottomFaceUV=false
+
+    # Fix breaking electric and other special armor helmet when a block falls on your head [default: true]
+    B:fixBreakingSpecialArmorHelmetOnBlockFall=true
+
+    # Fix breaking electric and other special armor when Thorns enchantment is applied [default: true]
+    B:fixBreakingSpecialArmorWithThornsEnchantment=true
 
     # Fix crash on Bukkit with BetterQuesting [default: true]
     B:fixBukkitBetterQuestingCrash=true
 
     # Fix the buttons not being centered in the GuiConfirmOpenLink [default: true]
     B:fixButtonsGuiConfirmOpenLink=true
+
+    # Orient particles from the render view entity instead of the player, so detached cameras (freecam, spectator-likes) do not tilt them (MC-46445) [default: true]
+    B:fixCameraParticleRotation=true
 
     # Fix NPE when interacting with sugar block [default: true]
     B:fixCandycraftBlockSugarNPE=true
@@ -94,20 +154,38 @@ fixes {
     # Fix wrapped chat lines missing colors [default: true]
     B:fixChatWrappedColors=true
 
+    # Fix NBTTagSmartByteArray sending null to NBTTagByteArray causing NPE when saving chunks [default: true]
+    B:fixCofhNullByteArray=true
+
     # Fix race condition in COFH's oredict [default: true]
     B:fixCofhOreDictCME=true
 
     # Fix NPE in COFH's oredict [default: true]
     B:fixCofhOreDictNPE=true
 
+    # Fix logic of /cofh tpx [default: true]
+    B:fixCofhTpxCommand=true
+
+    # Fix /say, /tell, /me losing formatting after the first word [default: true]
+    B:fixCommandFormattingLoss=true
+
     # Prevents crash if server sends container with wrong itemStack size [default: true]
     B:fixContainerPutStacksInSlots=true
+
+    # Backports 1.12's slot shift clicking to prevent recursion when crafting items [default: true]
+    B:fixContainerShiftClickRecursion=true
+
+    # Fix creative tab backgrounds showing black corners when alpha test is left disabled by item rendering (Forge GL state bug) [default: true]
+    B:fixCreativeTabAlphaTest=true
 
     # Fixes the debug hitbox of the player beeing offset [default: true]
     B:fixDebugBoundingBox=true
 
-    # Fix losing bonus hearts on dimension change [default: true]
-    B:fixDimensionChangeHearts=true
+    # Fix losing attributes on dimension change [default: true]
+    B:fixDimensionChangeAttributes=true
+
+    # Fix disconnect screen button overlapping long kick messages [default: true]
+    B:fixDisconnectScreenLayout=true
 
     # Fix duplicate sounds from playing when closing a gui. [default: true]
     B:fixDuplicateSounds=true
@@ -118,14 +196,41 @@ fixes {
     # Fix a class name typo in MinecraftForge's initialize method [default: true]
     B:fixEffectRendererClassTypo=true
 
+    # Use correct egg particles instead of snowball ones (MC-7807) [default: true]
+    B:fixEggParticles=true
+
     # Fix enchantment levels not displaying properly above a certain value [default: true]
     B:fixEnchantmentNumerals=true
+
+    # Prevent the client from crashing due to invalid entity attributes range (MC-150405) [default: true]
+    B:fixEntityAttributesRange=true
+
+    # Fixes items bouncing on stairs and other blocks with odd hitboxes [default: true]
+    B:fixEntityBouncing=true
+
+    # Fixes entity having buggy gravity [default: true]
+    B:fixEntityGravity=true
 
     # Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum) [default: false]
     B:fixExtraTiCTEConflict=false
 
+    # Fix Extra Utilities chests not updating comparator redstone signals when their inventories change [default: true]
+    B:fixExtraUtilitiesChestComparatorUpdate=true
+
     # Fix Extra Utilities drums eating IC2 cells and Forestry capsules [default: true]
     B:fixExtraUtilitiesDrumEatingCells=true
+
+    # Prevent Extra Utilities Ender Collector from inserting into auto-dropping Blocks that create a crash-loop [default: true]
+    B:fixExtraUtilitiesEnderCollectorCrash=true
+
+    # Fixes Ender Quarry get stuck at a mostly random location under certain conditions [default: true]
+    B:fixExtraUtilitiesEnderQuarryFreeze=true
+
+    # Fixes the erosion shovel to be unbreakable during damage checks that aren't breaking blocks or attacking. [default: true]
+    B:fixExtraUtilitiesErosionShovelUnbreakable=true
+
+    # Make Etheric Sword truly unbreakable [default: true]
+    B:fixExtraUtilitiesEthericSwordUnbreakable=true
 
     # Caps hotkey'd stacks to their maximum stack size in filing cabinets [default: true]
     B:fixExtraUtilitiesFilingCabinetDupe=true
@@ -139,6 +244,12 @@ fixes {
     # Fix Extra Utilities Lapis Caelestis microblocks rendering [default: true]
     B:fixExtraUtilitiesGreenscreenMicroblocks=true
 
+    # Fixes the healing axe not healing mobs when attacking them [default: true]
+    B:fixExtraUtilitiesHealingAxeHeal=true
+
+    # Fixes the healing axe to be unbreakable during damage checks that aren't breaking blocks or attacking. [default: true]
+    B:fixExtraUtilitiesHealingAxeUnbreakable=true
+
     # Fixes rendering issues with transparent items from Extra Utilities [default: true]
     B:fixExtraUtilitiesItemRendering=true
 
@@ -148,13 +259,25 @@ fixes {
     # Remove rain from the Last Millenium (Extra Utilities) [default: true]
     B:fixExtraUtilitiesLastMilleniumRain=true
 
+    # Fix Extra Utilities spikes losing NBT tags (other than enchantments) when being placed on the ground [default: true]
+    B:fixExtraUtilitiesPreserveSpikeNBT=true
+
     # Fix dupe bug with Division Sigil removing enchantment [default: true]
     B:fixExtraUtilitiesUnEnchanting=true
+
+    # Fix a crash caused when a mod tries to send a chat message to a FakePlayer [default: true]
+    B:fixFakePlayerChatCrash=true
 
     # Fix fence connections with other types of fence [default: true]
     B:fixFenceConnections=true
 
-    # Fix vanilla fire spread sometimes cause NPE on thermos [default: true]
+    # Fix the player arm swinging when right clicking a fence [default: true]
+    B:fixFenceRightClick=true
+
+    # Fix printed errors about json files when running a server for the first time [default: true]
+    B:fixFileNotFoundExceptionsServerFirstBoot=true
+
+    # Fix vanilla fire spread sometimes causing NPE on thermos [default: true]
     B:fixFireSpread=true
 
     # Fix Forge fluid container registry key [default: true]
@@ -165,6 +288,9 @@ fixes {
 
     # Fix windowId being set on openContainer even if openGui failed [default: true]
     B:fixForgeOpenGuiHandlerWindowId=true
+
+    # Patch Forge's @Optional.Interface processor to also strip Signature attribute entries (fixes TypeNotPresentException from Class.getGenericInterfaces when an optional interface's mod is missing) [default: true]
+    B:fixForgeOptionalInterfaceSignature=true
 
     # Fix the Forge update checker [default: true]
     B:fixForgeUpdateChecker=true
@@ -180,6 +306,9 @@ fixes {
 
     # Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135). [default: true]
     B:fixGlStateBugs=true
+
+    # Fix Glass Bottles filling with Water from some other Fluid blocks [default: true]
+    B:fixGlassBottleWaterFilling=true
 
     # Fix Gliby's voice chat not shutting down its thread cleanly [default: true]
     B:fixGlibysVoiceChatThreadStop=true
@@ -199,6 +328,9 @@ fixes {
     # Fix Drawer + Hopper voiding items [default: true]
     B:fixHopperVoidingItems=true
 
+    # Render the house character (⌂ - Unicode index 2302) in the Minecraft font. [default: true]
+    B:fixHouseCharRendering=true
+
     # Fix oversized chat message kicking player. [default: true]
     B:fixHugeChatKick=true
 
@@ -217,8 +349,17 @@ fixes {
     # Fix IC2's direct inventory access [default: true]
     B:fixIc2DirectInventoryAccess=true
 
+    # Fix EndlessIds incompatibility with IC2 [default: true]
+    B:fixIc2Eid=true
+
     # Fix IC2's armor hover mode [default: true]
     B:fixIc2HoverMode=true
+
+    # Fix IC2 keybinds using hardware key state instead of KeyBinding state, preventing other mods from suppressing keys [default: true]
+    B:fixIc2KeybindsIgnoreKeyState=true
+
+    # Fix IC2 Keybinds activating in GUIs [default: true]
+    B:fixIc2KeybindsInGuis=true
 
     # Prevent IC2's nightvision from blinding you [default: true]
     B:fixIc2Nightvision=true
@@ -229,6 +370,9 @@ fixes {
     # Fix IC2 not loading translations from resource packs [default: true]
     B:fixIc2ResourcePackTranslation=true
 
+    # Fix IC2 filled tin cans not running logic on both client and server [default: true]
+    B:fixIc2TinCan=true
+
     # Fixes various unchecked IC2 getBlock() methods [default: true]
     B:fixIc2UnprotectedGetBlock=true
 
@@ -238,8 +382,17 @@ fixes {
     # Fix the bug that makes fireballs stop moving when chunk unloads [default: true]
     B:fixImmobileFireballs=true
 
+    # Fix instant item texture switch when switching an item in hand with different NBT [default: true]
+    B:fixInstantHandItemTextureSwitch=true
+
+    # Fixes pistons with metadata over 5 from crashing worlds when powered. [default: true]
+    B:fixInvalidPistonCrashes=true
+
     # Fix inventory sync lag: prevents client to check recipes on empty slots. Particularly fixes lag when trying to eat food when full. [default: true]
     B:fixInventorySyncLag=true
+
+    # Fix vanilla item frame duplication. [default: true]
+    B:fixItemFrameDupe=true
 
     # Prevents journeymap from using illegal character in file paths [default: true]
     B:fixJourneymapFilePath=true
@@ -250,14 +403,23 @@ fixes {
     # Prevent unbound keybinds from triggering when pressing certain keys [default: true]
     B:fixJourneymapKeybinds=true
 
+    # Fix crash in the controls menu when two keybind categories share the same localized name [default: true]
+    B:fixKeybindCategorySorting=true
+
     # Fix an overflow of the dimension id when a player logins on a server [default: true]
     B:fixLoginDimensionIDOverflow=true
 
     # Fixes the damage of the Thick Neutron Reflectors in the MT Core recipe (Advanced Solar Panels) [default: true]
     B:fixMTCoreRecipe=true
 
+    # Fix broken modlist entries due to wrong mcmod.info files [default: true]
+    B:fixModlistEntries=true
+
     # Fix not properly waking players if not everyone is sleeping [default: true]
     B:fixMorpheusWaking=true
+
+    # Fix the enchant glint being applied multiple times for items with multiple render passes [default: true]
+    B:fixMultipleEnchantGlint=true
 
     # Fix nametags of spiders, endermen and ender dragons being rendered too dark [default: true]
     B:fixNametagBrightness=true
@@ -273,6 +435,9 @@ fixes {
 
     # If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too [default: true]
     B:fixNetherLeavesFaceRendering=true
+
+    # Fix ItemNetherSeed.getPlant method to return an actual Block instead of null [default: true]
+    B:fixNetherSeedPlantBlockNull=true
 
     # Fix NPE in Netty's Bootstrap class [default: true]
     B:fixNettyNPE=true
@@ -295,6 +460,9 @@ fixes {
     # Fix outdated URLs used in the PortalGun mod to download the sound pack [default: true]
     B:fixPortalGunURLs=true
 
+    # Fix potion effect panel rendering glitched when certain items are held on the cursor (Forge GL state bug) [default: true]
+    B:fixPotionEffectAlphaTest=true
+
     # Properly display level of potion effects in the inventory and on tooltips [default: true]
     B:fixPotionEffectNumerals=true
 
@@ -307,11 +475,11 @@ fixes {
     # Preserve the order of quads in terrain pass 1 [default: true]
     B:fixPreserveQuadOrder=true
 
-    # Fix redstone torch leaking world [default: true]
-    B:fixRedstoneTorchWorldLeak=true
+    # Fix RCON Threading by forcing it to run on the main thread [default: true]
+    B:fixRconThreading=true
 
-    # Fix EffectRenderer and RenderGlobal leaking world instance when leaving world [default: true]
-    B:fixRenderersWorldLeak=true
+    # Fix resetRainAndThunder (called when sleeping) setting rain and thunder timers to 0, which can cause immediate rain on world load if saved at that moment [default: true]
+    B:fixResetRainAndThunder=true
 
     # Fix game window becoming not resizable after toggling fullscrean in any way [default: true]
     B:fixResizableFullscreen=true
@@ -319,8 +487,8 @@ fixes {
     # Fix resource pack folder not opening on Windows if file path has a space [default: true]
     B:fixResourcePackOpening=true
 
-    # Fix skin manager leaking client world [default: true]
-    B:fixSkinManagerLeakingClientWorld=true
+    # Fix Minecraft creating new world in folders that already exists [default: true]
+    B:fixSaveFileWrittenToExistingDirectory=true
 
     # Fix forge command handler not checking for a / and also not running commands with any case [default: true]
     B:fixSlashCommands=true
@@ -331,6 +499,9 @@ fixes {
     # Fix Thaumcraft Aspects being sorted by tag instead of by name [default: true]
     B:fixThaumcraftAspectSorting=true
 
+    # Fix check for EE3 item in Thaumcraft to prevent issues on modern Java. [default: true]
+    B:fixThaumcraftEE3Check=true
+
     # Fix golem's marker loading failure when dimensionId larger than MAX_BYTE [default: true]
     B:fixThaumcraftGolemMarkerLoading=true
 
@@ -340,7 +511,7 @@ fixes {
     # Implement a proper hashing method for WorldCoordinates [default: true]
     B:fixThaumcraftWorldCoordinatesHashingMethod=true
 
-    # Fix time commands with GC [default: true]
+    # Fix time commands with Galacticraft [default: true]
     B:fixTimeCommandWithGC=true
 
     # Fix too many allocations from Chunk Coordinate Int Pair [default: true]
@@ -352,11 +523,17 @@ fixes {
     # Fix URISyntaxException in forge. [default: true]
     B:fixUrlDetection=true
 
+    # Fix Vanilla IOOBE when rendering chunks at a distance larger than 16 [default: true]
+    B:fixVanillaIOOBERenderDistance=true
+
     # Fixes various unchecked vanilla getBlock() methods [default: true]
     B:fixVanillaUnprotectedGetBlock=true
 
     # Fixes village unchecked getBlock() calls [default: true]
     B:fixVillageUncheckedGetBlock=true
+
+    # Fix Villagers only updating out-of-stock state after reopening GUI [default: true]
+    B:fixVillagerTradingDesync=true
 
     # Fix some NullPointerExceptions [default: true]
     B:fixVoxelMapChunkNPE=true
@@ -367,6 +544,14 @@ fixes {
     # Fix Thaumcraft wand pedestal vis duplication [default: true]
     B:fixWandPedestalVisDuplication=true
 
+    # Prevent the Witchery Demon's trading menu from opening when shift-clicking.
+    # This allows for some item interactions that are otherwise impossible,
+    # such as capturing the Demon in an EnderIO Soul Vial. [default: true]
+    B:fixWitcheryDemonShiftClick=true
+
+    # Fix EndlessIds incompatibility with Witchery [default: true]
+    B:fixWitcheryEid=true
+
     # Fixes Witchery player skins reflections with inhabited mirrors [default: true]
     B:fixWitcheryReflections=true
 
@@ -376,11 +561,8 @@ fixes {
     # Enhanced Witchery Thunder Detection for rituals and Witch Hunters [default: true]
     B:fixWitcheryThunderDetection=true
 
-    # Fix unprotected getBlock() in World [default: true]
-    B:fixWorldGetBlock=true
-
-    # Fix WorldServer leaking entities when no players are present in a dimension [default: true]
-    B:fixWorldServerLeakingUnloadedEntities=true
+    # Prevent recursive immediate block updates during WorldGenLiquids spring generation [default: true]
+    B:fixWorldGenLiquidsRecursion=true
 
     # Fix server-side check of block placement distance by players being not identical client-side checks [default: true]
     B:fixWrongBlockPlacementDistanceCheck=true
@@ -421,8 +603,31 @@ fixes {
     # Fix Volume Slider is ineffective until reaching the lower end [default: true]
     B:logarithmicVolumeControl=true
 
+    # Set lotr updateLangFiles to false by default, as it is incompatible with the Gradle cache (breaking dev environments) and very rarely needed [default: true]
+    B:lotrLanguageHelperDefault=true
+
+    # Fix slimes resetting their health to maximum when being loaded from NBT (world reload, dimension change, etc.) [default: true]
+    B:maintainSlimeHealth=true
+
     # The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB). [range: 1024 ~ 1073741824, default: 268435456]
     I:maxNetworkNbtSizeLimit=268435456
+
+    # Sets a minimum of 0 for Looting. Negative values still exist, but are treated as 0 for most purposes. Fixes crashes when killing mobs with negative looting, if you somehow manage to achieve it. [default: true]
+    B:minLootingIsZero=true
+
+    # Override the server-side 'moved too quickly' speed check threshold.
+    # Vanilla value is 100.0 (squared distance per tick, i.e. 10 blocks/tick in a single axis).
+    # Increase this if fast-movement items like GraviChestplate + ThaumicBoots trigger the check.
+    # A value of 200.0 accommodates ~14 blocks/tick and covers known modded items.
+    # Set to a very large number (e.g. 1.7976931348623157E308) to effectively disable the check.
+    # Values below 100.0 are ignored and the vanilla default is used instead. [range: 4.9E-324 ~ 1.7976931348623157E308, default: 100.0]
+    D:movedTooQuicklyThreshold=100.0
+
+    # Don't pause the game when using the Bibliocraft clipboard GUI [default: true]
+    B:noPauseGuiClipboard=true
+
+    # Only load languages once per File instead of once per Mod [default: true]
+    B:onlyLoadLanguagesOnce=true
 
     # Optimize inventory access to IC2 nuclear reactor [default: true]
     B:optimizeIc2ReactorInventoryAccess=true
@@ -433,8 +638,29 @@ fixes {
     # The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB). [range: 1024 ~ 1073741824, default: 268435456]
     I:packetSizeLimit=268435456
 
+    # [Game Breaking Config] Prevents block and entity updates from loading unloaded chunks.
+    # This is very likely to break some behaviors in game in favor of better TPS stability.
+    # This is intended for server owners facing TPS issues. If you play singleplayer just be
+    # sure all your infrastructure is properly chunk loaded. If you are still facing TPS issues
+    # make a CPU profile and we'll try to patch the mod causing it.
+    # DO NOT report any bugs if you have this enabled.
+    # Disable the setting and see if the bug still happens before reporting anything [default: false]
+    B:preventChunkLoadingFromBlockUpdates=false
+
+    # Prevent Zombies & Skeletons from flickering with fire when exposed to the sun while immune to fire (in particular, Wither Skeletons) [default: true]
+    B:preventFireImmuneUndeadFlicker=true
+
+    # Prevent ClassCastException on forming invalid Thermal Dynamic fluid grid [default: true]
+    B:preventFluidGridCrash=true
+
+    # Prevent moving mouse cursor to the center when pressing Esc in GUIs [default: true]
+    B:preventMouseCenteringOnEscInGUIs=true
+
     # Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers [default: true]
     B:preventThermalDynamicsNASE=true
+
+    # Raise FPS limit in the FML missing items screen (or any other FML StartupQuery). [default: true]
+    B:raiseMissingItemsFPS=true
 
     # Spigot-style extended chunk format to remove the 2MB chunk size limit [default: true]
     B:remove2MBChunkLimit=true
@@ -445,14 +671,24 @@ fixes {
     # Disable the creative search tab since it can be very laggy in large modpacks [default: true]
     B:removeCreativeSearchTab=true
 
+    # Remove invalid Entities in chunks. [default: true]
+    B:removeInvalidChunkEntites=true
+
     # Remove old/stale/outdated update checks. [default: true]
     B:removeUpdateChecks=true
 
-    # Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working) [default: true]
-    B:speedupAnimations=true
+    # Return items placed in Traveller's Gear slots after the mod is removed when players log in.
+    # Sends messages to the log that start with "[Hodgepodge]: [TG Recovery]".
+    # Removes players from the TG items file after returning items. Deletes it if it's empty.
+    # Automatically disables itself on servers after deleting the TG items file.
+    # Clients leave it on to allow for joining multiple SP worlds with TG items. [default: true]
+    B:returnTravellersGearItems=true
 
     # Stop "You can only sleep at night" message filling the chat [default: true]
     B:squashBedErrorMessage=true
+
+    # Synchonize from server to client the thrower and pickup delay of an item entity [default: true]
+    B:syncItemThrower=true
 
     # Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag [default: true]
     B:throttleItemPickupEvent=true
@@ -460,11 +696,17 @@ fixes {
     # Triggers all conflicting key bindings on key press instead of a random one [default: true]
     B:triggerAllConflictingKeybindings=true
 
+    # Updates the difficulty on every connected client when the difficulty of the server changes via /difficulty or the difficulty button. [default: true]
+    B:updateClientDifficultyOnServer=true
+
     # Validate vanilla packet encodings before sending in addition to on reception [default: true]
     B:validatePacketEncodingBeforeSending=true
 
     # Should the extended packet validation error cause a crash (true) or just print out an error to the log (false) [default: false]
     B:validatePacketEncodingBeforeSendingShouldCrash=false
+
+    # Makes Wither Skeletons not appear as just "Skeleton" in death messages and WAILA. [default: true]
+    B:witherSkeletonSpecialName=true
 }
 
 
@@ -472,15 +714,269 @@ general {
 }
 
 
+memory {
+
+    ##########################################################################################################
+    # leaks
+    #--------------------------------------------------------------------------------------------------------#
+    # Memory leak fixes
+    ##########################################################################################################
+
+    leaks {
+        # Fix memory leaks in bibliocraft's tile entity renderers [default: true]
+        B:fixBibliocraftTESRWorldLeak=true
+
+        # Fix CoFH WorldServer leak in main mod class [default: true]
+        B:fixCoFHWorldLeak=true
+
+        # Fix Enchantment Helper leaking world instance when leaving world [default: true]
+        B:fixEnchantmentHelperLeak=true
+
+        # Fix ItemRenderer keeping a reference to the last rendered item when leaving a world [default: true]
+        B:fixEntityRendererItemRendererLeak=true
+
+        # Fix EventBus keeping object references after unregistering event handlers. [default: true]
+        B:fixEventBusMemoryLeak=true
+
+        # Fix forge's FakePlayerFactory leaking the world instance [default: true]
+        B:fixForgePlayerFactoryLeak=true
+
+        # Fix IC2 block reactor leaking world instance when leaving world [default: true]
+        B:fixIC2BlockReactorLeak=true
+
+        # Fix IC2 TESR leaking the world instance [default: true]
+        B:fixIC2TESRleak=true
+
+        # Clears the reference to the minecraft server once it has stopped [default: true]
+        B:fixMinecraftServerLeak=true
+
+        # Fix NetHandlerClient leaking world instance when leaving world [default: true]
+        B:fixNetHandlerClientWorldLeak=true
+
+        # Fix memory leak caused by FML network channels attributes [default: true]
+        B:fixNetworkChannelsMemoryLeak=true
+
+        # Fix PlayerController leaking world instance when leaving world [default: true]
+        B:fixPlayerControllerWorldLeak=true
+
+        # Fix PointedEntity leaking world instance when leaving world [default: true]
+        B:fixPointedEntityLeak=true
+
+        # Fix redstone torch leaking world [default: true]
+        B:fixRedstoneTorchWorldLeak=true
+
+        # Fix RenderBlocks static singleton leaking world instance when leaving world [default: true]
+        B:fixRenderBlocksWorldLeak=true
+
+        # Fix Render Falling Block leaking world instance when leaving world [default: true]
+        B:fixRenderFallingBlockLeak=true
+
+        # Fix RenderManager leaking world instance when leaving world [default: true]
+        B:fixRenderManagerWorldLeak=true
+
+        # Fix EffectRenderer and RenderGlobal leaking world instance when leaving world [default: true]
+        B:fixRenderersWorldLeak=true
+
+        # Fix memory leak caused by minecraft's commandBase keeping a static reference to the server command handler [default: true]
+        B:fixServerCommandHandlerLeak=true
+
+        # Fix skin manager leaking client world [default: true]
+        B:fixSkinManagerLeakingClientWorld=true
+
+        # Fix TileEntityRenderer leaking world instance when leaving world [default: true]
+        B:fixTileEntityRendererWorldLeak=true
+
+        # Fix World static map storage leaking the server world [default: true]
+        B:fixWorldMapStorageLeak=true
+
+        # Fix WorldServer leaking entities when no players are present in a dimension [default: true]
+        B:fixWorldServerLeakingUnloadedEntities=true
+    }
+
+    ##########################################################################################################
+    # allocs
+    #--------------------------------------------------------------------------------------------------------#
+    # Memory allocation fixes
+    ##########################################################################################################
+
+    allocs {
+        # Caches the advanced Model renderers to speedup loading and avoid wasting memory with duplicate models [default: true]
+        B:cacheAdvancedModels=true
+
+        # Clear FML Texture Errors to free memory [default: true]
+        B:clearFMLTextureErrors=true
+
+        # Reduces the RAM usage of the ASMDataTable by interning the Strings [default: false]
+        B:deduplicateASMDataTableStrings=false
+
+        # Stops witchery from spamming Enum#values() [default: true]
+        B:fixWitcheryEnumValuesSpam=true
+
+        # Reduce the memory usage from resource location domain strings [default: false]
+        B:internResourceLocationDomain=false
+
+        # Reduce the memory usage from unique identifier modid strings [default: false]
+        B:internUniqueIdentifierModid=false
+    }
+
+}
+
+
+sound {
+    # Attenuation model to use if not specified. Attenuation is how a source's volume fades with distance.
+    # ATTENUATION_NONE: Global identifier for no attenuation. Attenuation is how a source's volume fades with distance. When there is no attenuation, a source's volume remains constant regardless of distance.
+    # ATTENUATION_ROLLOFF: Global identifier for rolloff attenuation. Rolloff attenuation is a realistic attenuation model, which uses a rolloff factor to determine how quickly a source fades with distance. A smaller rolloff factor will fade at a further distance, and a rolloff factor of 0 will never fade. NOTE: In OpenAL, rolloff attenuation only works for monotone sounds.
+    # ATTENUATION_LINEAR: Global identifier for linear attenuation. Linear attenuation is less realistic than rolloff attenuation, but it allows the user to specify a maximum "fade distance" where a source's volume becomes zero.
+    # Possible values: [ATTENUATION_NONE, ATTENUATION_ROLLOFF, ATTENUATION_LINEAR]
+    #  [default: ATTENUATION_ROLLOFF]
+    S:defaultAttenuationModel=ATTENUATION_ROLLOFF
+
+    # Default value to use for fade distance if not specified. [range: 1.4E-45 ~ 3.4028235E38, default: 1000.0]
+    S:defaultFadeDistance=1000.0
+
+    # Default value to use for the rolloff factor if not specified. [range: 1.4E-45 ~ 3.4028235E38, default: 0.03]
+    S:defaultRolloffFactor=0.03
+
+    # Value to use for the Doppler factor, for determining Doppler scale. [range: 1.4E-45 ~ 3.4028235E38, default: 0.0]
+    S:dopplerFactor=0.0
+
+    # Value to use for the Doppler velocity. [range: 1.4E-45 ~ 3.4028235E38, default: 1.0]
+    S:dopplerVelocity=1.0
+
+    # Sounds whose path contains any of these are never downmixed, so interface sounds keep their stereo.
+    # Matched case-insensitively against 'domain:path', e.g. 'gregtech:sounds/buttonup.ogg'.
+    # Only used by downmixStereoSounds. spatializeStereoSounds needs no list because it decides per playback from the attenuation model.
+    # Broad patterns can also match world sounds; those stay stereo and cannot be positioned by the downmix fallback. [default: [button], [click], [/gui], [menu], [typing], [page]]
+    S:downmixExclusions <
+        button
+        click
+        /gui
+        menu
+        typing
+        page
+     >
+
+    # Downmix non-streaming stereo OGG sounds to mono, halving their decoded PCM size and allowing positional audio.
+    # Non-streaming is used as a proxy for positional, so rare non-positional effects may also be downmixed. Streaming sounds, normally music and records, are unaffected.
+    # Ignored for sounds handled by spatializeStereoSounds. Takes full effect after 'Reload Sounds' or a restart. [default: true]
+    B:downmixStereoSounds=true
+
+    # Add environmental reverb to positional sounds based on how enclosed the listener is. Requires OpenAL EFX, available in the bundled Java 8 and lwjgl3ify backends.
+    # Surroundings are estimated by sampling 12 directions up to 20 blocks four times per second.
+    # Takes full effect after 'Reload Sounds' or a restart. [default: false]
+    B:environmentalReverb=false
+
+    # Size of each chunk used by non-streaming codecs that honor it. OGG uses streamingBufferSize to keep decode copying bounded. [range: -2147483648 ~ 2147483647, default: 1048576]
+    I:fileChunkSize=1048576
+
+    # Binaural 3D audio for headphones (HRTF): lets you hear whether a sound is above, below, in front or behind you, instead of just left/right.
+    # Designed for headphones; speakers may sound hollow or coloured. DEFAULT leaves it to OpenAL's device configuration, ON forces it, OFF forces it off.
+    # Requires lwjgl3ify; ignored on Java 8.
+    # Possible values: [DEFAULT, ON, OFF]
+    #  [default: DEFAULT]
+    S:hrtf=DEFAULT
+
+    # Maximum decoded size of a non-streaming sound. OGG decoding stops at this limit on a complete PCM frame. Streamed sounds are unaffected. [range: -2147483648 ~ 2147483647, default: 268435456]
+    I:maxFileSize=268435456
+
+    # Maximum number of normal (non-streaming) channels available for simultaneous sound effects.
+    # OpenAL Soft defaults to 256 sources unless overridden. If fewer are available, Paulscode creates as many channels as it can.
+    # Takes effect after 'Reload Sounds' in the sound options, or a restart. [range: -2147483648 ~ 2147483647, default: 64]
+    I:numberNormalChannels=64
+
+    # Number of buffers used for each streaming source. Slow codecs may require this number to be greater than 2 to prevent audio skipping during playback. [range: -2147483648 ~ 2147483647, default: 3]
+    I:numberStreamingBuffers=3
+
+    # Maximum number of streaming channels: music, records, and other streamed audio playing at once.
+    # Takes effect after 'Reload Sounds' in the sound options, or a restart. [range: -2147483648 ~ 2147483647, default: 8]
+    I:numberStreamingChannels=8
+
+    # Protects the final output mix from clipping by reducing gain when its combined level exceeds the device range.
+    # It reacts to signal level, not the number of playing sounds, and does not limit sound or channel count.
+    # DEFAULT leaves it to OpenAL, ON forces it, OFF disables it. Requires lwjgl3ify; ignored on Java 8.
+    # Possible values: [DEFAULT, ON, OFF]
+    #  [default: DEFAULT]
+    S:outputLimiter=DEFAULT
+
+    # MIDI device to try using as the Synthesizer. May be the full name or part of the name. If this String is empty, the default Synthesizer will be used, or one of the common alternate synthesizers if the default Synthesizer is unavailable. [default: ]
+    S:overrideMIDISynthesizer=
+
+    # Discard the Java-heap PCM copy after a non-streaming sound is uploaded to OpenAL, removing one of the two cached decoded copies.
+    # Turn off only if you suspect it of causing missing or corrupted sounds. Takes full effect after 'Reload Sounds' or a restart. [default: true]
+    B:releaseDecodedSoundData=true
+
+    # How wet the reverb gets in a fully enclosed space. Lower is subtler.
+    # Only used when environmentalReverb is on. [range: 0.0 ~ 1.0, default: 0.3]
+    S:reverbStrength=0.3
+
+    # Let OpenAL position stereo sounds that use distance attenuation without converting them to mono. This preserves the stereo PCM but uses roughly twice the buffer memory of mono.
+    # Requires lwjgl3ify and AL_SOFT_source_spatialize; otherwise downmixStereoSounds can provide the fallback.
+    # Takes full effect after 'Reload Sounds' or a restart. [default: true]
+    B:spatializeStereoSounds=true
+
+    # Enables a transition-speed optimization by assuming all sounds in each streaming source's queue will have exactly the same format once decoded (including channels, sample rate, and sample size). This is an advanced setting which should only be changed by experienced developers.
+    # NOTE: I have not checked if this is even true for vanilla. Changing this setting will most likely break things. [default: false]
+    B:streamQueueFormatsMatch=false
+
+    # Number of bytes to load at a time when streaming. [range: -2147483648 ~ 2147483647, default: 131072]
+    I:streamingBufferSize=131072
+}
+
+
 speedups {
-    # Removes hard caps on chunk handling speed. Experimental and probably incompatible with hybrid servers! [default: false]
+    # When to amortize chunk generation overruns by tracking time debt and skipping generation until the debt is paid down. Smooths out server tick times when single chunks exceed the time budget. DedicatedServerOnly enables on multiplayer servers but not singleplayer/LAN. [Requires throttleChunkGeneration]
+    # Possible values: [Always, DedicatedServerOnly, Never]
+    #  [default: DedicatedServerOnly]
+    S:amortizeChunkGenOverruns=DedicatedServerOnly
+
+    # Parse batched tile entity NBT asynchronously on the client [default: true]
+    B:asyncBatchedNBTParsing=true
+
+    # Load texture map icons on multiple threads [default: false]
+    B:asyncIconLoading=false
+
+    # Tile Entity Packet Batching Blacklist (Fully Qualified Class Names, Does not require restart) [default: ]
+    S:batchDescriptionBlacklist <
+     >
+
+    # Batch Tile Entity Description S35PacketUpdateTileEntity Packets (Enables Code, Does not require restart) [default: true]
+    B:batchDescriptionPacketsCode=true
+
+    # Batch Tile Entity Description S35PacketUpdateTileEntity Packets (Enables Mixins, Requires Restart) [default: true]
+    B:batchDescriptionPacketsMixins=true
+
+    # Compression level for chunk saving. -1=default, 0=none, 1=fastest, 9=smallest. [range: -1 ~ 9, default: -1]
+    I:chunkCompressionLevel=-1
+
+    # Time budget in milliseconds for chunk generation per tick. Actual budget is min(this, remaining tick time to 50ms). Generation is skipped when recent operations suggest the budget would be exceeded. 0 = no time limit (count-based only). [Requires throttleChunkGeneration] [range: 0 ~ 50, default: 20]
+    I:chunkGenBudgetMs=20
+
+    # Skip rendering item frame contents farther than 64 blocks and entire frames farther than 96 blocks [default: true]
+    B:cullDistantItemFrameContents=true
+
+    # Accelerate Block.getBlockById() and Block.getIdFromBlock(). [default: true]
+    B:fastBlockLookup=true
+
+    # Removes hard caps on chunk sending and unloading speed. Experimental and probably incompatible with hybrid servers! [default: false]
     B:fastChunkHandling=false
 
     # Rewrites internal cache methods to be safer and faster. Experimental, use at your own risk! [default: false]
     B:fastIntCache=false
 
+    # Improves the performance of items significantly by not checking collisions against other entities for them. (Adapted from FalseTweaks) [default: true]
+    B:fastItemEntityPhysics=true
+
+    # Replaces uses of java.util.Random with a faster version, skipping atomic operations. [default: true]
+    B:fastRandom=true
+
+    # Ticks before a visible chunk hole is force-processed regardless of budget. Only applies to chunks within view distance of a player. 0 = disabled. [range: 0 ~ 1200, default: 100]
+    I:forcePopulateAgeTicks=100
+
     # Limit mob spawning to the view distance [default: true]
     B:limitMobSpawningToViewDistance=true
+
+    # Maximum deferred chunk generations per player per tick. Higher values fill terrain faster but increase per-tick lag from worldgen. [Requires throttleChunkGeneration] [range: 1 ~ 20, default: 4]
+    I:maxChunkGenPerPlayerPerTick=4
 
     # The maximum speed of chunkloading per player, in chunks/tick. High values may overload clients! Only active with fastChunkHandling.
     # For reference: Vanilla is 5, or 100 chunks/sec. At 32 render distance = 4225 chunks, loading the world would take 42.25 seconds. [range: 5 ~ 2147483647, default: 50]
@@ -493,6 +989,9 @@ speedups {
     # Optimize ASMDataTable getAnnotationsFor for faster startup [default: true]
     B:optimizeASMDataTable=true
 
+    # Reduce regex overhead when scanning jar entries for class files during FML mod discovery [default: true]
+    B:optimizeJarDiscovererRegexOverhead=true
+
     # Optimize mob spawning [default: true]
     B:optimizeMobSpawning=true
 
@@ -502,11 +1001,48 @@ speedups {
     # Optimize tileEntity removal in World.class [default: true]
     B:optimizeTileentityRemoval=true
 
+    # Reduce regex overhead when loading object models [default: true]
+    B:optimizeWavefrontObjectModelLoading=true
+
+    # Pool Inflater/Deflater instances for NBT compression to reduce native cleanup overhead [default: true]
+    B:poolZlibInstances=true
+
+    # Prevent entity ticks and random ticks from triggering chunk generation. Missing chunks return empty air blocks during blocked phases; the scheduler loads them shortly after. [Requires throttleChunkGeneration] [default: true]
+    B:preventEntityChunkLoading=true
+
+    # Prevents flowing liquids from loading chunks [default: true]
+    B:preventLoadingChunksWhenLiquidsFlow=true
+
+    # Prevents Vanilla entities from loading chunks when pathfinding [default: true]
+    B:preventLoadingChunksWhenPathfinding=true
+
+    # Prevents Vanilla blocks from loading chunks when ticking
+    # Cocoa, Crop, Fire, Grass, Vine, Farmland, Mushroom, Mycelium, Sapling, Stem, Torch [default: true]
+    B:preventLoadingChunksWhenTickingBlocks=true
+
+    # Remove icon loading on texture map init [default: false]
+    B:removeExtraIconLoad=true
+
     # Replace reflection in VoxelMap to directly access the fields instead. [default: true]
     B:replaceVoxelMapReflection=true
 
+    # Skip mob spawning in chunks with pending lighting updates (requires Supernova) [default: true]
+    B:skipSpawningWithPendingLight=true
+
+    # Skip scheduling falling block ticks when the block below is solid [default: true]
+    B:skipUselessFallingBlockTicks=true
+
+    # Cache allocations in BOP biome decoration to avoid per-chunk object creation and reflection [default: true]
+    B:speedupBOPBiomeDecoration=true
+
+    # Use fast atan2 approximation for BOP Pixie entity yaw calculation [default: true]
+    B:speedupBOPEntityPixie=true
+
     # Speedup biome fog rendering in BiomesOPlenty [default: true]
     B:speedupBOPFogHandling=true
+
+    # Optimize chunk compression with reused deflater and batched writes [default: true]
+    B:speedupChunkCompression=true
 
     # Speedup ChunkCoordinates hashCode [default: true]
     B:speedupChunkCoordinatesHashCode=true
@@ -514,21 +1050,42 @@ speedups {
     # Speeds up ChunkProviderClient by removing chunkListing.  Note: Depends on asm.speedupLongIntHashMap [default: true]
     B:speedupChunkProviderClient=true
 
-    # Speed up grass block random ticking [default: true]
-    B:speedupGrassBlockRandomTicking=true
+    # Optimized chunk unloading with fastutil collections and batched removal [default: true]
+    B:speedupChunkUnload=true
 
-    # Speed up NBT copying [default: true]
-    B:speedupNBTCopy=true
+    # Speedup IC2 reactor size computation [default: true]
+    B:speedupIC2ReactorSize=true
+
+    # BFS leaf decay with early exit on nearby logs, replacing vanilla's full scan [default: true]
+    B:speedupLeafDecay=true
+
+    # Spatial index for pending block updates, accelerates chunk saving and unloading [default: true]
+    B:speedupPendingTickLookup=true
+
+    # Speed up the vanilla method to remove formatting codes [default: true]
+    B:speedupRemoveFormatting=true
+
+    # Speedup ThaumcraftApi#getInfusionRecipes [default: true]
+    B:speedupThaumGetInfusionRecipes=true
 
     # Speedup Vanilla Furnace recipe lookup [default: true]
     B:speedupVanillaFurnace=true
 
     # Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks [default: true]
     B:tcpNoDelay=true
+
+    # Spread chunk generation across ticks to reduce server stalls when players move through ungenerated terrain.  [default: true]
+    B:throttleChunkGeneration=true
+
+    # Replaces a boxed primitive map in MapGenStructure with the fastutil equivalent, to reduce allocations. [default: true]
+    B:unboxMapGen=true
 }
 
 
 tweaks {
+    # Add BOP lavenders to the bone meal pool in lavender fields [default: true]
+    B:addBOPLavenderToBoneMealPool=true
+
     # Add CV support to Thaumcraft wand recharge pedestal [default: true]
     B:addCVSupportToWandPedestal=true
 
@@ -544,8 +1101,14 @@ tweaks {
     # Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture) [default: true]
     B:addSystemInfo=true
 
+    # Adds the 'get' subcommand to /time to query the current time [default: false]
+    B:addTimeGet=false
+
     # Add a debug message in the chat when toggling vanilla debug options [default: true]
     B:addToggleDebugMessage=true
+
+    # Allows players in Creative to eat food. [default: true]
+    B:allowEatingFoodInCreative=true
 
     # The max amount of XP levels an anvil recipe can use. [range: -2147483648 ~ 2147483647, default: 40]
     I:anvilMaxLevel=2147483647
@@ -568,20 +1131,38 @@ tweaks {
     # Show "cannot sleep" messages above hotbar [default: true]
     B:bedMessageAboveHotbar=true
 
+    # Better ModList [default: true]
+    B:betterModList=true
+
     # Changes the file extension of VoxelMap's cache files from .zip to .data to stop the TechnicLauncher from deleting them when updating [default: true]
     B:changeCacheFileExtension=true
 
     # Moves the sprint keybind to the movement category [default: true]
-    e:changeSprintCategory=true
+    S:changeSprintCategory=true
 
     # Amount of chat lines kept (Vanilla: 100) [range: 100 ~ 32767, default: 8191]
     I:chatLength=8191
 
+    # Removes the color codes from the chat logs [default: true]
+    B:cleanChatLogs=true
+
     # Compacts identical consecutive chat messages together [default: true]
     B:compactChat=true
 
+    # Override the vanilla delay between in-game music tracks using musicDelayMinSeconds/musicDelayMaxSeconds. [default: true]
+    B:configurableMusicDelay=true
+
+    # Allow creative tab gui title color via localization key [default: true]
+    B:creativeTabLocalizationOverrides=true
+
     # Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port. [range: 0 ~ 65535, default: 25565]
     I:defaultLanPort=25565
+
+    # Controls the default sorting on the mod list GUI.
+    # 0 - Default sort (load order)
+    # 1 - A to Z sort
+    # 2 - Z to A sort [range: 0 ~ 2, default: 1]
+    I:defaultModSort=1
 
     # Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far. [default: true]
     B:disableAidSpawnByXUSpikes=true
@@ -619,14 +1200,14 @@ tweaks {
     # Open an integrated server on a static port. [default: true]
     B:enableDefaultLanPort=true
 
-    # Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.) [default: true]
-    B:enableMacosCmdShortcuts=true
-
     # Enable string pooling for NBT Strings - trades performance for memory [default: false]
     B:enableNBTStringPooling=false
 
     # Enable string pooling for NBT TagCompound Keys [default: true]
     B:enableTagCompoundStringPooling=true
+
+    # Use CTRL (CMD on MacOS) to COPY / PASTE / SELECT ALL / CUT in text fields (Chat, NEI, Server IP etc.), fixes these shortcuts not working with some keyboard layouts [default: true]
+    B:enableTextFieldCtrlShortcuts=true
 
     # Shows renderer's impact on FPS in vanilla lagometer [default: true]
     B:enableTileRendererProfiler=true
@@ -668,6 +1249,15 @@ tweaks {
     # Ender Quarry RF Storage Override (ExU default value: 10000000) (0 to use default value) [range: 0 ~ 2147483647, default: 0]
     I:extraUtilitiesEnderQuarryOverride=200000000
 
+    # Enable extra F1 toggle to hide GUI but keep rendering hand [default: false]
+    B:f1ShowHand=false
+
+    # Replaces night vision expiry effect with a fade-out effect [default: true]
+    B:fadeNightVision=true
+
+    # Night vision fade-out duration (in ticks) [range: -2147483648 ~ 2147483647, default: 50]
+    I:fadeNightVisionDuration=50
+
     # Allows blocks to be placed at a faster rate (toggleable via keybind) [default: false]
     B:fastBlockPlacing=false
 
@@ -686,8 +1276,14 @@ tweaks {
     # Prevents the inventory from shifting when the player has active potion effects [default: true]
     B:fixPotionRenderOffset=true
 
+    # Stops rendering the crosshair when a GUI screen (e.g. an inventory) is open [default: true]
+    B:hideCrosshairInGui=true
+
     # Stops rendering the crosshair when you are playing in third person [default: true]
     B:hideCrosshairInThirdPerson=true
+
+    # Remove the notice about numeric ID deprecation that appears when a command uses them [default: true]
+    B:hideDeprecatedIdNotice=true
 
     # Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor [default: true]
     B:hideIc2ReactorSlots=true
@@ -695,17 +1291,41 @@ tweaks {
     # Stops rendering potion particles from yourself [default: true]
     B:hidePotionParticlesFromSelf=true
 
-    # Give IC2 cells containers like GregTech cells do [default: true]
+    # Hides the texture errors in the log. [default: true]
+    B:hideTextureErrors=true
+
+    # Add a gamerule to disable hunger [default: true]
+    B:hungerGameRule=true
+
+    # Give IC2 cells containers like GregTech cells do [default: false]
     B:ic2CellWithContainer=true
+
+    # Allow Dispensers to dispense IC2 ITNT. [default: true]
+    B:ic2DispenserITNT=true
 
     # IC2 seed max stack size [range: 1 ~ 64, default: 64]
     I:ic2SeedMaxStackSize=64
+
+    # Improve CoFH's breakBlock method [default: true]
+    B:improveCofhBreakBlock=true
+
+    # Improves MineFactory Reloaded breaker block to support other mods manipulating its drops [default: true]
+    B:improveMfrBlockBreaker=true
+
+    # Improves MineFactory Reloaded smasher block to support other mods manipulating its drops [default: true]
+    B:improveMfrBlockSmasher=true
+
+    # Add a accurate hitbox to the redstone wire [default: true]
+    B:improvedRedstoneWireHitbox=true
 
     # Increase particle limit [default: true]
     B:increaseParticleLimit=true
 
     # Wake up passive & personal anchors on player login [default: true]
     B:installAnchorAlarm=true
+
+    # Translate Forge's Mod Options button in the pause menu [default: true]
+    B:localizeForgeModOptionsButton=true
 
     # Makes the chat history longer instead of 100 lines [default: true]
     B:longerChat=true
@@ -716,17 +1336,44 @@ tweaks {
     # Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree [default: true]
     B:makeBigFirsPlantable=true
 
+    # Max hold time for F3+C to copy player location instead of causing a crash. Set to 0 to disable this. [range: 0 ~ 1000, default: 500]
+    I:maxHoldF3CForCopy=500
+
     # Adds pick block functionality to survival mode [default: true]
     B:modernPickBlock=true
 
+    # Makes the int cache size more readable [default: true]
+    B:moreReadableIntCacheSize=true
+
+    # Maximum delay between in-game music tracks, in seconds. 1.7.10 GAME: 1200. Modern GAME: 300. Clamped to >= musicDelayMinSeconds at use time. [range: 0 ~ 3600, default: 300]
+    I:musicDelayMaxSeconds=300
+
+    # Minimum delay between in-game music tracks, in seconds. 1.7.10 GAME: 600. Modern GAME: 5. Only applies to long-form music types (game/creative/nether/end), not menu/credits. [range: 0 ~ 3600, default: 5]
+    I:musicDelayMinSeconds=5
+
+    # Nether portal coordinate conversion ratio (Vanilla: 8.0). Controls how Overworld and Nether coordinates are scaled when traveling through portals [range: 0.125 ~ 64.0, default: 8.0]
+    D:netherPortalRatio=8.0
+
     # Particle limit (Vanilla: 4000) [range: 4000 ~ 16000, default: 8000]
     I:particleLimit=8000
+
+    # Prevents ModularPowerSuits from charging and draining EU energy from other non-MPS items in inventory [default: false]
+    B:preventMPSEnergyTransferEU=false
+
+    # Prevents ModularPowerSuits from charging and draining ME energy from other non-MPS items in inventory [default: false]
+    B:preventMPSEnergyTransferME=false
+
+    # Prevents ModularPowerSuits from charging and draining RF energy from other non-MPS items in inventory [default: false]
+    B:preventMPSEnergyTransferRF=false
 
     # Prevent monsters from picking up loot. [default: true]
     B:preventPickupLoot=true
 
     # Adds a button in the sounds menu to reload the sound system without needing to press F3 + S [default: true]
     B:reloadSoundsButton=true
+
+    # Remove the BOP donator effect which blocks the main thread when starting the game [default: true]
+    B:removeBOPDonatorEffect=true
 
     # Remove the BOP quicksand generation [default: false]
     B:removeBOPQuicksandGeneration=false
@@ -737,18 +1384,36 @@ tweaks {
     # Stop playing a sound when spawning a minecart in the world [default: true]
     B:removeSpawningMinecartSound=true
 
-    # Synchronize IC2 reactors to the world tick time, allowing for tick-perfect automation. [default: false]
-    B:synchronizeIC2Reactors=true
-
     # Save Mineshaft data (Requires threadedWorldDataSaving for changes to take effect)
     # Might cause small worldgen issues if disabled; equivalent to removing the file on each boot if disabled [default: true]
     B:saveMineshaftData=true
 
+    # Show potion effect icons in inventory screens [default: true]
+    B:showInventoryEffectIcons=true
+
+    # Sign input counts visible characters only, ignoring color format codes like &RRGGBB [default: true]
+    B:signInputIgnoresFormatCodes=true
+
+    # Simulation distance (needs addSimulationDistance_WIP to be active) [range: -2147483648 ~ 2147483647, default: 32]
+    I:simulationDistance=32
+
+    # Skips playing empty sounds. [default: true]
+    B:skipEmptySounds=true
+
     # Sort Mob stats lexicographically (Requires addModEntityStats) [default: true]
     B:sortEntityStats=true
 
+    # Adds a button in the sounds menu for Hodgepodge's sound enhancements [default: true]
+    B:soundEnhancementsButton=true
+
     # String pooling mode (0 = Java intern, 1 = Guava strong interner, 2 = Guava weak interner) [range: 0 ~ 2, default: 1]
     I:stringPoolMode=1
+
+    # Synchronize IC2 reactors to the world tick time, allowing for tick-perfect automation. [default: false]
+    B:synchronizeIC2Reactors=true
+
+    # Use a custom textured scrollbar [default: true]
+    B:texturedScrollbar=true
 
     # Implement container for thirsty tank [default: true]
     B:thirstyTankContainer=true
@@ -764,6 +1429,9 @@ tweaks {
 
     # Reduces water opacity from 3 to 1, to match modern [default: false]
     B:useLighterWater=false
+
+    # Fix the metadata of potions dropped and thrown by witches. [default: true]
+    B:witchPotionMetadata=true
 }
 
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
fresh hodgepodge config taken from daily 683, in which i also turned on `removeExtraIconLoad` as it was disabled in a very conservative fashion with `asyncIconLoading`, which was causing issues. This shaves a bit of loading time during resource reload.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
