### PR TITLE
Changed the Wireframe linehight to 2.5 like the user suggests (#26380)

### DIFF
--- a/config/GregTech/Client.cfg
+++ b/config/GregTech/Client.cfg
@@ -275,8 +275,8 @@ client {
         # The green color of the block overlay [range: 0 ~ 255, default: 0]
         I:green=0
 
-        # The line width of the block overlay [range: 0.0 ~ 30.0, default: 5]
-        S:lineWidth=5
+        # The line width of the block overlay [range: 0.0 ~ 30.0, default: 2.5]
+        S:lineWidth=2.5
 
         # The red color of the block overlay [range: 0 ~ 255, default: 0]
         I:red=0


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Closes #26380

This pr changes the Wireframe linehight from the gregtech client config as the user suggests bc. sometimes the wireframe doesn't render correctly when the linehight is 5.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
