### PR TITLE
add new config entry for BLS so DAXXL can override it for mobile

### DIFF
--- a/config/Betterloadingscreen/betterloadingscreen.cfg
+++ b/config/Betterloadingscreen/betterloadingscreen.cfg
@@ -32,6 +32,11 @@ general {
     # What sound to play when loading is complete. Default is the level up sound (betterloadingscreen:rhapsodia_orb) [default: betterloadingscreen:rhapsodia_orb]
     S:sound=minecraft:random.orb
 
+    # Render the loading screen on a separate thread using a shared OpenGL context.
+    # Disable this on platforms without shared context support, such as Android.
+    # When disabled, animations update only when loading progress changes. [default: true]
+    B:threadedRendering=true
+
     # Whether or not to use minecraft's display to show the progress. This looks better, but there is a possibility of not being compatible, so if you do have any strange crash reports or compatibility issues, try setting this to false
     # Note: IIRC, setting this to false makes the screen black [default: true]
     B:useMinecraft=true


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Mirroring the change made in https://github.com/GTNewHorizons/BetterLoadingScreen/pull/38. Having it updated makes it so the override in DAXXL can be done in https://github.com/GTNewHorizons/DreamAssemblerXXL/pull/300

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
