### PR TITLE
Fix typo in quest, alloy -> allow

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/SmeltingAllJoy-AAAAAAAAAAAAAAAAAAAAjw==.json
+++ b/config/betterquesting/DefaultQuests/Quests/Tier2MV-AAAAAAAAAAAAAAAAAAAABA==/SmeltingAllJoy-AAAAAAAAAAAAAAAAAAAAjw==.json
@@ -17,7 +17,7 @@
         "id:8": "minecraft:stick"
       },
       "countAsQuest:1": 1,
-      "desc:8": "This combination smelter allows you to produce fused quartz and quite clear glass of all variants.\n\nIt does §onot§r alloy you to make the EIO alloys though, you\u0027ll need a mixer and (probably) EBF for that.",
+      "desc:8": "This combination smelter allows you to produce fused quartz and quite clear glass of all variants.\n\nIt does §onot§r allow you to make the EIO alloys though, you\u0027ll need a mixer and (probably) EBF for that.",
       "globalShare:1": 1,
       "icon:10": {
         "Count:3": 1,


### PR DESCRIPTION
## Summary
Fix a typo in the EIO alloy smelter's quest.
(I'm guessing this was not supposed to be an intentional pun since the quest description does not hint at that otherwise.)


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
