### PR TITLE
Reenable hungry mobs

### DIFF
--- a/config/SpecialMobs.cfg
+++ b/config/SpecialMobs.cfg
@@ -342,7 +342,7 @@ pigzombie_rates {
     I:brutish=1
     I:fishing=1
     I:giant=1
-    I:hungry=0
+    I:hungry=1
     I:plague=1
     I:vampire=1
 }
@@ -435,7 +435,7 @@ spider_rates {
     I:flying=1
     I:ghost=1
     I:giant=1
-    I:hungry=0
+    I:hungry=1
     I:mother=1
     I:pale=1
     I:poison=1
@@ -485,7 +485,7 @@ zombie_rates {
     I:fire=1
     I:fishing=1
     I:giant=1
-    I:hungry=0
+    I:hungry=1
     I:plague=1
 }
 


### PR DESCRIPTION
## Summary
This PR is a followup to https://github.com/GTNewHorizons/SpecialMobs/pull/33, reenabling the newly fixed/changed hungry mob type with Dream's approval.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
