### PR TITLE
Blacklist Railcraft boilers from World Accelerator

### DIFF
--- a/config/GregTech/GregTech.cfg
+++ b/config/GregTech/GregTech.cfg
@@ -352,6 +352,10 @@ gregtech {
             goodgenerator.blocks.tileEntity.EssentiaHatch
             magicbees.tileentity.TileEntityApimancersDrainerCommon
             magicbees.tileentity.TileEntityApimancersDrainerGT
+            mods.railcraft.common.blocks.machine.beta.TileBoilerFireboxFluid
+            mods.railcraft.common.blocks.machine.beta.TileBoilerFireboxSolid
+            mods.railcraft.common.blocks.machine.beta.TileBoilerTankHigh
+            mods.railcraft.common.blocks.machine.beta.TileBoilerTankLow
          >
 
         # This will set the percentage how much ReinforcedGlass is Allowed in Cleanroom Walls. [range: 1.4E-45 ~ 3.4028235E38, default: 5.0]
@@ -415,5 +419,4 @@ gregtech {
     }
 
 }
-
 


### PR DESCRIPTION
## Summary
Blacklist all concrete Railcraft boiler firebox and tank tile entities from GregTech's World Accelerator TE mode to prevent accelerated boiler processing.

Closes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/339

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge